### PR TITLE
Move JsEngine evaluation onto typed AST

### DIFF
--- a/src/Asynkron.JsEngine/Ast/ParsedProgram.cs
+++ b/src/Asynkron.JsEngine/Ast/ParsedProgram.cs
@@ -1,0 +1,12 @@
+using Asynkron.JsEngine.Lisp;
+
+namespace Asynkron.JsEngine.Ast;
+
+/// <summary>
+/// Bundles the transformed S-expression with its typed AST counterpart so the
+/// runtime can decide between the legacy and typed evaluators without
+/// re-parsing.
+/// </summary>
+/// <param name="SExpression">The transformed S-expression produced by the parser pipeline.</param>
+/// <param name="Typed">The typed AST built from the S-expression.</param>
+public sealed record ParsedProgram(Cons SExpression, ProgramNode Typed);

--- a/src/Asynkron.JsEngine/Ast/TypedProgramExecutor.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedProgramExecutor.cs
@@ -1,5 +1,4 @@
 using Asynkron.JsEngine.Evaluation;
-using Asynkron.JsEngine.Lisp;
 
 namespace Asynkron.JsEngine.Ast;
 
@@ -11,17 +10,13 @@ namespace Asynkron.JsEngine.Ast;
 /// </summary>
 internal sealed class TypedProgramExecutor
 {
-    private readonly SExpressionAstBuilder _builder = new();
-
-    public object? Evaluate(Cons program, JsEnvironment environment)
+    public object? Evaluate(ParsedProgram program, JsEnvironment environment)
     {
-        var typedProgram = _builder.BuildProgram(program);
-
-        if (!TypedAstSupportAnalyzer.Supports(typedProgram, out _))
+        if (!TypedAstSupportAnalyzer.Supports(program.Typed, out _))
         {
-            return ProgramEvaluator.EvaluateProgram(program, environment);
+            return ProgramEvaluator.EvaluateProgram(program.SExpression, environment);
         }
 
-        return TypedAstEvaluator.EvaluateProgram(typedProgram, environment);
+        return TypedAstEvaluator.EvaluateProgram(program.Typed, environment);
     }
 }

--- a/src/Asynkron.JsEngine/EvalHostFunction.cs
+++ b/src/Asynkron.JsEngine/EvalHostFunction.cs
@@ -34,8 +34,8 @@ public sealed class EvalHostFunction : IJsEnvironmentAwareCallable, IJsPropertyA
         var environment = CallingJsEnvironment ?? throw new InvalidOperationException(
             "eval() called without a calling environment");
 
-        // Parse the code
-        var program = _engine.Parse(code);
+        // Parse the code and build the typed AST so eval shares the same pipeline
+        var program = _engine.ParseForExecution(code);
 
         // Evaluate directly in the calling environment without going through the event queue
         // This is safe because eval() is synchronous in JavaScript


### PR DESCRIPTION
## Summary
- add a ParsedProgram wrapper so JsEngine can keep the transformed S-expression together with its typed AST
- update JsEngine and EvalHostFunction to build ParsedProgram instances for evaluation, replacing the Cons-only flow
- simplify TypedProgramExecutor so it consumes ParsedProgram and only falls back to the legacy interpreter when necessary

## Testing
- `dotnet test` *(fails: testhost requires .NET 8 runtime in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a7ad1f088328b35c8d5cb4adfd21)