### PR TITLE
Add opt-in typed transformer pipeline

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedCpsTransformer.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedCpsTransformer.cs
@@ -19,6 +19,7 @@ public sealed class TypedCpsTransformer
     private static readonly Symbol AwaitHelperIdentifier = Symbol.Intern("__awaitHelper");
     private static readonly Symbol AwaitValueIdentifier = Symbol.Intern("__value");
     private static readonly Symbol CatchIdentifier = Symbol.Intern("__error");
+    private static readonly Symbol ThenIdentifier = Symbol.Intern("then");
 
     /// <summary>
     /// Returns true when the typed program contains async functions that would
@@ -160,15 +161,16 @@ public sealed class TypedCpsTransformer
     {
         var resolveCall = CreateResolveCall(new IdentifierExpression(null, AwaitValueIdentifier));
         var callbackBodyStatements = ImmutableArray.Create<StatementNode>(
-            new ExpressionStatement(null, resolveCall));
+            new ReturnStatement(null, resolveCall));
         var callbackBody = new BlockStatement(null, callbackBodyStatements, false);
         var callback = new FunctionExpression(null, null,
             [new FunctionParameter(null, AwaitValueIdentifier, false, null, null)],
             callbackBody, false, false);
         var target = new MemberExpression(null, awaitCall,
-            new LiteralExpression(null, "then"), false, false);
-        var thenArguments = ImmutableArray.Create(
-            new CallArgument(null, callback, false));
+            new IdentifierExpression(null, ThenIdentifier), false, false);
+        var callbackArgument = new CallArgument(null, callback, false);
+        var rejectArgument = new CallArgument(null, new IdentifierExpression(null, RejectIdentifier), false);
+        var thenArguments = ImmutableArray.Create(callbackArgument, rejectArgument);
         return new CallExpression(null, target, thenArguments, false);
     }
 


### PR DESCRIPTION
## Summary
- add a `UseTypedTransformers` switch so the engine can attempt the typed AST constant folding and CPS passes or continue using the existing Cons-based transformers
- route the parser through the requested pipeline and fall back to the Cons transformers when the typed analyzer reports unsupported constructs

## Testing
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj --filter "MathMethodsTests.Math_Clz32_WithZero|AsyncAwaitTests.AsyncFunction_WithAwait_ReturnsValue" --verbosity minimal`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a05b77b108328bbcf674d6b6d5393)