### PR TITLE
Fix function body retention for async iterators

### DIFF
--- a/src/Asynkron.JsEngine/Cons.cs
+++ b/src/Asynkron.JsEngine/Cons.cs
@@ -113,6 +113,36 @@ public sealed class Cons : IEnumerable<object?>
         return FromStack(stack);
     }
 
+    /// <summary>
+    /// Creates a deep copy of the current cons list.
+    /// Atoms (non-cons items) are reused, while nested cons lists are cloned recursively.
+    /// Source references and origin metadata are preserved on the cloned list.
+    /// </summary>
+    public Cons CloneDeep()
+    {
+        if (IsEmpty) return EmptyInstance;
+
+        var clonedItems = new List<object?>();
+        foreach (var item in this)
+        {
+            if (item is Cons consItem)
+            {
+                clonedItems.Add(consItem.CloneDeep());
+            }
+            else
+            {
+                clonedItems.Add(item);
+            }
+        }
+
+        var clone = FromEnumerable(clonedItems);
+
+        if (SourceReference != null) clone.WithSourceReference(SourceReference);
+        if (Origin != null) clone.WithOrigin(Origin);
+
+        return clone;
+    }
+
     private static Cons FromArray(object?[] array)
     {
         var current = EmptyInstance;

--- a/src/Asynkron.JsEngine/JsFunction.cs
+++ b/src/Asynkron.JsEngine/JsFunction.cs
@@ -22,7 +22,7 @@ public sealed class JsFunction : IJsEnvironmentAwareCallable
         _name = name;
         _parameters = parameters;
         _restParameter = restParameter;
-        _body = body;
+        _body = body.CloneDeep();
         _closure = closure;
 
         // Every function in JavaScript exposes a prototype object so instances created via `new` can inherit from it.


### PR DESCRIPTION
## Summary
- add a deep-clone helper for Cons nodes so function bodies are preserved
- ensure JsFunction captures a cloned body to prevent later mutations from stripping async iterator logic

## Testing
- not run (dotnet CLI unavailable in execution environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691782ead36c832892613a3291ff0983)