### PR TITLE
Improve SunSpider compatibility

### DIFF
--- a/src/Asynkron.JsEngine/Evaluator.cs
+++ b/src/Asynkron.JsEngine/Evaluator.cs
@@ -2062,7 +2062,7 @@ public static class Evaluator
         };
     }
 
-    private static double ToNumber(object? value)
+    internal static double ToNumber(object? value)
     {
         return value switch
         {
@@ -3376,16 +3376,13 @@ public static class Evaluator
     private static int ToInt32(object? value)
     {
         var num = ToNumber(value);
-        if (double.IsNaN(num) || double.IsInfinity(num)) return 0;
-        // JavaScript ToInt32: convert to uint first, then to int to handle values > Int32.MaxValue
-        return unchecked((int)(uint)(long)num);
+        return JsNumericConversions.ToInt32(num);
     }
 
     private static uint ToUInt32(object? value)
     {
         var num = ToNumber(value);
-        if (double.IsNaN(num) || double.IsInfinity(num)) return 0;
-        return (uint)(long)num;
+        return JsNumericConversions.ToUInt32(num);
     }
 
     // Increment/Decrement operations

--- a/src/Asynkron.JsEngine/JsEngine.cs
+++ b/src/Asynkron.JsEngine/JsEngine.cs
@@ -128,6 +128,29 @@ public sealed class JsEngine
         // Register dynamic import function
         SetGlobalFunction("import", args => DynamicImport(args));
 
+        // Provide a minimal document stub for browser-oriented benchmarks
+        var documentStub = new JsObject();
+        documentStub.SetProperty("write", new HostFunction((_, _) => null));
+        documentStub.SetProperty("addEventListener", new HostFunction((_, _) => null));
+        documentStub.SetProperty("removeEventListener", new HostFunction((_, _) => null));
+        documentStub.SetProperty("createElement", new HostFunction((_, _) =>
+        {
+            var element = new JsObject();
+            element.SetProperty("setAttribute", new HostFunction((_, _) => null));
+            element.SetProperty("appendChild", new HostFunction((_, _) => null));
+            element.SetProperty("addEventListener", new HostFunction((_, _) => null));
+            element.SetProperty("removeEventListener", new HostFunction((_, _) => null));
+            element.SetProperty("style", new JsObject());
+            return element;
+        }));
+        documentStub.SetProperty("getElementsByTagName", new HostFunction((_, _) => new JsArray()));
+        documentStub.SetProperty("getElementById", new HostFunction((_, _) => new JsObject()));
+        var documentElement = new JsObject();
+        documentElement.SetProperty("style", new JsObject());
+        documentStub.SetProperty("documentElement", documentElement);
+        documentStub.SetProperty("head", new JsObject());
+        SetGlobal("document", documentStub);
+
         // Register debug function as a debug-aware host function
         _global.Define(Symbol.Intern("__debug"), new DebugAwareHostFunction(CaptureDebugMessage));
 

--- a/src/Asynkron.JsEngine/JsNumericConversions.cs
+++ b/src/Asynkron.JsEngine/JsNumericConversions.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace Asynkron.JsEngine;
+
+internal static class JsNumericConversions
+{
+    private const double TwoTo32 = 4294967296d;
+    private const double TwoTo31 = 2147483648d;
+
+    public static int ToInt32(double number)
+    {
+        if (double.IsNaN(number) || double.IsInfinity(number) || number == 0d) return 0;
+
+        var sign = number < 0 ? -1 : 1;
+        var abs = Math.Abs(number);
+        var integer = Math.Floor(abs);
+        var modulo = integer % TwoTo32;
+
+        if (sign < 0)
+        {
+            modulo = TwoTo32 - modulo;
+            if (modulo == TwoTo32) modulo = 0;
+        }
+
+        if (modulo >= TwoTo31) return (int)(modulo - TwoTo32);
+
+        return (int)modulo;
+    }
+
+    public static uint ToUInt32(double number)
+    {
+        if (double.IsNaN(number) || double.IsInfinity(number) || number == 0d) return 0u;
+
+        var sign = number < 0 ? -1 : 1;
+        var abs = Math.Abs(number);
+        var integer = Math.Floor(abs);
+        var modulo = integer % TwoTo32;
+
+        if (sign < 0)
+        {
+            modulo = TwoTo32 - modulo;
+            if (modulo == TwoTo32) modulo = 0;
+        }
+
+        return (uint)modulo;
+    }
+}

--- a/src/Asynkron.JsEngine/StandardLibrary.cs
+++ b/src/Asynkron.JsEngine/StandardLibrary.cs
@@ -194,18 +194,18 @@ public static class StandardLibrary
 
         math["clz32"] = new HostFunction(args =>
         {
-            if (args.Count == 0) return 32d;
-            if (args[0] is not double d) return 32d;
-            var n = (int)d;
-            if (n == 0) return 32d;
-            return (double)System.Numerics.BitOperations.LeadingZeroCount((uint)n);
+            var number = args.Count > 0 ? Evaluator.ToNumber(args[0]) : 0d;
+            var value = JsNumericConversions.ToUInt32(number);
+            if (value == 0) return 32d;
+            return (double)System.Numerics.BitOperations.LeadingZeroCount(value);
         });
 
         math["imul"] = new HostFunction(args =>
         {
-            if (args.Count < 2) return 0d;
-            var a = args[0] is double d1 ? (int)d1 : 0;
-            var b = args[1] is double d2 ? (int)d2 : 0;
+            var left = args.Count > 0 ? Evaluator.ToNumber(args[0]) : 0d;
+            var right = args.Count > 1 ? Evaluator.ToNumber(args[1]) : 0d;
+            var a = JsNumericConversions.ToInt32(left);
+            var b = JsNumericConversions.ToInt32(right);
             return (double)(a * b);
         });
 
@@ -473,6 +473,18 @@ public static class StandardLibrary
                 {
                     var dt = DateTimeOffset.FromUnixTimeMilliseconds((long)ms);
                     return (double)dt.Year;
+                }
+
+                return double.NaN;
+            });
+
+            dateInstance["getYear"] = new HostFunction((thisVal, methodArgs) =>
+            {
+                if (thisVal is JsObject obj && obj.TryGetProperty("_internalDate", out var val) && val is double ms)
+                {
+                    var dt = DateTimeOffset.FromUnixTimeMilliseconds((long)ms);
+                    var year = dt.Year;
+                    return (double)(year >= 1900 ? year - 1900 : year);
                 }
 
                 return double.NaN;


### PR DESCRIPTION
## Summary
- refine the interpreter's number conversion helpers to honour JavaScript's 32-bit wrapping semantics and adjust Math functions to use them
- provide a minimal DOM-like document stub so browser-oriented SunSpider scripts can execute
- expose Date#getYear so the date-format benchmarks can format legacy years correctly

## Testing
- not run (dotnet CLI unavailable in the execution environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178307580083289a4806c401c86077)