### PR TITLE
Add typed generator support

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstSupportAnalyzer.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstSupportAnalyzer.cs
@@ -311,8 +311,13 @@ internal static class TypedAstSupportAnalyzer
                                VisitExpression(destructuringAssignment.Value);
                     case AwaitExpression:
                         return Fail("await expressions are not supported by the typed evaluator yet.");
-                    case YieldExpression:
-                        return Fail("yield expressions are not supported by the typed evaluator yet.");
+                    case YieldExpression yieldExpression:
+                        if (yieldExpression.IsDelegated)
+                        {
+                            return Fail("Delegated yield expressions are not supported by the typed evaluator yet.");
+                        }
+
+                        return VisitExpression(yieldExpression.Expression);
                     case SuperExpression:
                         return Fail("super expressions are not supported by the typed evaluator yet.");
                     case UnknownExpression unknown:
@@ -352,9 +357,9 @@ internal static class TypedAstSupportAnalyzer
 
         private bool VisitFunction(FunctionExpression function)
         {
-            if (function.IsAsync || function.IsGenerator)
+            if (function.IsAsync)
             {
-                return Fail("Async or generator functions are not supported by the typed evaluator yet.");
+                return Fail("Async functions are not supported by the typed evaluator yet.");
             }
 
             foreach (var parameter in function.Parameters)


### PR DESCRIPTION
## Summary
- add generator function and yield expression support to the typed evaluator, including a typed generator factory/object implementation
- relax the typed AST support analyzer so generator constructs are no longer rejected

## Testing
- dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter GeneratorTests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919c3775c8083288f40054aa06a64d6)