### PR TITLE
Add typed support for destructuring assignments

### DIFF
--- a/src/Asynkron.JsEngine/Ast/Expressions.cs
+++ b/src/Asynkron.JsEngine/Ast/Expressions.cs
@@ -95,10 +95,12 @@ public sealed record SequenceExpression(SourceReference? Source, ExpressionNode 
     : ExpressionNode(Source);
 
 /// <summary>
-/// Represents a destructuring assignment.
+/// Represents a destructuring assignment (<c>[a, b] = value</c> or <c>({ x } = value)</c>).
+/// The pattern is expressed via the same typed binding nodes used by declarations so the
+/// evaluator can reuse its destructuring logic.
 /// </summary>
-public sealed record DestructuringAssignmentExpression(SourceReference? Source, Cons Pattern, ExpressionNode Value)
-    : ExpressionNode(Source);
+public sealed record DestructuringAssignmentExpression(SourceReference? Source, BindingTarget Target,
+    ExpressionNode Value) : ExpressionNode(Source);
 
 /// <summary>
 /// Represents an array literal.

--- a/src/Asynkron.JsEngine/Ast/SExpressionAstBuilder.cs
+++ b/src/Asynkron.JsEngine/Ast/SExpressionAstBuilder.cs
@@ -704,9 +704,14 @@ public sealed class SExpressionAstBuilder
 
         if (ReferenceEquals(symbol, JsSymbols.DestructuringAssignment))
         {
-            var pattern = cons.Rest.Head as Cons ?? Cons.Empty;
+            if (cons.Rest.Head is null)
+            {
+                return new UnknownExpression(cons.SourceReference, cons);
+            }
+
+            var target = BuildBindingTarget(cons.Rest.Head, cons.SourceReference);
             var value = BuildExpression(cons.Rest.Rest.Head);
-            return new DestructuringAssignmentExpression(cons.SourceReference, pattern, value);
+            return new DestructuringAssignmentExpression(cons.SourceReference, target, value);
         }
 
         if (ReferenceEquals(symbol, JsSymbols.Call) || ReferenceEquals(symbol, JsSymbols.OptionalCall))

--- a/src/Asynkron.JsEngine/Ast/TypedAstSupportAnalyzer.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstSupportAnalyzer.cs
@@ -275,8 +275,9 @@ internal static class TypedAstSupportAnalyzer
                         return true;
                     case TaggedTemplateExpression:
                         return Fail("Tagged template literals are not supported by the typed evaluator yet.");
-                    case DestructuringAssignmentExpression:
-                        return Fail("Destructuring assignments are not supported by the typed evaluator yet.");
+                    case DestructuringAssignmentExpression destructuringAssignment:
+                        return IsSupportedBinding(destructuringAssignment.Target) &&
+                               VisitExpression(destructuringAssignment.Value);
                     case AwaitExpression:
                         return Fail("await expressions are not supported by the typed evaluator yet.");
                     case YieldExpression:

--- a/tests/Asynkron.JsEngine.Tests/TypedAstDestructuringTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/TypedAstDestructuringTests.cs
@@ -59,4 +59,32 @@ public class TypedAstDestructuringTests
 
         Assert.Equal(12.0, result);
     }
+
+    [Fact]
+    public async Task ArrayDestructuringAssignment_Works()
+    {
+        await using var engine = new JsEngine();
+        var result = await engine.Evaluate(@"
+            let first = 0;
+            let second = 0;
+            [first, second] = [3, 7];
+            first * second;
+        ");
+
+        Assert.Equal(21.0, result);
+    }
+
+    [Fact]
+    public async Task ObjectDestructuringAssignment_WithNestedPattern_Works()
+    {
+        await using var engine = new JsEngine();
+        var result = await engine.Evaluate(@"
+            let x = 0;
+            let y = 0;
+            ({ x, inner: { y } } = { x: 2, inner: { y: 5 } });
+            x + y;
+        ");
+
+        Assert.Equal(7.0, result);
+    }
 }


### PR DESCRIPTION
## Summary
- represent destructuring assignments with typed binding targets and let the builder translate the legacy Cons pattern into the typed model
- teach the typed evaluator and support analyzer to execute destructuring assignments using the existing binding machinery
- cover the new behavior with array and object destructuring assignment tests

## Testing
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter FullyQualifiedName~TypedAstDestructuringTests`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919bb822adc832886f984e88ce22792)