### PR TITLE
Restore missing symbols and helpers

### DIFF
--- a/src/Asynkron.JsEngine/Ast/Cons.cs
+++ b/src/Asynkron.JsEngine/Ast/Cons.cs
@@ -82,6 +82,15 @@ public sealed class Cons : IEnumerable<object?>
     public Cons? Origin { get; private set; }
 
     /// <summary>
+    /// Creates a single cons cell from a head value and optional rest.
+    /// This mirrors the historical Cell helper so existing DSL builders keep working.
+    /// </summary>
+    public static Cons Cell(object? head, Cons? rest = null)
+    {
+        return new Cons(head, rest);
+    }
+
+    /// <summary>
     /// Builds a list from the supplied items. Alias for List method.
     /// </summary>
     public static Cons From(params object?[] items)

--- a/src/Asynkron.JsEngine/EvaluationContext.cs
+++ b/src/Asynkron.JsEngine/EvaluationContext.cs
@@ -174,6 +174,17 @@ public sealed class EvaluationContext
     }
 
     /// <summary>
+    /// Clears the Return signal (used when a function consumes it).
+    /// </summary>
+    public void ClearReturn()
+    {
+        if (CurrentSignal is ReturnSignal)
+        {
+            CurrentSignal = null;
+        }
+    }
+
+    /// <summary>
     /// Clears any control flow signal.
     /// </summary>
     public void Clear()

--- a/src/Asynkron.JsEngine/JsSymbols.cs
+++ b/src/Asynkron.JsEngine/JsSymbols.cs
@@ -87,6 +87,7 @@ public static class JsSymbols
     public static readonly Symbol PatternElement = Symbol.Intern("pattern-element");
     public static readonly Symbol PatternProperty = Symbol.Intern("pattern-property");
     public static readonly Symbol PatternRest = Symbol.Intern("pattern-rest");
+    public static readonly Symbol PatternDefault = Symbol.Intern("pattern-default");
     public static readonly Symbol DestructuringAssignment = Symbol.Intern("destructuring-assignment");
 
     // Module symbols


### PR DESCRIPTION
## Summary
- reintroduce the `JsSymbols.PatternDefault` symbol so the destructuring parser can resolve default clauses again
- add back the `Cons.Cell` helper used by the s-expression DSL builders
- restore `EvaluationContext.ClearReturn()` so evaluators can clear consumed return signals

## Testing
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj` *(fails: numerous tests time out in this environment; see run log for details)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919286a9d888328a878fe22ec2c075d)