### PR TITLE
Add typed class evaluation

### DIFF
--- a/src/Asynkron.JsEngine/Ast/Statements.cs
+++ b/src/Asynkron.JsEngine/Ast/Statements.cs
@@ -171,11 +171,38 @@ public sealed record FunctionDeclaration(SourceReference? Source, Symbol Name, F
     : StatementNode(Source);
 
 /// <summary>
-/// Represents a class declaration. We keep the shape broad for now while retaining the
-/// original S-expression to avoid losing information needed by downstream passes.
+/// Represents a class declaration with its fully typed definition.
 /// </summary>
-public sealed record ClassDeclaration(SourceReference? Source, Symbol Name, Cons? ExtendsClause, Cons Constructor,
-    Cons Methods, Cons Fields) : StatementNode(Source);
+public sealed record ClassDeclaration(SourceReference? Source, Symbol Name, ClassDefinition Definition)
+    : StatementNode(Source);
+
+/// <summary>
+/// Captures the structure of a class body.
+/// </summary>
+public sealed record ClassDefinition(SourceReference? Source, ExpressionNode? Extends, FunctionExpression Constructor,
+    ImmutableArray<ClassMember> Members, ImmutableArray<ClassField> Fields) : AstNode(Source);
+
+/// <summary>
+/// Represents a single method/getter/setter within a class body.
+/// </summary>
+public sealed record ClassMember(SourceReference? Source, ClassMemberKind Kind, string Name,
+    FunctionExpression Function, bool IsStatic) : AstNode(Source);
+
+/// <summary>
+/// Distinguishes between regular methods, getters and setters.
+/// </summary>
+public enum ClassMemberKind
+{
+    Method,
+    Getter,
+    Setter
+}
+
+/// <summary>
+/// Represents a field declared on a class.
+/// </summary>
+public sealed record ClassField(SourceReference? Source, string Name, ExpressionNode? Initializer,
+    bool IsStatic, bool IsPrivate) : AstNode(Source);
 
 /// <summary>
 /// Base type for module import/export statements. Concrete records capture the

--- a/src/Asynkron.JsEngine/JsTypes/JsFunction.cs
+++ b/src/Asynkron.JsEngine/JsTypes/JsFunction.cs
@@ -13,7 +13,7 @@ public sealed class JsFunction : IJsEnvironmentAwareCallable, IJsPropertyAccesso
     private readonly Cons _body;
     private readonly JsEnvironment _closure;
     private readonly JsObject _properties = new();
-    private JsFunction? _superConstructor;
+    private IJsEnvironmentAwareCallable? _superConstructor;
     private JsObject? _superPrototype;
 
     /// <summary>
@@ -332,7 +332,7 @@ public sealed class JsFunction : IJsEnvironmentAwareCallable, IJsPropertyAccesso
         _properties.SetProperty(name, value);
     }
 
-    public void SetSuperBinding(JsFunction? superConstructor, JsObject? superPrototype)
+    public void SetSuperBinding(IJsEnvironmentAwareCallable? superConstructor, JsObject? superPrototype)
     {
         _superConstructor = superConstructor;
         _superPrototype = superPrototype;

--- a/src/Asynkron.JsEngine/SuperBinding.cs
+++ b/src/Asynkron.JsEngine/SuperBinding.cs
@@ -5,9 +5,9 @@ namespace Asynkron.JsEngine;
 /// <summary>
 /// Captures superclass metadata for use by class constructors and methods when resolving <c>super</c> references.
 /// </summary>
-public sealed class SuperBinding(JsFunction? constructor, JsObject? prototype, object? thisValue)
+public sealed class SuperBinding(IJsEnvironmentAwareCallable? constructor, JsObject? prototype, object? thisValue)
 {
-    public JsFunction? Constructor { get; } = constructor;
+    public IJsEnvironmentAwareCallable? Constructor { get; } = constructor;
 
     public JsObject? Prototype { get; } = prototype;
 


### PR DESCRIPTION
## Summary
- add typed AST nodes that describe class declarations, members, and fields
- teach the S-expression builder and support analyzer to translate class structures into the new nodes
- implement class declaration evaluation in the typed evaluator, including static/instance fields and super bindings, and adjust JsFunction/SuperBinding to share metadata

## Testing
- dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter StaticClassFieldsTests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919be2bcc4483289e90e34b376f680c)