### PR TITLE
Fix typed AST semantics for computed keys and hoisting

### DIFF
--- a/src/Asynkron.JsEngine/Ast/SExpressionAstBuilder.cs
+++ b/src/Asynkron.JsEngine/Ast/SExpressionAstBuilder.cs
@@ -807,6 +807,12 @@ public sealed class SExpressionAstBuilder
             return BuildExpression(cons);
         }
 
+        if (keyNode is Symbol symbol)
+        {
+            isComputed = true;
+            return BuildSymbolExpression(symbol);
+        }
+
         isComputed = false;
         return keyNode ?? string.Empty;
     }


### PR DESCRIPTION
## Summary
- ensure computed property names that reference identifiers are treated as computed keys so their runtime values are used
- make the typed evaluator handle `typeof` on undeclared identifiers and improve delete semantics and var hoisting to match JS rules

## Testing
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "FullyQualifiedName=Asynkron.JsEngine.Tests.DeleteOperatorTests.Delete_OnNonExistentProperty_ReturnsTrue" -v m`
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "FullyQualifiedName=Asynkron.JsEngine.Tests.TestTypeofUndeclared.TypeofUndeclaredVariable_ShouldReturnUndefined" -v m`
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "FullyQualifiedName=Asynkron.JsEngine.Tests.NewFeaturesTests.VariableHoisting_ConditionalAccess" -v m`
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "FullyQualifiedName=Asynkron.JsEngine.Tests.ObjectEnhancementsTests.ComputedPropertyNameMixed" -v m`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919840cf3cc83288f9673fb8e413099)