### PR TITLE
Improve typed AST destructuring and super support

### DIFF
--- a/src/Asynkron.JsEngine/SuperBinding.cs
+++ b/src/Asynkron.JsEngine/SuperBinding.cs
@@ -1,11 +1,15 @@
+using System;
 using Asynkron.JsEngine.JsTypes;
 
 namespace Asynkron.JsEngine;
 
 /// <summary>
 /// Captures superclass metadata for use by class constructors and methods when resolving <c>super</c> references.
+/// Exposes the prototype through <see cref="IJsPropertyAccessor"/> so the typed evaluator can treat the binding
+/// as a regular property accessor when resolving <c>super.prop</c> and <c>super[expr]</c> lookups.
 /// </summary>
 public sealed class SuperBinding(IJsEnvironmentAwareCallable? constructor, JsObject? prototype, object? thisValue)
+    : IJsPropertyAccessor
 {
     public IJsEnvironmentAwareCallable? Constructor { get; } = constructor;
 
@@ -23,5 +27,10 @@ public sealed class SuperBinding(IJsEnvironmentAwareCallable? constructor, JsObj
         value = null;
         return false;
 
+    }
+
+    public void SetProperty(string name, object? value)
+    {
+        throw new InvalidOperationException("Assigning through super is not supported.");
     }
 }


### PR DESCRIPTION
## Summary
- teach the typed AST evaluator how to resolve `super()` calls and `super.prop` reads using the existing `SuperBinding`, including better source information when `super` is unavailable
- align destructuring bindings with the legacy interpreter by treating missing array/object entries as `null` and surface clearer source-aware errors when destructuring fails

## Testing
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter FullyQualifiedName~DestructuringTests -nologo`
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter FullyQualifiedName~JsEvaluatorTests -nologo`
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter FullyQualifiedName~SourceReferenceInExceptionsTests -nologo`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919c7819b608328a35e6589564fd6f9)