### PR TITLE
Normalize JS string conversion for addition

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.cs
@@ -1253,10 +1253,14 @@ public static class TypedAstEvaluator
 
     private static object? Add(object? left, object? right)
     {
-        if (left is string || right is string || left is JsObject || left is JsArray || right is JsObject ||
-            right is JsArray)
+        if (left is string || right is string)
         {
-            return $"{left}{right}";
+            return JsEvaluator.ToJsString(left) + JsEvaluator.ToJsString(right);
+        }
+
+        if (left is JsObject || left is JsArray || right is JsObject || right is JsArray)
+        {
+            return JsEvaluator.ToJsString(left) + JsEvaluator.ToJsString(right);
         }
 
         if (left is JsBigInt leftBigInt && right is JsBigInt rightBigInt)

--- a/src/Asynkron.JsEngine/StandardLibrary.cs
+++ b/src/Asynkron.JsEngine/StandardLibrary.cs
@@ -1365,7 +1365,7 @@ public static class StandardLibrary
             var parts = new List<string>();
             foreach (var item in jsArray.Items)
             {
-                parts.Add(JsEvaluator.ToStringForArray(item));
+                parts.Add(JsEvaluator.ToJsStringForArray(item));
             }
 
             return string.Join(separator, parts);


### PR DESCRIPTION
## Summary
- add reusable helpers for converting JS values to their string representation and use them when objects participate in addition
- align the typed evaluator with the JsEvaluator so concatenation no longer returns C# type names or capitalized booleans
- update StandardLibrary helpers to use the shared conversion so array joins mirror JavaScript

## Testing
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "FullyQualifiedName~SparseArrayTest" -v minimal`
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "FullyQualifiedName~TypeCoercionTests.Addition_EmptyArrays" -v minimal`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193d3dca448328b9eba3579098e2fa)