### PR TITLE
Support sequence expressions in expression statements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Guidance
+
+## .NET installation
+To ensure the correct .NET runtime/SDK is available when working on this repository, use the official `dotnet-install` script.
+
+On Linux/macOS:
+```
+curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+chmod +x dotnet-install.sh
+./dotnet-install.sh --channel 8.0
+export PATH="$HOME/.dotnet:$PATH"
+```
+
+On Windows PowerShell:
+```
+irm https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
+./dotnet-install.ps1 -Channel 8.0
+$env:PATH = "$env:USERPROFILE\.dotnet;" + $env:PATH
+```
+
+These commands install the latest .NET 8 SDK (which includes the runtime) into the user profile so the repository can build and run tests without requiring global admin access.

--- a/src/Asynkron.JsEngine/Parser.cs
+++ b/src/Asynkron.JsEngine/Parser.cs
@@ -1064,7 +1064,9 @@ public sealed class Parser(IReadOnlyList<Token> tokens, string source)
 
     private object ParseExpressionStatement()
     {
-        var expression = ParseExpression();
+        // Expression statements should allow the comma operator so transpiled output
+        // like "a = b, c = d;" parses as a single statement rather than two.
+        var expression = ParseSequenceExpression();
         Consume(TokenType.Semicolon, "Expected ';' after expression statement.");
         return S(ExpressionStatement, expression);
     }

--- a/tests/Asynkron.JsEngine.Tests/ParserTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/ParserTests.cs
@@ -115,6 +115,37 @@ public class ParserTests
     }
 
     [Fact(Timeout = 2000)]
+    public Task ParseCommaSeparatedExpressionStatementAsSequence()
+    {
+        var program = JsEngine.ParseWithoutTransformation(
+            "_ref = _temp === void 0 ? {} : _temp, _ref$jsx = _ref.jsx, jsx = _ref$jsx === void 0 ? false : _ref$jsx;");
+
+        var expressionStatement = Assert.IsType<Cons>(program.Rest.Head);
+        Assert.Same(JsSymbols.ExpressionStatement, expressionStatement.Head);
+
+        var outerSequence = Assert.IsType<Cons>(expressionStatement.Rest.Head);
+        Assert.Same(JsSymbols.Operator(","), outerSequence.Head);
+
+        var firstSequence = Assert.IsType<Cons>(outerSequence.Rest.Head);
+        Assert.Same(JsSymbols.Operator(","), firstSequence.Head);
+
+        var firstAssignment = Assert.IsType<Cons>(firstSequence.Rest.Head);
+        Assert.Same(JsSymbols.Assign, firstAssignment.Head);
+        Assert.Equal(Symbol.Intern("_ref"), firstAssignment.Rest.Head);
+        Assert.IsType<Cons>(firstAssignment.Rest.Rest.Head); // ternary expression
+
+        var secondAssignment = Assert.IsType<Cons>(firstSequence.Rest.Rest.Head);
+        Assert.Same(JsSymbols.Assign, secondAssignment.Head);
+        Assert.Equal(Symbol.Intern("_ref$jsx"), secondAssignment.Rest.Head);
+
+        var thirdAssignment = Assert.IsType<Cons>(outerSequence.Rest.Rest.Head);
+        Assert.Same(JsSymbols.Assign, thirdAssignment.Head);
+        Assert.Equal(Symbol.Intern("jsx"), thirdAssignment.Rest.Head);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact(Timeout = 2000)]
     public Task ParseArrayLiteralAndIndexedAssignment()
     {
         var engine = new JsEngine();


### PR DESCRIPTION
## Summary
- document how to install the required .NET SDK via dotnet-install
- allow expression statements to parse comma-separated sequence expressions
- add a parser regression test covering comma-separated assignments

## Testing
- not run (dotnet CLI unavailable in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69189ceb1dc08328a0f16d4f81bc19f3)