### PR TITLE
Expand typed AST evaluator coverage

### DIFF
--- a/docs/typed-ast-evaluation.md
+++ b/docs/typed-ast-evaluation.md
@@ -35,3 +35,14 @@ As the interpreter matures we can gradually widen the supported node set and
 port semantics from `JsEvaluator` into the typed version. Because evaluation is
 now factored into a single class, we can unit-test it in isolation and evolve it
 without re-threading behaviour through the AST definitions.
+
+## Bootstrapping the runtime
+
+`TypedProgramExecutor` now ships alongside the evaluator. It converts the
+transformed S-expression into the typed tree and runs a fast capability check
+(`TypedAstSupportAnalyzer`) before evaluating the program. When the analyzer
+spots syntax that the typed runtime does not understand yet we simply fall back
+to the legacy `JsEvaluator`. This keeps the public behaviour stable while still
+allowing most scripts to execute through the new pipeline. As more constructs
+gain typed support we can shrink the set of early exits until the fallback is no
+longer necessary.

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
+using System.Text;
 using Asynkron.JsEngine;
 using Asynkron.JsEngine.JsTypes;
 
@@ -51,9 +54,15 @@ public static class TypedAstEvaluator
             VariableDeclaration declaration => EvaluateVariableDeclaration(declaration, environment, context),
             FunctionDeclaration functionDeclaration => EvaluateFunctionDeclaration(functionDeclaration, environment),
             IfStatement ifStatement => EvaluateIf(ifStatement, environment, context),
+            WhileStatement whileStatement => EvaluateWhile(whileStatement, environment, context),
+            DoWhileStatement doWhileStatement => EvaluateDoWhile(doWhileStatement, environment, context),
+            ForStatement forStatement => EvaluateFor(forStatement, environment, context),
+            ForEachStatement forEachStatement => EvaluateForEach(forEachStatement, environment, context),
             BreakStatement breakStatement => EvaluateBreak(breakStatement, context),
             ContinueStatement continueStatement => EvaluateContinue(continueStatement, context),
             LabeledStatement labeledStatement => EvaluateLabeled(labeledStatement, environment, context),
+            TryStatement tryStatement => EvaluateTry(tryStatement, environment, context),
+            SwitchStatement switchStatement => EvaluateSwitch(switchStatement, environment, context),
             EmptyStatement => JsSymbols.Undefined,
             UnknownStatement unknown => throw new NotSupportedException(
                 $"Typed evaluator does not yet understand the '{unknown.Node.Head}' statement form."),
@@ -117,6 +126,387 @@ public static class TypedAstEvaluator
 
         var branch = IsTruthy(test) ? statement.Then : statement.Else;
         return branch is null ? JsSymbols.Undefined : EvaluateStatement(branch, environment, context);
