### PR TITLE
Fix debug call stack capture and typed function prototype

### DIFF
--- a/src/Asynkron.JsEngine/JsEnvironment.cs
+++ b/src/Asynkron.JsEngine/JsEnvironment.cs
@@ -1,3 +1,4 @@
+using System;
 using Asynkron.JsEngine.Ast;
 using Asynkron.JsEngine.Lisp;
 
@@ -177,7 +178,10 @@ public sealed class JsEnvironment(
             // Always add a frame if we have any identifying information
             if (current._creatingExpression is not null || current._description is not null)
             {
-                var operationType = DetermineOperationType(current._creatingExpression);
+                var hasExpression = current._creatingExpression is not null;
+                var operationType = hasExpression
+                    ? DetermineOperationType(current._creatingExpression)
+                    : DetermineOperationTypeFromDescription(current._description);
                 var description = current._description ??
                                   GetExpressionDescription(current._creatingExpression, operationType);
 
@@ -245,6 +249,23 @@ public sealed class JsEnvironment(
 
         return symbol.Name;
 
+    }
+
+    private static string DetermineOperationTypeFromDescription(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            return "unknown";
+        }
+
+        var trimmed = description.TrimStart();
+        var separators = new[] { ' ', '-', ':' };
+        var separatorIndex = trimmed.IndexOfAny(separators);
+        var firstToken = separatorIndex >= 0 ? trimmed[..separatorIndex] : trimmed;
+
+        return string.IsNullOrEmpty(firstToken)
+            ? "unknown"
+            : firstToken.ToLowerInvariant();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- ensure debug-aware host functions receive the current execution context when invoked by the typed evaluator so DebugTests behave like the legacy evaluator
- allow call stack frames without backing s-expressions (such as typed loop scopes) to derive their operation type from the provided description so `for` loops appear in debug call stacks
- make typed functions expose a prototype object via `IJsPropertyAccessor`, enabling code such as `NBodySystem.prototype.getCount = ...`

## Testing
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter FullyQualifiedName~DebugTests`
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter FullyQualifiedName~AsyncIterableDebugTests`
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter FullyQualifiedName~NBodyArraySizeTest`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197ccde4408328ac314cf31c58821d)