### PR TITLE
Expand typed evaluator coverage

### DIFF
--- a/docs/typed-ast-evaluation.md
+++ b/docs/typed-ast-evaluation.md
@@ -35,3 +35,19 @@ As the interpreter matures we can gradually widen the supported node set and
 port semantics from `JsEvaluator` into the typed version. Because evaluation is
 now factored into a single class, we can unit-test it in isolation and evolve it
 without re-threading behaviour through the AST definitions.
+
+## Recent improvements
+
+`TypedAstEvaluator` now understands a much larger portion of the surface area:
+
+- Property reads/writes (including optional chaining) and `new` construction now
+  use the same helper routines as the legacy evaluator, so object literals and
+  method calls behave as expected.
+- Control-flow constructs such as `while`, `do/while`, and classic `for` loops
+  execute natively, including support for labeled `break`/`continue`.
+- Array/object literals (with spreads), template literals, and tagged templates
+  are fully evaluated.
+
+These changes make it viable to execute real programs purely through the typed
+pipeline while keeping a small compatibility layer for helpers that still live
+in `JsEvaluator`.

--- a/src/Asynkron.JsEngine/JsEvaluator.cs
+++ b/src/Asynkron.JsEngine/JsEvaluator.cs
@@ -2465,7 +2465,7 @@ public static class JsEvaluator
         }
     }
 
-    private static void InitializePrivateFields(object? constructor, JsObject instance, JsEnvironment environment,
+    internal static void InitializePrivateFields(object? constructor, JsObject instance, JsEnvironment environment,
         EvaluationContext context)
     {
         // First, initialize parent class private and public fields (if any)
@@ -3151,7 +3151,7 @@ public static class JsEvaluator
         return value is sbyte or byte or short or ushort or int or uint or long or ulong or float or double or decimal;
     }
 
-    private static bool TryGetPropertyValue(object? target, string propertyName, out object? value)
+    internal static bool TryGetPropertyValue(object? target, string propertyName, out object? value)
     {
         // First, try the common interface for types with TryGetProperty
         if (target is IJsPropertyAccessor propertyAccessor)
@@ -3203,7 +3203,7 @@ public static class JsEvaluator
         return false;
     }
 
-    private static void AssignPropertyValue(object? target, string propertyName, object? value)
+    internal static void AssignPropertyValue(object? target, string propertyName, object? value)
     {
         // First, try the common interface for types with SetProperty
         if (target is IJsPropertyAccessor propertyAccessor)
@@ -3215,7 +3215,7 @@ public static class JsEvaluator
         throw new InvalidOperationException($"Cannot assign property '{propertyName}' on value '{target}'.");
     }
 
-    private static bool TryConvertToIndex(object? value, out int index)
+    internal static bool TryConvertToIndex(object? value, out int index)
     {
         switch (value)
         {
@@ -3244,7 +3244,7 @@ public static class JsEvaluator
         return false;
     }
 
-    private static string? ToPropertyName(object? value)
+    internal static string? ToPropertyName(object? value)
     {
         return value switch
         {
@@ -3976,7 +3976,7 @@ public static class JsEvaluator
     /// <summary>
     /// Implements the 'in' operator, which checks if a property exists in an object.
     /// </summary>
-    private static bool InOperator(object? left, object? right)
+    internal static bool InOperator(object? left, object? right)
     {
         // Convert left operand to string (property name)
         var propertyName = left?.ToString() ?? "";
@@ -3994,7 +3994,7 @@ public static class JsEvaluator
     /// <summary>
     /// Implements the instanceof operator. Checks if an object has a constructor's prototype in its prototype chain.
     /// </summary>
-    private static bool InstanceofOperator(object? left, object? right)
+    internal static bool InstanceofOperator(object? left, object? right)
     {
         // Left operand must be an object
         if (left is not JsObject leftObj)

--- a/tests/Asynkron.JsEngine.Tests/TypedAstEvaluatorTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/TypedAstEvaluatorTests.cs
@@ -1,0 +1,59 @@
+using Asynkron.JsEngine;
+using Asynkron.JsEngine.Ast;
+using Asynkron.JsEngine.Parser;
+
+namespace Asynkron.JsEngine.Tests;
+
+public class TypedAstEvaluatorTests
+{
+    [Fact]
+    public void EvaluateProgram_SupportsMemberAccessAndCalls()
+    {
+        const string source = @"
+            let counter = {
+                value: 0,
+                inc: function() {
+                    this.value = this.value + 1;
+                }
+            };
+            counter.inc();
+            counter.value;
+        ";
+
+        var program = BuildTypedProgram(source);
+        var environment = new JsEnvironment(isFunctionScope: true);
+
+        var result = TypedAstEvaluator.EvaluateProgram(program, environment);
+
+        Assert.Equal(1d, result);
+    }
+
+    [Fact]
+    public void EvaluateProgram_SupportsWhileLoops()
+    {
+        const string source = @"
+            var i = 0;
+            while (i < 3) {
+                i = i + 1;
+            }
+            i;
+        ";
+
+        var program = BuildTypedProgram(source);
+        var environment = new JsEnvironment(isFunctionScope: true);
+
+        var result = TypedAstEvaluator.EvaluateProgram(program, environment);
+
+        Assert.Equal(3d, result);
+    }
+
+    private static ProgramNode BuildTypedProgram(string source)
+    {
+        var lexer = new Lexer(source);
+        var tokens = lexer.Tokenize();
+        var parser = new Parser.Parser(tokens, source);
+        var program = parser.ParseProgram();
+        var builder = new SExpressionAstBuilder();
+        return builder.BuildProgram(program);
+    }
+}


### PR DESCRIPTION
## Summary
- extend the typed AST evaluator to support loops, property access, object/array literals, template literals, member calls and `new`
- expose reusable helpers from the legacy evaluator and document the newly supported surface
- add a regression suite that runs programs directly through `TypedAstEvaluator`

## Testing
- `dotnet test` *(fails: .NET 8 runtime missing in the CI container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69192ce6a7848328ab6cb1be6a119e6c)