### PR TITLE
Allow trailing commas in call expressions

### DIFF
--- a/src/Asynkron.JsEngine/Parser.cs
+++ b/src/Asynkron.JsEngine/Parser.cs
@@ -1853,7 +1853,7 @@ public sealed class Parser(IReadOnlyList<Token> tokens, string source)
         var arguments = new List<object?>();
         if (!Check(TokenType.RightParen))
         {
-            do
+            while (true)
             {
                 // Check for spread in arguments
                 if (Match(TokenType.DotDotDot))
@@ -1865,7 +1865,18 @@ public sealed class Parser(IReadOnlyList<Token> tokens, string source)
                 {
                     arguments.Add(ParseExpression());
                 }
-            } while (Match(TokenType.Comma));
+
+                if (!Match(TokenType.Comma))
+                {
+                    break;
+                }
+
+                if (Check(TokenType.RightParen))
+                {
+                    // Allow trailing commas in call expressions (e.g. foo(1,))
+                    break;
+                }
+            }
         }
 
         Consume(TokenType.RightParen, "Expected ')' after arguments.");

--- a/tests/Asynkron.JsEngine.Tests/ParserTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/ParserTests.cs
@@ -494,6 +494,26 @@ public class ParserTests
     }
 
     [Fact(Timeout = 2000)]
+    public Task ParseFunctionCallWithTrailingComma()
+    {
+        var engine = new JsEngine();
+        var program = engine.Parse("foo(1,);");
+
+        var exprStmt = Assert.IsType<Cons>(program.Rest.Head);
+        var callExpr = Assert.IsType<Cons>(exprStmt.Rest.Head);
+        Assert.Same(JsSymbols.Call, callExpr.Head);
+
+        // Callee symbol should remain intact
+        Assert.Equal(Symbol.Intern("foo"), callExpr.Rest.Head);
+
+        // Single argument survives even with trailing comma
+        Assert.Equal(1d, callExpr.Rest.Rest.Head);
+        Assert.Same(Cons.Empty, callExpr.Rest.Rest.Rest);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact(Timeout = 2000)]
     public Task ParseCommaSeparatedVarDeclarations()
     {
         var engine = new JsEngine();


### PR DESCRIPTION
## Summary
- update the parser to permit trailing commas in function call argument lists by stopping consumption when the closing parenthesis is reached
- add a parser unit test that exercises `foo(1,)` to confirm the call keeps its single argument

## Testing
- dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter ParseFunctionCallWithTrailingComma --no-restore


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918a3b053e88328aba1906708d7f655)