### PR TITLE
Add typed destructuring support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,15 +7,15 @@ On Linux/macOS:
 ```
 curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
 chmod +x dotnet-install.sh
-./dotnet-install.sh --channel 8.0
+./dotnet-install.sh --channel 10.0
 export PATH="$HOME/.dotnet:$PATH"
 ```
 
 On Windows PowerShell:
 ```
 irm https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
-./dotnet-install.ps1 -Channel 8.0
+./dotnet-install.ps1 -Channel 10.0
 $env:PATH = "$env:USERPROFILE\.dotnet;" + $env:PATH
 ```
 
-These commands install the latest .NET 8 SDK (which includes the runtime) into the user profile so the repository can build and run tests without requiring global admin access.
+These commands install the latest .NET 10 SDK (which includes the runtime) into the user profile so the repository can build and run tests without requiring global admin access.

--- a/src/Asynkron.JsEngine/Ast/Expressions.cs
+++ b/src/Asynkron.JsEngine/Ast/Expressions.cs
@@ -42,9 +42,9 @@ public sealed record FunctionExpression(SourceReference? Source, Symbol? Name,
 
 /// <summary>
 /// Represents a single function parameter. Parameters may use destructuring or rest syntax,
-/// so we capture the original pattern while exposing default values in a typed way.
+/// so we capture the typed binding target while exposing default values.
 /// </summary>
-public sealed record FunctionParameter(SourceReference? Source, Symbol? Name, bool IsRest, Cons? Pattern,
+public sealed record FunctionParameter(SourceReference? Source, Symbol? Name, bool IsRest, BindingTarget? Pattern,
     ExpressionNode? DefaultValue);
 
 /// <summary>

--- a/src/Asynkron.JsEngine/Ast/Statements.cs
+++ b/src/Asynkron.JsEngine/Ast/Statements.cs
@@ -43,10 +43,28 @@ public abstract record BindingTarget(SourceReference? Source) : AstNode(Source);
 public sealed record IdentifierBinding(SourceReference? Source, Symbol Name) : BindingTarget(Source);
 
 /// <summary>
-/// Placeholder for complex destructuring patterns. We keep the original cons tree
-/// so we can incrementally replace it with a richer typed model without losing fidelity.
+/// Represents an array destructuring binding with optional rest element.
 /// </summary>
-public sealed record DestructuringBinding(SourceReference? Source, Cons Pattern) : BindingTarget(Source);
+public sealed record ArrayBinding(SourceReference? Source, ImmutableArray<ArrayBindingElement> Elements,
+    BindingTarget? RestElement) : BindingTarget(Source);
+
+/// <summary>
+/// Represents a single element within an array destructuring binding.
+/// </summary>
+public sealed record ArrayBindingElement(SourceReference? Source, BindingTarget? Target, ExpressionNode? DefaultValue)
+    : AstNode(Source);
+
+/// <summary>
+/// Represents an object destructuring binding with optional rest binding.
+/// </summary>
+public sealed record ObjectBinding(SourceReference? Source, ImmutableArray<ObjectBindingProperty> Properties,
+    BindingTarget? RestElement) : BindingTarget(Source);
+
+/// <summary>
+/// Represents a single property inside an object destructuring binding.
+/// </summary>
+public sealed record ObjectBindingProperty(SourceReference? Source, string Name, BindingTarget Target,
+    ExpressionNode? DefaultValue) : AstNode(Source);
 
 /// <summary>
 /// Represents an expression statement.

--- a/tests/Asynkron.JsEngine.Tests/TypedAstDestructuringTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/TypedAstDestructuringTests.cs
@@ -1,0 +1,62 @@
+using System.Threading.Tasks;
+using Asynkron.JsEngine;
+using Xunit;
+
+namespace Asynkron.JsEngine.Tests;
+
+public class TypedAstDestructuringTests
+{
+    [Fact]
+    public async Task ArrayDestructuring_WithDefaultValue_Works()
+    {
+        await using var engine = new JsEngine();
+        var result = await engine.Evaluate(@"
+            let [a, b = 2] = [1];
+            a + b;
+        ");
+
+        Assert.Equal(3.0, result);
+    }
+
+    [Fact]
+    public async Task ObjectDestructuring_WithNestedPattern_Works()
+    {
+        await using var engine = new JsEngine();
+        var result = await engine.Evaluate(@"
+            let { x, inner: { z = 5 } } = { x: 1, inner: {} };
+            x + z;
+        ");
+
+        Assert.Equal(6.0, result);
+    }
+
+    [Fact]
+    public async Task ForLoop_WithInnerDestructuring_Works()
+    {
+        await using var engine = new JsEngine();
+        var result = await engine.Evaluate(@"
+            let total = 0;
+            for (const pair of [[1, 2], [3, 4]]) {
+                const [x, y] = pair;
+                total += x + y;
+            }
+            total;
+        ");
+
+        Assert.Equal(10.0, result);
+    }
+
+    [Fact]
+    public async Task FunctionParameter_DestructuringBinding_Works()
+    {
+        await using var engine = new JsEngine();
+        var result = await engine.Evaluate(@"
+            function combine({ left, right: { value } }) {
+                return left + value;
+            }
+            combine({ left: 4, right: { value: 8 } });
+        ");
+
+        Assert.Equal(12.0, result);
+    }
+}


### PR DESCRIPTION
## Summary
- update the contributor guidance to reference the .NET 10 SDK
- replace the legacy cons-based destructuring bindings with typed binding targets and evaluate them through `TypedAstEvaluator`
- add unit tests that exercise typed AST destructuring in variable declarations, loops, and function parameters

## Testing
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "FullyQualifiedName~TypedAstDestructuringTests" --no-restore`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b1856b948328ba7c0249e4ac7530)