### PR TITLE
Refactor SunSpider tests and sync scripts

### DIFF
--- a/tests/Asynkron.JsEngine.Tests/Scripts/3d-raytrace.js
+++ b/tests/Asynkron.JsEngine.Tests/Scripts/3d-raytrace.js
@@ -23,16 +23,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-// TEST STATUS: FAILING
-// Error: Expected output length but got incorrect result
-// Root Cause: 3D ray-tracing algorithm produces wrong output
-// Likely issues with:
-//   - Complex floating-point calculations
-//   - Vector and matrix operations
-//   - Object property access in nested loops
-//   - Array manipulation
-// The algorithm involves intensive numerical computations that may have precision issues.
-
 function createVector(x,y,z) {
     return new Array(x,y,z);
 }
@@ -448,9 +438,7 @@ for (var y = 0; y < size; y++) {\n\
     return s;
 }
 
-__debug(); // Debug: before raytraceScene
 testOutput = arrayToCanvasCommands(raytraceScene());
-__debug(); // Debug: after raytraceScene, check testOutput
 
 var expectedLength = 20970;
 

--- a/tests/Asynkron.JsEngine.Tests/Scripts/access-fannkuch.js
+++ b/tests/Asynkron.JsEngine.Tests/Scripts/access-fannkuch.js
@@ -2,15 +2,6 @@
    http://shootout.alioth.debian.org/
    contributed by Isaac Gouy */
 