+    }
+
+    private static object? EvaluateWhile(WhileStatement statement, JsEnvironment environment, EvaluationContext context)
+    {
+        object? lastValue = JsSymbols.Undefined;
+        var loopLabel = context.CurrentLabel;
+
+        while (true)
+        {
+            var test = EvaluateExpression(statement.Condition, environment, context);
+            if (context.ShouldStopEvaluation)
+            {
+                return lastValue;
+            }
+
+            if (!IsTruthy(test))
+            {
+                break;
+            }
+
+            lastValue = EvaluateStatement(statement.Body, environment, context);
+            if (context.IsReturn || context.IsThrow)
+            {
+                break;
+            }
+
+            if (context.TryClearContinue(loopLabel))
+            {
+                continue;
+            }
+
+            if (context.TryClearBreak(loopLabel))
+            {
+                break;
+            }
+
+            if (context.ShouldStopEvaluation)
+            {
+                break;
+            }
+        }
+
+        return lastValue;
+    }
+
+    private static object? EvaluateDoWhile(DoWhileStatement statement, JsEnvironment environment, EvaluationContext context)
+    {
+        object? lastValue = JsSymbols.Undefined;
+        var loopLabel = context.CurrentLabel;
+
+        do
+        {
+            lastValue = EvaluateStatement(statement.Body, environment, context);
+            if (context.IsReturn || context.IsThrow)
+            {
+                break;
+            }
+
+            if (context.TryClearContinue(loopLabel))
+            {
+                // continue with next iteration
+            }
+            else if (context.TryClearBreak(loopLabel))
+            {
+                break;
+            }
+            else if (context.ShouldStopEvaluation)
+            {
+                break;
+            }
+
+            var test = EvaluateExpression(statement.Condition, environment, context);
+            if (context.ShouldStopEvaluation)
+            {
+                break;
+            }
+
+            if (!IsTruthy(test))
+            {
+                break;
+            }
+        } while (true);
+
+        return lastValue;
+    }
+
+    private static object? EvaluateFor(ForStatement statement, JsEnvironment environment, EvaluationContext context)
+    {
+        var loopEnvironment = new JsEnvironment(environment, creatingExpression: null, description: "for-loop");
+        var loopLabel = context.CurrentLabel;
+        object? lastValue = JsSymbols.Undefined;
+
+        if (statement.Initializer is not null)
+        {
+            EvaluateStatement(statement.Initializer, loopEnvironment, context);
+            if (context.ShouldStopEvaluation)
+            {
+                return JsSymbols.Undefined;
+            }
+        }
+
+        bool ContinueLoop()
+        {
+            if (statement.Condition is null)
+            {
+                return true;
+            }
+
+            var test = EvaluateExpression(statement.Condition, loopEnvironment, context);
+            if (context.ShouldStopEvaluation)
+            {
+                return false;
+            }
+
+            return IsTruthy(test);
+        }
+
+        while (ContinueLoop())
+        {
+            lastValue = EvaluateStatement(statement.Body, loopEnvironment, context);
+            if (context.IsReturn || context.IsThrow)
+            {
+                break;
+            }
+
+            if (context.TryClearContinue(loopLabel))
+            {
+                if (statement.Increment is not null)
+                {
+                    EvaluateExpression(statement.Increment, loopEnvironment, context);
+                    if (context.ShouldStopEvaluation)
+                    {
+                        break;
+                    }
+                }
+
+                continue;
+            }
+
+            if (context.TryClearBreak(loopLabel))
+            {
+                break;
+            }
+
+            if (context.ShouldStopEvaluation)
+            {
+                break;
+            }
+
+            if (statement.Increment is not null)
+            {
+                EvaluateExpression(statement.Increment, loopEnvironment, context);
+                if (context.ShouldStopEvaluation)
+                {
+                    break;
+                }
+            }
+        }
+
+        return lastValue;
+    }
+
+    private static object? EvaluateForEach(ForEachStatement statement, JsEnvironment environment,
+        EvaluationContext context)
+    {
+        if (statement.Kind == ForEachKind.AwaitOf)
+        {
+            throw new NotSupportedException("for await...of is not yet supported by the typed evaluator.");
+        }
+
+        var iterable = EvaluateExpression(statement.Iterable, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            return JsSymbols.Undefined;
+        }
+
+        var loopEnvironment = new JsEnvironment(environment, creatingExpression: null, description: "for-each-loop");
+        var loopLabel = context.CurrentLabel;
+        object? lastValue = JsSymbols.Undefined;
+
+        IEnumerable<object?> values = statement.Kind switch
+        {
+            ForEachKind.In => EnumeratePropertyKeys(iterable),
+            ForEachKind.Of => EnumerateValues(iterable),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        foreach (var value in values)
+        {
+            if (context.ShouldStopEvaluation)
+            {
+                break;
+            }
+
+            AssignLoopBinding(statement, value, loopEnvironment, environment);
+
+            lastValue = EvaluateStatement(statement.Body, loopEnvironment, context);
+
+            if (context.IsReturn || context.IsThrow)
+            {
+                break;
+            }
+
+            if (context.TryClearContinue(loopLabel))
+            {
+                continue;
+            }
+
+            if (context.TryClearBreak(loopLabel))
+            {
+                break;
+            }
+        }
+
+        return lastValue;
+    }
+
+    private static void AssignLoopBinding(ForEachStatement statement, object? value, JsEnvironment loopEnvironment,
+        JsEnvironment outerEnvironment)
+    {
+        if (statement.DeclarationKind is null)
+        {
+            AssignBindingTarget(statement.Target, value, outerEnvironment);
+            return;
+        }
+
+        switch (statement.DeclarationKind)
+        {
+            case VariableKind.Var:
+                DefineOrAssignVar(statement.Target, value, loopEnvironment);
+                break;
+            case VariableKind.Let:
+            case VariableKind.Const:
+                DefineBindingTarget(statement.Target, value, loopEnvironment,
+                    statement.DeclarationKind == VariableKind.Const);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    private static IEnumerable<object?> EnumeratePropertyKeys(object? value)
+    {
+        if (value is JsObject jsObject)
+        {
+            foreach (var key in jsObject.GetOwnPropertyNames())
+            {
+                yield return key;
+            }
+
+            yield break;
+        }
+
+        if (value is JsArray array)
+        {
+            for (var i = 0; i < array.Items.Count; i++)
+            {
+                yield return i.ToString(CultureInfo.InvariantCulture);
+            }
+
+            yield break;
+        }
+
+        if (value is string s)
+        {
+            for (var i = 0; i < s.Length; i++)
+            {
+                yield return i.ToString(CultureInfo.InvariantCulture);
+            }
+
+            yield break;
+        }
+
+        throw new InvalidOperationException("Cannot iterate properties of non-object value.");
+    }
+
+    private static IEnumerable<object?> EnumerateValues(object? value)
+    {
+        switch (value)
+        {
+            case JsArray array:
+                foreach (var item in array.Items)
+                {
+                    yield return item;
+                }
+
+                yield break;
+            case string s:
+                foreach (var ch in s)
+                {
+                    yield return ch.ToString();
+                }
+
+                yield break;
+            case IEnumerable<object?> enumerable:
+                foreach (var item in enumerable)
+                {
+                    yield return item;
+                }
+
+                yield break;
+        }
+
+        throw new InvalidOperationException("Value is not iterable.");
+    }
+
+    private static object? EvaluateTry(TryStatement statement, JsEnvironment environment, EvaluationContext context)
+    {
+        var result = EvaluateBlock(statement.TryBlock, environment, context);
+        if (context.IsThrow && statement.Catch is not null)
+        {
+            var thrownValue = context.FlowValue;
+            context.Clear();
+            var catchEnv = new JsEnvironment(environment, creatingExpression: null, description: "catch");
+            catchEnv.Define(statement.Catch.Binding, thrownValue);
+            result = EvaluateBlock(statement.Catch.Body, catchEnv, context);
+        }
+
+        if (statement.Finally is not null)
+        {
+            var savedSignal = context.CurrentSignal;
+            _ = EvaluateBlock(statement.Finally, environment, context);
+            if (context.CurrentSignal is null)
+            {
+                RestoreSignal(context, savedSignal);
+            }
+        }
+
+        return result;
+    }
+
+    private static object? EvaluateSwitch(SwitchStatement statement, JsEnvironment environment, EvaluationContext context)
+    {
+        var discriminant = EvaluateExpression(statement.Discriminant, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            return JsSymbols.Undefined;
+        }
+
+        object? lastValue = JsSymbols.Undefined;
+        var loopLabel = context.CurrentLabel;
+        var hasMatched = false;
+
+        foreach (var switchCase in statement.Cases)
+        {
+            if (!hasMatched)
+            {
+                if (switchCase.Test is null)
+                {
+                    hasMatched = true;
+                }
+                else
+                {
+                    var test = EvaluateExpression(switchCase.Test, environment, context);
+                    if (context.ShouldStopEvaluation)
+                    {
+                        return lastValue;
+                    }
+
+                    hasMatched = StrictEquals(discriminant, test);
+                }
+
+                if (!hasMatched)
+                {
+                    continue;
+                }
+            }
+
+            lastValue = EvaluateBlock(switchCase.Body, environment, context);
+            if (context.TryClearBreak(loopLabel))
+            {
+                break;
+            }
+
+            if (context.IsReturn || context.IsThrow)
+            {
+                break;
+            }
+        }
+
+        return lastValue;
     }
 
     private static object? EvaluateVariableDeclaration(VariableDeclaration declaration, JsEnvironment environment,
@@ -202,7 +592,16 @@ public static class TypedAstEvaluator
             CallExpression call => EvaluateCall(call, environment, context),
             FunctionExpression functionExpression => new TypedFunction(functionExpression, environment),
             AssignmentExpression assignment => EvaluateAssignment(assignment, environment, context),
+            PropertyAssignmentExpression propertyAssignment =>
+                EvaluatePropertyAssignment(propertyAssignment, environment, context),
+            IndexAssignmentExpression indexAssignment =>
+                EvaluateIndexAssignment(indexAssignment, environment, context),
             SequenceExpression sequence => EvaluateSequence(sequence, environment, context),
+            MemberExpression member => EvaluateMember(member, environment, context),
+            NewExpression newExpression => EvaluateNew(newExpression, environment, context),
+            ArrayExpression array => EvaluateArray(array, environment, context),
+            ObjectExpression obj => EvaluateObject(obj, environment, context),
+            TemplateLiteralExpression template => EvaluateTemplateLiteral(template, environment, context),
             ThisExpression => environment.Get(JsSymbols.This),
             UnknownExpression unknown => throw new NotSupportedException(
                 $"Typed evaluator does not yet understand the '{unknown.Node.Head}' expression form."),
@@ -214,13 +613,72 @@ public static class TypedAstEvaluator
     private static object? EvaluateAssignment(AssignmentExpression expression, JsEnvironment environment,
         EvaluationContext context)
     {
+        var targetValue = EvaluateExpression(expression.Value, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            return targetValue;
+        }
+
+        environment.Assign(expression.Target, targetValue);
+        return targetValue;
+    }
+
+    private static object? EvaluatePropertyAssignment(PropertyAssignmentExpression expression, JsEnvironment environment,
+        EvaluationContext context)
+    {
+        var target = EvaluateExpression(expression.Target, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            return JsSymbols.Undefined;
+        }
+
+        if (expression.IsComputed && IsNullish(target))
+        {
+            throw new InvalidOperationException("Cannot set property on null or undefined.");
+        }
+
+        var property = EvaluateExpression(expression.Property, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            return JsSymbols.Undefined;
+        }
+
+        var propertyName = ToPropertyName(property)
+                           ?? throw new InvalidOperationException("Property name cannot be null.");
         var value = EvaluateExpression(expression.Value, environment, context);
         if (context.ShouldStopEvaluation)
         {
-            return value;
+            return JsSymbols.Undefined;
         }
 
-        environment.Assign(expression.Target, value);
+        AssignPropertyValue(target, propertyName, value);
+        return value;
+    }
+
+    private static object? EvaluateIndexAssignment(IndexAssignmentExpression expression, JsEnvironment environment,
+        EvaluationContext context)
+    {
+        var target = EvaluateExpression(expression.Target, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            return JsSymbols.Undefined;
+        }
+
+        var index = EvaluateExpression(expression.Index, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            return JsSymbols.Undefined;
+        }
+
+        var propertyName = ToPropertyName(index)
+                           ?? throw new InvalidOperationException("Property name cannot be null.");
+        var value = EvaluateExpression(expression.Value, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            return JsSymbols.Undefined;
+        }
+
+        AssignPropertyValue(target, propertyName, value);
         return value;
     }
 
@@ -231,6 +689,34 @@ public static class TypedAstEvaluator
         return context.ShouldStopEvaluation
             ? JsSymbols.Undefined
             : EvaluateExpression(expression.Right, environment, context);
+    }
+
+    private static object? EvaluateMember(MemberExpression expression, JsEnvironment environment,
+        EvaluationContext context)
+    {
+        var target = EvaluateExpression(expression.Target, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            return JsSymbols.Undefined;
+        }
+
+        if (expression.IsOptional && IsNullish(target))
+        {
+            return JsSymbols.Undefined;
+        }
+
+        var propertyValue = EvaluateExpression(expression.Property, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            return JsSymbols.Undefined;
+        }
+
+        var propertyName = ToPropertyName(propertyValue)
+                           ?? throw new InvalidOperationException("Property name cannot be null.");
+
+        return TryGetPropertyValue(target, propertyName, out var value)
+            ? value
+            : JsSymbols.Undefined;
     }
 
     private static object? EvaluateConditional(ConditionalExpression expression, JsEnvironment environment,
@@ -249,6 +735,22 @@ public static class TypedAstEvaluator
 
     private static object? EvaluateUnary(UnaryExpression expression, JsEnvironment environment, EvaluationContext context)
     {
+        if (expression.Operator is "++" or "--")
+        {
+            var reference = ResolveReference(expression.Operand, environment, context);
+            var currentValue = reference.GetValue();
+            var updatedValue = expression.Operator == "++"
+                ? currentValue.ToNumber() + 1
+                : currentValue.ToNumber() - 1;
+            reference.SetValue(updatedValue);
+            return expression.IsPrefix ? updatedValue : currentValue;
+        }
+
+        if (expression.Operator == "delete")
+        {
+            return EvaluateDelete(expression.Operand, environment, context);
+        }
+
         var operand = EvaluateExpression(expression.Operand, environment, context);
         if (context.ShouldStopEvaluation)
         {
@@ -260,6 +762,9 @@ public static class TypedAstEvaluator
             "!" => !IsTruthy(operand),
             "+" => operand.ToNumber(),
             "-" => -operand.ToNumber(),
+            "~" => ~JsNumericConversions.ToInt32(operand.ToNumber()),
+            "typeof" => GetTypeofString(operand),
+            "void" => JsSymbols.Undefined,
             _ => throw new NotSupportedException($"Operator '{expression.Operator}' is not supported yet.")
         };
     }
@@ -310,14 +815,22 @@ public static class TypedAstEvaluator
             "<=" => left.ToNumber() <= right.ToNumber(),
             ">" => left.ToNumber() > right.ToNumber(),
             ">=" => left.ToNumber() >= right.ToNumber(),
+            "&" => JsNumericConversions.ToInt32(left.ToNumber()) & JsNumericConversions.ToInt32(right.ToNumber()),
+            "|" => JsNumericConversions.ToInt32(left.ToNumber()) | JsNumericConversions.ToInt32(right.ToNumber()),
+            "^" => JsNumericConversions.ToInt32(left.ToNumber()) ^ JsNumericConversions.ToInt32(right.ToNumber()),
+            "<<" => JsNumericConversions.ToInt32(left.ToNumber()) << (JsNumericConversions.ToInt32(right.ToNumber()) & 0x1F),
+            ">>" => JsNumericConversions.ToInt32(left.ToNumber()) >> (JsNumericConversions.ToInt32(right.ToNumber()) & 0x1F),
+            ">>>" => (int)(JsNumericConversions.ToUInt32(left.ToNumber()) >> (int)(JsNumericConversions.ToUInt32(right.ToNumber()) & 0x1F)),
+            "in" => InOperator(left, right),
+            "instanceof" => InstanceofOperator(left, right),
             _ => throw new NotSupportedException($"Operator '{expression.Operator}' is not supported yet.")
         };
     }
 
     private static object? EvaluateCall(CallExpression expression, JsEnvironment environment, EvaluationContext context)
     {
-        var callee = EvaluateExpression(expression.Callee, environment, context);
-        if (context.ShouldStopEvaluation)
+        var (callee, thisValue, skippedOptional) = EvaluateCallTarget(expression.Callee, environment, context);
+        if (context.ShouldStopEvaluation || skippedOptional)
         {
             return JsSymbols.Undefined;
         }
@@ -338,7 +851,18 @@ public static class TypedAstEvaluator
         {
             if (argument.IsSpread)
             {
-                throw new NotSupportedException("Spread arguments are not yet supported by the typed evaluator.");
+                var spreadValue = EvaluateExpression(argument.Expression, environment, context);
+                if (context.ShouldStopEvaluation)
+                {
+                    return JsSymbols.Undefined;
+                }
+
+                foreach (var item in EnumerateSpread(spreadValue))
+                {
+                    arguments.Add(item);
+                }
+
+                continue;
             }
 
             arguments.Add(EvaluateExpression(argument.Expression, environment, context));
@@ -355,13 +879,293 @@ public static class TypedAstEvaluator
 
         try
         {
-            return callable.Invoke(arguments.MoveToImmutable(), thisValue: null);
+            return callable.Invoke(arguments.MoveToImmutable(), thisValue);
         }
         catch (ThrowSignal signal)
         {
             context.SetThrow(signal.ThrownValue);
             return signal.ThrownValue;
         }
+    }
+
+    private static (object? Callee, object? ThisValue, bool SkippedOptional) EvaluateCallTarget(ExpressionNode callee,
+        JsEnvironment environment, EvaluationContext context)
+    {
+        if (callee is MemberExpression member)
+        {
+            var target = EvaluateExpression(member.Target, environment, context);
+            if (context.ShouldStopEvaluation)
+            {
+                return (JsSymbols.Undefined, null, true);
+            }
+
+            if (member.IsOptional && IsNullish(target))
+            {
+                return (null, null, true);
+            }
+
+            var property = EvaluateExpression(member.Property, environment, context);
+            if (context.ShouldStopEvaluation)
+            {
+                return (JsSymbols.Undefined, null, true);
+            }
+
+            var propertyName = ToPropertyName(property)
+                               ?? throw new InvalidOperationException("Property name cannot be null.");
+            if (!TryGetPropertyValue(target, propertyName, out var value))
+            {
+                return (JsSymbols.Undefined, target, false);
+            }
+
+            return (value, target, false);
+        }
+
+        var directCallee = EvaluateExpression(callee, environment, context);
+        return (directCallee, null, false);
+    }
+
+    private static IEnumerable<object?> EnumerateSpread(object? value)
+    {
+        switch (value)
+        {
+            case null:
+                yield break;
+            case JsArray array:
+                foreach (var item in array.Items)
+                {
+                    yield return item;
+                }
+
+                yield break;
+            case string s:
+                foreach (var ch in s)
+                {
+                    yield return ch.ToString();
+                }
+
+                yield break;
+            case IEnumerable enumerable:
+                foreach (var item in enumerable)
+                {
+                    yield return item;
+                }
+
+                yield break;
+            default:
+                throw new InvalidOperationException("Value is not iterable.");
+        }
+    }
+
+    private static bool EvaluateDelete(ExpressionNode operand, JsEnvironment environment, EvaluationContext context)
+    {
+        if (operand is MemberExpression member)
+        {
+            var target = EvaluateExpression(member.Target, environment, context);
+            if (context.ShouldStopEvaluation)
+            {
+                return false;
+            }
+
+            var propertyValue = EvaluateExpression(member.Property, environment, context);
+            if (context.ShouldStopEvaluation)
+            {
+                return false;
+            }
+
+            var propertyName = ToPropertyName(propertyValue)
+                               ?? throw new InvalidOperationException("Property name cannot be null.");
+            return DeletePropertyValue(target, propertyName);
+        }
+
+        // Deleting identifiers is a no-op in strict mode; return false to indicate failure.
+        return false;
+    }
+
+    private static object? EvaluateNew(NewExpression expression, JsEnvironment environment, EvaluationContext context)
+    {
+        var constructor = EvaluateExpression(expression.Constructor, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            return JsSymbols.Undefined;
+        }
+
+        if (constructor is not IJsCallable callable)
+        {
+            throw new InvalidOperationException("Attempted to construct a non-callable value.");
+        }
+
+        var instance = new JsObject();
+        if (TryGetPropertyValue(constructor, "prototype", out var prototype) && prototype is JsObject proto)
+        {
+            instance.SetPrototype(proto);
+        }
+
+        var args = ImmutableArray.CreateBuilder<object?>(expression.Arguments.Length);
+        foreach (var argument in expression.Arguments)
+        {
+            args.Add(EvaluateExpression(argument, environment, context));
+            if (context.ShouldStopEvaluation)
+            {
+                return JsSymbols.Undefined;
+            }
+        }
+
+        var result = callable.Invoke(args.MoveToImmutable(), instance);
+        return result is JsObject or JsArray ? result : instance;
+    }
+
+    private static object? EvaluateArray(ArrayExpression expression, JsEnvironment environment,
+        EvaluationContext context)
+    {
+        var array = new JsArray();
+        foreach (var element in expression.Elements)
+        {
+            if (element.IsSpread)
+            {
+                var spreadValue = EvaluateExpression(element.Expression!, environment, context);
+                if (context.ShouldStopEvaluation)
+                {
+                    return JsSymbols.Undefined;
+                }
+
+                foreach (var item in EnumerateSpread(spreadValue))
+                {
+                    array.Push(item);
+                }
+
+                continue;
+            }
+
+            array.Push(element.Expression is null
+                ? JsSymbols.Undefined
+                : EvaluateExpression(element.Expression, environment, context));
+            if (context.ShouldStopEvaluation)
+            {
+                return JsSymbols.Undefined;
+            }
+        }
+
+        return array;
+    }
+
+    private static object? EvaluateObject(ObjectExpression expression, JsEnvironment environment,
+        EvaluationContext context)
+    {
+        var obj = new JsObject();
+        foreach (var member in expression.Members)
+        {
+            switch (member.Kind)
+            {
+                case ObjectMemberKind.Property:
+                {
+                    var name = ToPropertyName(member.Key)
+                               ?? throw new InvalidOperationException("Property name cannot be null.");
+                    var value = member.Value is null
+                        ? JsSymbols.Undefined
+                        : EvaluateExpression(member.Value, environment, context);
+                    obj.SetProperty(name, value);
+                    break;
+                }
+                case ObjectMemberKind.Method:
+                {
+                    var method = new TypedFunction(member.Function!, environment);
+                    var name = ToPropertyName(member.Key)
+                               ?? throw new InvalidOperationException("Property name cannot be null.");
+                    obj.SetProperty(name, method);
+                    break;
+                }
+                case ObjectMemberKind.Getter:
+                {
+                    var getter = new TypedFunction(member.Function!, environment);
+                    var name = ToPropertyName(member.Key)
+                               ?? throw new InvalidOperationException("Property name cannot be null.");
+                    obj.SetGetter(name, getter);
+                    break;
+                }
+                case ObjectMemberKind.Setter:
+                {
+                    var setter = new TypedFunction(member.Function!, environment);
+                    var name = ToPropertyName(member.Key)
+                               ?? throw new InvalidOperationException("Property name cannot be null.");
+                    obj.SetSetter(name, setter);
+                    break;
+                }
+                case ObjectMemberKind.Field:
+                {
+                    var name = ToPropertyName(member.Key)
+                               ?? throw new InvalidOperationException("Property name cannot be null.");
+                    var value = member.Value is null
+                        ? JsSymbols.Undefined
+                        : EvaluateExpression(member.Value, environment, context);
+                    obj.SetProperty(name, value);
+                    break;
+                }
+                case ObjectMemberKind.Spread:
+                {
+                    var spreadValue = EvaluateExpression(member.Value!, environment, context);
+                    if (context.ShouldStopEvaluation)
+                    {
+                        return JsSymbols.Undefined;
+                    }
+
+                    if (spreadValue is JsObject spreadObject)
+                    {
+                        foreach (var key in spreadObject.GetOwnPropertyNames())
+                        {
+                            var spreadPropertyValue = spreadObject.TryGetProperty(key, out var val)
+                                ? val
+                                : JsSymbols.Undefined;
+                            obj.SetProperty(key, spreadPropertyValue);
+                        }
+
+                        break;
+                    }
+
+                    if (spreadValue is IDictionary<string, object?> dictionary)
+                    {
+                        foreach (var kvp in dictionary)
+                        {
+                            obj.SetProperty(kvp.Key, kvp.Value);
+                        }
+
+                        break;
+                    }
+
+                    throw new InvalidOperationException("Cannot spread value that is not an object.");
+                }
+            }
+        }
+
+        return obj;
+    }
+
+    private static object? EvaluateTemplateLiteral(TemplateLiteralExpression expression, JsEnvironment environment,
+        EvaluationContext context)
+    {
+        var builder = new System.Text.StringBuilder();
+        foreach (var part in expression.Parts)
+        {
+            if (part.Text is not null)
+            {
+                builder.Append(part.Text);
+                continue;
+            }
+
+            if (part.Expression is null)
+            {
+                continue;
+            }
+
+            var value = EvaluateExpression(part.Expression, environment, context);
+            if (context.ShouldStopEvaluation)
+            {
+                return JsSymbols.Undefined;
+            }
+
+            builder.Append(value);
+        }
+
+        return builder.ToString();
     }
 
     private static bool IsNullish(object? value)
@@ -385,7 +1189,7 @@ public static class TypedAstEvaluator
 
     private static object? Add(object? left, object? right)
     {
-        if (left is string leftString || right is string rightString)
+        if (left is string || right is string)
         {
             return $"{left}{right}";
         }
@@ -435,6 +1239,239 @@ public static class TypedAstEvaluator
             Symbol leftSymbol => ReferenceEquals(leftSymbol, right),
             _ => Equals(left, right)
         };
+    }
+
+    private static string? ToPropertyName(object? value)
+    {
+        return value switch
+        {
+            null => "null",
+            string s => s,
+            Symbol symbol => symbol.Name,
+            JsSymbol jsSymbol => $"@@symbol:{jsSymbol.GetHashCode()}",
+            bool b => b ? "true" : "false",
+            int i => i.ToString(CultureInfo.InvariantCulture),
+            long l => l.ToString(CultureInfo.InvariantCulture),
+            double d when !double.IsNaN(d) && !double.IsInfinity(d) => d.ToString(CultureInfo.InvariantCulture),
+            _ => Convert.ToString(value, CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static bool TryGetPropertyValue(object? target, string propertyName, out object? value)
+    {
+        if (target is IJsPropertyAccessor propertyAccessor)
+        {
+            return propertyAccessor.TryGetProperty(propertyName, out value);
+        }
+
+        switch (target)
+        {
+            case double num:
+                var numberWrapper = StandardLibrary.CreateNumberWrapper(num);
+                if (numberWrapper.TryGetProperty(propertyName, out value))
+                {
+                    return true;
+                }
+
+                break;
+            case string str:
+                if (propertyName == "length")
+                {
+                    value = (double)str.Length;
+                    return true;
+                }
+
+                if (int.TryParse(propertyName, NumberStyles.Integer, CultureInfo.InvariantCulture, out var index) &&
+                    index >= 0 && index < str.Length)
+                {
+                    value = str[index].ToString();
+                    return true;
+                }
+
+                var stringWrapper = StandardLibrary.CreateStringWrapper(str);
+                if (stringWrapper.TryGetProperty(propertyName, out value))
+                {
+                    return true;
+                }
+
+                break;
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static void AssignPropertyValue(object? target, string propertyName, object? value)
+    {
+        if (target is IJsPropertyAccessor accessor)
+        {
+            accessor.SetProperty(propertyName, value);
+            return;
+        }
+
+        throw new InvalidOperationException($"Cannot assign property '{propertyName}' on value '{target}'.");
+    }
+
+    private static bool DeletePropertyValue(object? target, string propertyName)
+    {
+        if (target is JsObject jsObject)
+        {
+            return jsObject.Remove(propertyName);
+        }
+
+        return false;
+    }
+
+    private static bool InOperator(object? property, object? target)
+    {
+        var propertyName = ToPropertyName(property)
+                           ?? throw new InvalidOperationException("Property name cannot be null.");
+        return TryGetPropertyValue(target, propertyName, out _);
+    }
+
+    private static bool InstanceofOperator(object? left, object? right)
+    {
+        if (!TryGetPropertyValue(right, "prototype", out var prototype) || prototype is not JsObject prototypeObject)
+        {
+            throw new InvalidOperationException("Right-hand side of 'instanceof' is not a constructor.");
+        }
+
+        var current = left as JsObject;
+        while (current is not null)
+        {
+            if (ReferenceEquals(current, prototypeObject))
+            {
+                return true;
+            }
+
+            current = current.Prototype;
+        }
+
+        return false;
+    }
+
+    private static string GetTypeofString(object? value)
+    {
+        if (value is null)
+        {
+            return "object";
+        }
+
+        if (value is Symbol sym && ReferenceEquals(sym, JsSymbols.Undefined))
+        {
+            return "undefined";
+        }
+
+        if (value is JsSymbol)
+        {
+            return "symbol";
+        }
+
+        if (value is JsBigInt)
+        {
+            return "bigint";
+        }
+
+        return value switch
+        {
+            bool => "boolean",
+            double or float or decimal or int or uint or long or ulong or short or ushort or byte or sbyte => "number",
+            string => "string",
+            JsFunction or HostFunction => "function",
+            _ => "object"
+        };
+    }
+
+    private static void AssignBindingTarget(BindingTarget target, object? value, JsEnvironment environment)
+    {
+        if (target is IdentifierBinding identifier)
+        {
+            environment.Assign(identifier.Name, value);
+            return;
+        }
+
+        throw new NotSupportedException("Destructuring bindings are not yet supported by the typed evaluator.");
+    }
+
+    private static void DefineBindingTarget(BindingTarget target, object? value, JsEnvironment environment, bool isConst)
+    {
+        if (target is IdentifierBinding identifier)
+        {
+            environment.Define(identifier.Name, value, isConst);
+            return;
+        }
+
+        throw new NotSupportedException("Destructuring bindings are not yet supported by the typed evaluator.");
+    }
+
+    private static void DefineOrAssignVar(BindingTarget target, object? value, JsEnvironment environment)
+    {
+        if (target is IdentifierBinding identifier)
+        {
+            environment.DefineFunctionScoped(identifier.Name, value, true);
+            return;
+        }
+
+        throw new NotSupportedException("Destructuring bindings are not yet supported by the typed evaluator.");
+    }
+
+    private static void RestoreSignal(EvaluationContext context, ISignal? signal)
+    {
+        switch (signal)
+        {
+            case null:
+                return;
+            case ReturnSignal returnSignal:
+                context.SetReturn(returnSignal.Value);
+                break;
+            case BreakSignal breakSignal:
+                context.SetBreak(breakSignal.Label);
+                break;
+            case ContinueSignal continueSignal:
+                context.SetContinue(continueSignal.Label);
+                break;
+            case ThrowFlowSignal throwSignal:
+                context.SetThrow(throwSignal.Value);
+                break;
+        }
+    }
+
+    private readonly record struct AssignmentReference(Func<object?> GetValue, Action<object?> SetValue);
+
+    private static AssignmentReference ResolveReference(ExpressionNode expression, JsEnvironment environment,
+        EvaluationContext context)
+    {
+        return expression switch
+        {
+            IdentifierExpression identifier => new AssignmentReference(
+                () => environment.Get(identifier.Name),
+                value => environment.Assign(identifier.Name, value)),
+            MemberExpression member => ResolveMemberReference(member, environment, context),
+            _ => throw new NotSupportedException("Unsupported assignment target.")
+        };
+    }
+
+    private static AssignmentReference ResolveMemberReference(MemberExpression member, JsEnvironment environment,
+        EvaluationContext context)
+    {
+        var target = EvaluateExpression(member.Target, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            return new AssignmentReference(() => JsSymbols.Undefined, _ => { });
+        }
+
+        var propertyValue = EvaluateExpression(member.Property, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            return new AssignmentReference(() => JsSymbols.Undefined, _ => { });
+        }
+
+        var propertyName = ToPropertyName(propertyValue)
+                           ?? throw new InvalidOperationException("Property name cannot be null.");
+
+        return new AssignmentReference(
+            () => TryGetPropertyValue(target, propertyName, out var value) ? value : JsSymbols.Undefined,
+            newValue => AssignPropertyValue(target, propertyName, newValue));
     }
 
     private sealed class TypedFunction : IJsEnvironmentAwareCallable

--- a/src/Asynkron.JsEngine/Ast/TypedAstSupportAnalyzer.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstSupportAnalyzer.cs
@@ -1,0 +1,358 @@
+namespace Asynkron.JsEngine.Ast;
+
+/// <summary>
+/// Lightweight static analysis pass that determines whether the current typed AST
+/// only relies on language constructs supported by <see cref="TypedAstEvaluator"/>.
+/// This allows callers to detect unsupported features before evaluation begins so
+/// we can safely fall back to the legacy cons-based interpreter without executing
+/// half the program twice.
+/// </summary>
+internal static class TypedAstSupportAnalyzer
+{
+    public static bool Supports(ProgramNode program, out string? reason)
+    {
+        var visitor = new SupportVisitor();
+        visitor.VisitProgram(program);
+        reason = visitor.UnsupportedReason;
+        return reason is null;
+    }
+
+    private sealed class SupportVisitor
+    {
+        public string? UnsupportedReason { get; private set; }
+
+        public void VisitProgram(ProgramNode program)
+        {
+            foreach (var statement in program.Body)
+            {
+                if (!VisitStatement(statement))
+                {
+                    return;
+                }
+            }
+        }
+
+        private bool VisitStatement(StatementNode statement)
+        {
+            if (UnsupportedReason is not null)
+            {
+                return false;
+            }
+
+            switch (statement)
+            {
+                case BlockStatement block:
+                    foreach (var child in block.Statements)
+                    {
+                        if (!VisitStatement(child))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                case ExpressionStatement expressionStatement:
+                    return VisitExpression(expressionStatement.Expression);
+                case ReturnStatement returnStatement:
+                    return returnStatement.Expression is null || VisitExpression(returnStatement.Expression);
+                case ThrowStatement throwStatement:
+                    return VisitExpression(throwStatement.Expression);
+                case VariableDeclaration declaration:
+                    foreach (var declarator in declaration.Declarators)
+                    {
+                        if (!IsSupportedBinding(declarator.Target))
+                        {
+                            return false;
+                        }
+
+                        if (declarator.Initializer is not null && !VisitExpression(declarator.Initializer))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                case FunctionDeclaration functionDeclaration:
+                    return VisitFunction(functionDeclaration.Function);
+                case IfStatement ifStatement:
+                    return VisitExpression(ifStatement.Condition) &&
+                           VisitStatement(ifStatement.Then) &&
+                           (ifStatement.Else is null || VisitStatement(ifStatement.Else));
+                case WhileStatement whileStatement:
+                    return VisitExpression(whileStatement.Condition) && VisitStatement(whileStatement.Body);
+                case DoWhileStatement doWhileStatement:
+                    return VisitStatement(doWhileStatement.Body) && VisitExpression(doWhileStatement.Condition);
+                case ForStatement forStatement:
+                    if (forStatement.Initializer is not null && !VisitStatement(forStatement.Initializer))
+                    {
+                        return false;
+                    }
+
+                    if (forStatement.Condition is not null && !VisitExpression(forStatement.Condition))
+                    {
+                        return false;
+                    }
+
+                    if (forStatement.Increment is not null && !VisitExpression(forStatement.Increment))
+                    {
+                        return false;
+                    }
+
+                    return VisitStatement(forStatement.Body);
+                case ForEachStatement forEach when forEach.Kind == ForEachKind.AwaitOf:
+                    return Fail("for await...of loops are not supported by the typed evaluator yet.");
+                case ForEachStatement forEach:
+                    return IsSupportedBinding(forEach.Target) &&
+                           VisitExpression(forEach.Iterable) &&
+                           VisitStatement(forEach.Body);
+                case LabeledStatement labeled:
+                    return VisitStatement(labeled.Statement);
+                case TryStatement tryStatement:
+                    if (!VisitBlock(tryStatement.TryBlock))
+                    {
+                        return false;
+                    }
+
+                    if (tryStatement.Catch is not null && !VisitCatch(tryStatement.Catch))
+                    {
+                        return false;
+                    }
+
+                    if (tryStatement.Finally is not null && !VisitBlock(tryStatement.Finally))
+                    {
+                        return false;
+                    }
+
+                    return true;
+                case SwitchStatement switchStatement:
+                    if (!VisitExpression(switchStatement.Discriminant))
+                    {
+                        return false;
+                    }
+
+                    foreach (var switchCase in switchStatement.Cases)
+                    {
+                        if (switchCase.Test is not null && !VisitExpression(switchCase.Test))
+                        {
+                            return false;
+                        }
+
+                        if (!VisitBlock(switchCase.Body))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                case BreakStatement:
+                case ContinueStatement:
+                case EmptyStatement:
+                    return true;
+                case ClassDeclaration:
+                    return Fail("class declarations are not yet translated to the typed evaluator.");
+                case ModuleStatement:
+                    return Fail("module import/export statements are not supported by the typed evaluator yet.");
+                case UnknownStatement unknown:
+                    return Fail($"Unknown statement form '{unknown.Node.Head}'.");
+                default:
+                    return Fail($"Statement '{statement.GetType().Name}' is not supported by the typed evaluator yet.");
+            }
+        }
+
+        private bool VisitBlock(BlockStatement block)
+        {
+            foreach (var statement in block.Statements)
+            {
+                if (!VisitStatement(statement))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool VisitCatch(CatchClause clause)
+        {
+            return VisitBlock(clause.Body);
+        }
+
+        private bool VisitExpression(ExpressionNode expression)
+        {
+            if (UnsupportedReason is not null)
+            {
+                return false;
+            }
+
+            switch (expression)
+            {
+                case LiteralExpression:
+                case IdentifierExpression:
+                case ThisExpression:
+                    return true;
+                case BinaryExpression binary:
+                    return VisitExpression(binary.Left) && VisitExpression(binary.Right);
+                case UnaryExpression unary:
+                    return VisitExpression(unary.Operand);
+                case ConditionalExpression conditional:
+                    return VisitExpression(conditional.Test) &&
+                           VisitExpression(conditional.Consequent) &&
+                           VisitExpression(conditional.Alternate);
+                case CallExpression call:
+                    if (!VisitExpression(call.Callee))
+                    {
+                        return false;
+                    }
+
+                    foreach (var argument in call.Arguments)
+                    {
+                        if (!VisitExpression(argument.Expression))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                case FunctionExpression function:
+                    return VisitFunction(function);
+                case AssignmentExpression assignment:
+                    return VisitExpression(assignment.Value);
+                case PropertyAssignmentExpression propertyAssignment:
+                    return VisitExpression(propertyAssignment.Target) &&
+                           VisitExpression(propertyAssignment.Property) &&
+                           VisitExpression(propertyAssignment.Value);
+                case IndexAssignmentExpression indexAssignment:
+                    return VisitExpression(indexAssignment.Target) &&
+                           VisitExpression(indexAssignment.Index) &&
+                           VisitExpression(indexAssignment.Value);
+                case SequenceExpression sequence:
+                    return VisitExpression(sequence.Left) && VisitExpression(sequence.Right);
+                case MemberExpression member:
+                    return VisitExpression(member.Target) && VisitExpression(member.Property);
+                case NewExpression newExpression:
+                    if (!VisitExpression(newExpression.Constructor))
+                    {
+                        return false;
+                    }
+
+                    foreach (var argument in newExpression.Arguments)
+                    {
+                        if (!VisitExpression(argument))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                case ArrayExpression arrayExpression:
+                    foreach (var element in arrayExpression.Elements)
+                    {
+                        if (element.Expression is not null && !VisitExpression(element.Expression))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                case ObjectExpression objectExpression:
+                    foreach (var member in objectExpression.Members)
+                    {
+                        if (!VisitObjectMember(member))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                case TemplateLiteralExpression template:
+                    foreach (var part in template.Parts)
+                    {
+                        if (part.Expression is not null && !VisitExpression(part.Expression))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                case TaggedTemplateExpression:
+                    return Fail("Tagged template literals are not supported by the typed evaluator yet.");
+                case DestructuringAssignmentExpression:
+                    return Fail("Destructuring assignments are not supported by the typed evaluator yet.");
+                case AwaitExpression:
+                    return Fail("await expressions are not supported by the typed evaluator yet.");
+                case YieldExpression:
+                    return Fail("yield expressions are not supported by the typed evaluator yet.");
+                case SuperExpression:
+                    return Fail("super expressions are not supported by the typed evaluator yet.");
+                case UnknownExpression unknown:
+                    return Fail($"Unknown expression form '{unknown.Node.Head}'.");
+                default:
+                    return Fail($"Expression '{expression.GetType().Name}' is not supported by the typed evaluator yet.");
+            }
+        }
+
+        private bool VisitObjectMember(ObjectMember member)
+        {
+            if (member.Kind == ObjectMemberKind.Unknown)
+            {
+                return Fail("Object literal member kind is not recognised by the typed evaluator.");
+            }
+
+            if (member.Value is not null && !VisitExpression(member.Value))
+            {
+                return false;
+            }
+
+            if (member.Function is not null && !VisitFunction(member.Function))
+            {
+                return false;
+            }
+
+            if (member.Key is ExpressionNode keyExpression && !VisitExpression(keyExpression))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool VisitFunction(FunctionExpression function)
+        {
+            if (function.IsAsync || function.IsGenerator)
+            {
+                return Fail("Async or generator functions are not supported by the typed evaluator yet.");
+            }
+
+            foreach (var parameter in function.Parameters)
+            {
+                if (parameter.Pattern is not null)
+                {
+                    return Fail("Destructuring parameters are not supported by the typed evaluator yet.");
+                }
+
+                if (parameter.DefaultValue is not null && !VisitExpression(parameter.DefaultValue))
+                {
+                    return false;
+                }
+            }
+
+            return VisitBlock(function.Body);
+        }
+
+        private bool IsSupportedBinding(BindingTarget target)
+        {
+            if (target is IdentifierBinding)
+            {
+                return true;
+            }
+
+            return Fail("Destructuring bindings are not supported by the typed evaluator yet.");
+        }
+
+        private bool Fail(string reason)
+        {
+            UnsupportedReason ??= reason;
+            return false;
+        }
+    }
+}

--- a/src/Asynkron.JsEngine/Ast/TypedProgramExecutor.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedProgramExecutor.cs
@@ -1,0 +1,25 @@
+using Asynkron.JsEngine.Lisp;
+
+namespace Asynkron.JsEngine.Ast;
+
+/// <summary>
+/// Coordinates conversion from S-expressions to the typed AST and decides whether
+/// the typed evaluator can handle the program. When unsupported constructs are
+/// detected we fall back to the legacy cons-based interpreter to preserve
+/// behaviour while we continue expanding the typed runtime.
+/// </summary>
+internal sealed class TypedProgramExecutor
+{
+    private readonly SExpressionAstBuilder _builder = new();
+
+    public object? Evaluate(Cons program, JsEnvironment environment)
+    {
+        var typedProgram = _builder.BuildProgram(program);
+        if (!TypedAstSupportAnalyzer.Supports(typedProgram, out _))
+        {
+            return JsEvaluator.EvaluateProgram(program, environment);
+        }
+
+        return TypedAstEvaluator.EvaluateProgram(typedProgram, environment);
+    }
+}

--- a/src/Asynkron.JsEngine/EvalHostFunction.cs
+++ b/src/Asynkron.JsEngine/EvalHostFunction.cs
@@ -39,7 +39,7 @@ public sealed class EvalHostFunction : IJsEnvironmentAwareCallable, IJsPropertyA
 
         // Evaluate directly in the calling environment without going through the event queue
         // This is safe because eval() is synchronous in JavaScript
-        var result = JsEvaluator.EvaluateProgram(program, environment);
+        var result = _engine.ExecuteProgram(program, environment);
 
         return result;
     }

--- a/tests/Asynkron.JsEngine.Tests/TypedAstEvaluatorTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/TypedAstEvaluatorTests.cs
@@ -1,0 +1,42 @@
+using Asynkron.JsEngine;
+using Asynkron.JsEngine.Ast;
+using Xunit;
+
+namespace Asynkron.JsEngine.Tests;
+
+public class TypedAstEvaluatorTests
+{
+    [Theory]
+    [InlineData("let sum = 0; let i = 0; while (i < 4) { sum = sum + i; i = i + 1; } sum;", 6d)]
+    [InlineData("let obj = { value: 3 }; obj.value = obj.value + 4; obj.value;", 7d)]
+    [InlineData("let data = null; data?.value;", null)]
+    [InlineData("let total = 0; for (const value of [1, 2, 3]) { total = total + value; } total;", 6d)]
+    [InlineData("let captured = 0; try { throw 9; } catch (err) { captured = err; } captured;", 9d)]
+    public void TypedEvaluator_matches_legacy_for_core_flows(string source, object? expected)
+    {
+        var (typed, legacy) = EvaluateBoth(source);
+        Assert.Equal(legacy, typed);
+        if (expected is null)
+        {
+            Assert.True(typed is null || ReferenceEquals(typed, JsSymbols.Undefined));
+        }
+        else
+        {
+            Assert.Equal(expected, typed);
+        }
+    }
+
+    private static (object? Typed, object? Legacy) EvaluateBoth(string source)
+    {
+        var program = JsEngine.ParseWithoutTransformation(source);
+        var builder = new SExpressionAstBuilder();
+        var typedProgram = builder.BuildProgram(program);
+
+        var typedEnv = new JsEnvironment(isFunctionScope: true);
+        var legacyEnv = new JsEnvironment(isFunctionScope: true);
+
+        var typed = TypedAstEvaluator.EvaluateProgram(typedProgram, typedEnv);
+        var legacy = JsEvaluator.EvaluateProgram(program, legacyEnv);
+        return (typed, legacy);
+    }
+}


### PR DESCRIPTION
## Summary
- extend the typed AST evaluator with control-flow constructs, property helpers, member/call semantics, and literal/object handling so the interpreter can execute more of the language surface
- add a focused xUnit test suite that compares typed evaluation with the legacy evaluator for representative flows

## Testing
- dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter TypedAstEvaluatorTests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69192ce6a7848328ab6cb1be6a119e6c)