-// TEST STATUS: FAILING
-// Error: Expected 22 but got incorrect result
-// Root Cause: Fannkuch algorithm (array permutation benchmark) produces wrong result
-// Likely issues with:
-//   - Array manipulation and copying
-//   - Integer arithmetic in counting flips
-//   - Loop iteration logic
-// The algorithm involves heavy array operations that may not be working correctly.
-
 function fannkuch(n) {
    var check = 0;
    var perm = Array(n);
@@ -20,7 +11,6 @@ function fannkuch(n) {
    var maxFlipsCount = 0;
    var m = n - 1;
 
-   __debug(); // Debug: start of function
    for (var i = 0; i < n; i++) perm1[i] = i;
    var r = n;
 
@@ -33,14 +23,12 @@ function fannkuch(n) {
       }
 
       while (r != 1) { count[r - 1] = r; r--; }
-      __debug(); // Debug: after first while loop
       if (!(perm1[0] == 0 || perm1[m] == m)) {
          for (var i = 0; i < n; i++) perm[i] = perm1[i];
 
          var flipsCount = 0;
          var k;
 
-         __debug(); // Debug: before inner while loop
          while (!((k = perm[0]) == 0)) {
             var k2 = (k + 1) >> 1;
             for (var i = 0; i < k2; i++) {
@@ -74,9 +62,7 @@ function fannkuch(n) {
 }
 
 var n = 8;
-__debug(); // Debug: before fannkuch call
 var ret = fannkuch(n);
-__debug(); // Debug: after fannkuch, check ret
 
 var expected = 22;
 if (ret != expected)

--- a/tests/Asynkron.JsEngine.Tests/Scripts/access-nbody.js
+++ b/tests/Asynkron.JsEngine.Tests/Scripts/access-nbody.js
@@ -2,15 +2,6 @@
    http://shootout.alioth.debian.org/
    contributed by Isaac Gouy */
 
-// TEST STATUS: FAILING
-// Error: Expected -1.3524862408537381 but got incorrect result
-// Root Cause: N-body physics simulation produces wrong energy calculation
-// Likely issues with:
-//   - Floating-point arithmetic precision
-//   - Object property access and modification
-//   - Math operations (sqrt, multiplication, division)
-// The complex numerical calculations may have precision or rounding issues.
-
 var PI = 3.141592653589793;
 var SOLAR_MASS = 4 * PI * PI;
 var DAYS_PER_YEAR = 365.24;
@@ -162,24 +153,20 @@ NBodySystem.prototype.energy = function(){
 
 var ret = 0;
 
-__debug(); // Debug: before main loop
 for ( var n = 3; n <= 24; n *= 2 ) {
     (function(){
         var bodies = new NBodySystem( Array(
            Sun(),Jupiter(),Saturn(),Uranus(),Neptune()
         ));
         var max = n * 100;
-        __debug(); // Debug: in loop iteration, check n and max
         
         ret += bodies.energy();
         for (var i=0; i<max; i++){
             bodies.advance(0.01);
         }
         ret += bodies.energy();
-        __debug(); // Debug: after energy calculations, check ret
     })();
 }
-__debug(); // Debug: after all iterations, final ret
 
 var expected = -1.3524862408537381;
 if (ret != expected)

--- a/tests/Asynkron.JsEngine.Tests/Scripts/bitops-nsieve-bits.js
+++ b/tests/Asynkron.JsEngine.Tests/Scripts/bitops-nsieve-bits.js
@@ -2,14 +2,6 @@
 //  http://shootout.alioth.debian.org
 //
 //  Contributed by Ian Osgood
-//
-// TEST STATUS: FAILING
-// Error: Expected -1286749544853 but got 0
-// Root Cause: Bitwise sieve algorithm produces wrong result - likely issues with:
-//   - Bit manipulation: isPrime[i>>5] & 1<<(i&31)
-//   - Bitwise AND/OR operations on array elements
-//   - Signed integer handling (result should be large negative number)
-// The algorithm relies heavily on bit-level operations which aren't working correctly.
 
 function pad(n,width) {
   var s = n.toString();
@@ -19,7 +11,6 @@ function pad(n,width) {
 
 function primes(isPrime, n) {
   var i, count = 0, m = 10000<<n, size = m+31>>5;
-  __debug(); // Debug: function entry with parameters
 
   for (i=0; i<size; i++) isPrime[i] = 0xffffffff;
 
@@ -29,27 +20,22 @@ function primes(isPrime, n) {
         isPrime[j>>5] &= ~(1<<(j&31));
       count++;
     }
-  __debug(); // Debug: after main loop, check count
 }
 
 function sieve() {
-    __debug(); // Debug: sieve function entry
     for (var i = 4; i <= 4; i++) {
         var isPrime = new Array((10000<<i)+31>>5);
         primes(isPrime, i);
-        __debug(); // Debug: after primes call
     }
     return isPrime;
 }
 
 var result = sieve();
-__debug(); // Debug: after sieve, check result
 
 var sum = 0;
 for (var i = 0; i < result.length; ++i)
     sum += result[i];
 
-__debug(); // Debug: after sum calculation
 var expected = -1286749544853;
 if (sum != expected)
     throw "ERROR: bad result: expected " + expected + " but got " + sum;

--- a/tests/Asynkron.JsEngine.Tests/Scripts/crypto-aes.js
+++ b/tests/Asynkron.JsEngine.Tests/Scripts/crypto-aes.js
@@ -1,16 +1,5 @@
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  */
 
-// TEST STATUS: FAILING
-// Error: AES encryption/decryption produces incorrect results
-// Root Cause: AES (Advanced Encryption Standard) implementation has issues
-// Likely problems with:
-//   - Byte-level bit operations (S-box substitutions)
-//   - Bit shifting and rotation in cipher rounds
-//   - XOR operations on state arrays
-//   - Key expansion algorithm
-//   - Mix columns transformation
-// AES is extremely sensitive to bit manipulation errors - even small mistakes produce completely wrong output.
-
 /*
  * AES Cipher function: encrypt 'input' with Rijndael algorithm
  *
@@ -429,11 +418,8 @@ And sails upon the bosom of the air.";
 
 var password = "O Romeo, Romeo! wherefore art thou Romeo?";
 
-__debug(); // Debug: before encryption
 var cipherText = AESEncryptCtr(plainText, password, 256);
-__debug(); // Debug: after encryption, check cipherText
 var decryptedText = AESDecryptCtr(cipherText, password, 256);
-__debug(); // Debug: after decryption, check decryptedText
 
 if (decryptedText != plainText)
     throw "ERROR: bad result: expected " + plainText + " but got " + decryptedText;

--- a/tests/Asynkron.JsEngine.Tests/Scripts/crypto-md5.js
+++ b/tests/Asynkron.JsEngine.Tests/Scripts/crypto-md5.js
@@ -8,27 +8,6 @@
  */
 
 /*
- * TEST STATUS: FAILING
- * Error: Expected hash a831e91e0f70eddcb70dc61c6f82f6cd but got 4ebea80adf00ebd69b1e70e54a6f194a
- * Root Cause: MD5 algorithm produces incorrect hash - likely issue with:
- *   - Bitwise operations (shifts, rotations, XOR/AND/OR)
- *   - 32-bit unsigned integer arithmetic
- *   - Integer overflow/wrap-around behavior
- * The algorithm executes but bit manipulations are not working correctly.
- */
-
-// Console object for debugging
-var console = {
-  log: function(msg) {
-    // Store in a global array for later inspection
-    if (typeof consoleLogs === 'undefined') {
-      consoleLogs = [];
-    }
-    consoleLogs.push(String(msg));
-  }
-};
-
-/*
  * Configurable variables. You may need to tweak these to be compatible with
  * the server-side, but the defaults work in most cases.
  */
@@ -60,18 +39,9 @@ function md5_vm_test()
  */
 function core_md5(x, len)
 {
-  console.log("core_md5 entry, x.length=" + x.length + ", len=" + len);
-  
   /* append padding */
-  var padIndex1 = len >> 5;
-  var padIndex2 = (((len + 64) >>> 9) << 4) + 14;
-  
-  console.log("Setting padding at indices: " + padIndex1 + " and " + padIndex2);
-  
-  x[padIndex1] |= 0x80 << ((len) % 32);
-  x[padIndex2] = len;
-
-  console.log("core_md5 after padding, x.length=" + x.length);
+  x[len >> 5] |= 0x80 << ((len) % 32);
+  x[(((len + 64) >>> 9) << 4) + 14] = len;
 
   var a =  1732584193;
   var b = -271733879;
@@ -84,8 +54,6 @@ function core_md5(x, len)
     var oldb = b;
     var oldc = c;
     var oldd = d;
-
-    console.log("Block " + (i/16) + ", a=" + a + ", b=" + b + ", c=" + c + ", d=" + d);
 
     a = md5_ff(a, b, c, d, x[i+ 0], 7 , -680876936);
     d = md5_ff(d, a, b, c, x[i+ 1], 12, -389564586);
@@ -311,17 +279,11 @@ To know our further pleasure in this case,\n\
 To old Free-town, our common judgment-place.\n\
 Once more, on pain of death, all men depart."
 
-__debug(); // Debug: initial plainText length
-console.log("Initial plainText.length=" + plainText.length);
 for (var i = 0; i <4; i++) {
     plainText += plainText;
-    console.log("After iteration " + i + ", plainText.length=" + plainText.length);
 }
-__debug(); // Debug: after expanding plainText
 
 var md5Output = hex_md5(plainText);
-console.log("Calling hex_md5 with plainText.length=" + plainText.length);
-__debug(); // Debug: after hex_md5, check output
 
 var expected = "a831e91e0f70eddcb70dc61c6f82f6cd";
 

--- a/tests/Asynkron.JsEngine.Tests/Scripts/crypto-sha1.js
+++ b/tests/Asynkron.JsEngine.Tests/Scripts/crypto-sha1.js
@@ -8,27 +8,6 @@
  */
 
 /*
- * TEST STATUS: FAILING
- * Error: Expected hash 2524d264def74cce2498bf112bedf00e6c0b796d but got 85634b6b67255134eeb5fd1c9b02f4bf0481b7c4
- * Root Cause: SHA1 algorithm produces incorrect hash - likely issue with:
- *   - Bitwise rotation operations (rol function)
- *   - 32-bit unsigned integer arithmetic
- *   - Bit shifting and masking operations
- * Similar root cause to crypto-md5.js failure.
- */
-
-// Console object for debugging
-var console = {
-  log: function(msg) {
-    // Store in a global array for later inspection
-    if (typeof consoleLogs === 'undefined') {
-      consoleLogs = [];
-    }
-    consoleLogs.push(String(msg));
-  }
-};
-
-/*
  * Configurable variables. You may need to tweak these to be compatible with
  * the server-side, but the defaults work in most cases.
  */
@@ -64,8 +43,6 @@ function core_sha1(x, len)
   x[len >> 5] |= 0x80 << (24 - len % 32);
   x[((len + 64 >> 9) << 4) + 15] = len;
 
-  console.log(x);
-
   var w = Array(80);
   var a =  1732584193;
   var b = -271733879;
@@ -87,10 +64,6 @@ function core_sha1(x, len)
       else w[j] = rol(w[j-3] ^ w[j-8] ^ w[j-14] ^ w[j-16], 1);
       var t = safe_add(safe_add(rol(a, 5), sha1_ft(j, b, c, d)),
                        safe_add(safe_add(e, w[j]), sha1_kt(j)));
-
-       console.log(w);
-       console.log(t);
-
       e = d;
       d = c;
       c = rol(b, 30);
@@ -244,14 +217,11 @@ Is now the two hours' traffic of our stage;\n\
 The which if you with patient ears attend,\n\
 What here shall miss, our toil shall strive to mend.";
 
-__debug(); // Debug: initial plainText length
 for (var i = 0; i <4; i++) {
     plainText += plainText;
 }
-__debug(); // Debug: after expanding plainText
 
 var sha1Output = hex_sha1(plainText);
-__debug(); // Debug: after hex_sha1, check output
 
 var expected = "2524d264def74cce2498bf112bedf00e6c0b796d";
 if (sha1Output != expected)

--- a/tests/Asynkron.JsEngine.Tests/Scripts/date-format-tofte.js
+++ b/tests/Asynkron.JsEngine.Tests/Scripts/date-format-tofte.js
@@ -1,13 +1,3 @@
-// TEST STATUS: FAILING
-// Error: Date formatting produces incorrect or throws error
-// Root Cause: Custom Date.prototype.formatDate implementation has issues
-// Likely problems with:
-//   - Date object method calls (getMonth, getDate, getHours, etc.)
-//   - String manipulation and padding
-//   - Switch/case logic for format characters
-//   - Timezone or locale handling
-// Date formatting is complex and may have edge case issues.
-
 function arrayExists(array, x) {
     for (var i = 0; i < array.length; i++) {
         if (array[i] == x) return true;
@@ -301,13 +291,11 @@ Date.prototype.formatDate = function (input,time) {
 
 var date = new Date("1/1/2007 1:11:11");
 
-__debug(); // Debug: before loop, check date
 for (i = 0; i < 500; ++i) {
     var shortFormat = date.formatDate("Y-m-d");
     var longFormat = date.formatDate("l, F d, Y g:i:s A");
     date.setTime(date.getTime() + 84266956);
 }
-__debug(); // Debug: after loop, check final date and formats
 
 // FIXME: Find a way to validate this test.
 // https://bugs.webkit.org/show_bug.cgi?id=114849

--- a/tests/Asynkron.JsEngine.Tests/Scripts/date-format-xparb.js
+++ b/tests/Asynkron.JsEngine.Tests/Scripts/date-format-xparb.js
@@ -11,17 +11,6 @@
  * details.
  */
 
-// TEST STATUS: FAILING
-// Error: Date formatting produces incorrect or throws error
-// Root Cause: Alternative date formatting library (xparb) has issues
-// Similar to date-format-tofte.js but different implementation
-// Likely problems with:
-//   - Dynamic function generation (Date.createNewFormat)
-//   - Date object method calls
-//   - String manipulation and regex operations
-//   - Function caching and evaluation
-// This is a more complex date library with runtime code generation.
-
 Date.parseFunctions = {count:0};
 Date.parseRegexes = [];
 Date.formatFunctions = {count:0};
@@ -421,13 +410,11 @@ Date.patterns = {
 
 var date = new Date("1/1/2007 1:11:11");
 
-__debug(); // Debug: before loop, check date
 for (i = 0; i < 4000; ++i) {
     var shortFormat = date.dateFormat("Y-m-d");
     var longFormat = date.dateFormat("l, F d, Y g:i:s A");
     date.setTime(date.getTime() + 84266956);
 }
-__debug(); // Debug: after loop, check final date and formats
 
 // FIXME: Find a way to validate this test.
 // https://bugs.webkit.org/show_bug.cgi?id=114849

--- a/tests/Asynkron.JsEngine.Tests/Scripts/string-base64.js
+++ b/tests/Asynkron.JsEngine.Tests/Scripts/string-base64.js
@@ -23,17 +23,6 @@
  *   Samuel Sieb <samuel@sieb.net>
  *
  * Alternatively, the contents of this file may be used under the terms of
-
-// TEST STATUS: FAILING
-// Error: Base64 encoding/decoding produces incorrect results
-// Root Cause: Character code and bit manipulation issues
-// Likely problems with:
-//   - Bit shifting operations in encoding (>> and <<)
-//   - Character code operations (charCodeAt, fromCharCode)
-//   - Bitwise AND operations for masking
-//   - String.fromCharCode with calculated values
-// Base64 encoding requires precise bit manipulation which isn't working correctly.
-
  * either the GNU General Public License Version 2 or later (the "GPL"), or
  * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
  * in which case the provisions of the GPL or the LGPL are applicable instead
@@ -129,19 +118,15 @@ function base64ToString(data) {
 
 var str = "";
 
-__debug(); // Debug: before building random string
 for ( var i = 0; i < 8192; i++ )
         str += String.fromCharCode( (25 * Math.random()) + 97 );
 
-__debug(); // Debug: after building initial string
 for ( var i = 8192; i <= 16384; i *= 2 ) {
 
     var base64;
-    __debug(); // Debug: in outer loop, check i and str length
 
     base64 = toBase64(str);
     var encoded = base64ToString(base64);
-    __debug(); // Debug: after encoding/decoding
     if (encoded != str)
         throw "ERROR: bad result: expected " + str + " but got " + encoded;
 

--- a/tests/Asynkron.JsEngine.Tests/Scripts/string-fasta.js
+++ b/tests/Asynkron.JsEngine.Tests/Scripts/string-fasta.js
@@ -2,16 +2,6 @@
 //  http://shootout.alioth.debian.org
 //
 //  Contributed by Ian Osgood
-//
-// TEST STATUS: FAILING
-// Error: Expected 1456000 but got incorrect result
-// Root Cause: FASTA string generation produces wrong total length
-// Likely issues with:
-//   - String concatenation in loops
-//   - Random number generation (linear congruential generator)
-//   - Array operations and indexing
-//   - Integer arithmetic for counting
-// The algorithm builds strings based on probabilities which may not be accumulating correctly.
 
 var last = 42, A = 3877, C = 29573, M = 139968;
 
@@ -89,13 +79,9 @@ function fastaRandom(n, table) {
 var ret = 0;
 
 var count = 7;
-__debug(); // Debug: before fasta operations
 fastaRepeat(2*count*100000, ALU);
-__debug(); // Debug: after fastaRepeat
 fastaRandom(3*count*1000, IUB);
-__debug(); // Debug: after first fastaRandom
 fastaRandom(5*count*1000, HomoSap);
-__debug(); // Debug: after second fastaRandom, check ret
 
 var expected = 1456000;
 

--- a/tests/Asynkron.JsEngine.Tests/Scripts/string-validate-input.js
+++ b/tests/Asynkron.JsEngine.Tests/Scripts/string-validate-input.js
@@ -1,11 +1,3 @@
-// TEST STATUS: FAILING - PARSE ERROR
-// Error: ParseException: Invalid assignment target near line 15 column 44
-// Root Cause: Line 15 has ternary operator with assignments in both branches:
-//   (k%2)?email=username+"@mac.com":email=username+"(at)mac.com";
-// The parser doesn't support assignments as expressions within ternary operators.
-// This is valid JavaScript but requires parser enhancement to support.
-// Fix: Parser needs to allow assignment expressions in ternary branches.
-
 letters = new Array("a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z");
 numbers = new Array(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26);
 colors  = new Array("FF","CC","99","66","33","00");


### PR DESCRIPTION
## Summary
- collapse the SunSpider suite into a single `[Theory]` that lists each benchmark via `InlineData`, asserting success or the current known failures in one place
- refresh the SunSpider benchmark script resources with the upstream versions from Jint so the tests run against the canonical inputs

## Testing
- dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "DisplayName~3d-cube"
- dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "DisplayName~3d-raytrace"
- dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "DisplayName~string-tagcloud"
- dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "DisplayName~date-format-xparb"
- dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "DisplayName~crypto-aes"
- dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "DisplayName~string-base64"
- dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "DisplayName~access-nbody"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918a88726c88328806a308491002a33)