### PR TITLE
Implement ES2022 AllPrivateNamesValid check for eval code

### DIFF
--- a/src/Asynkron.JsEngine/EvalHostFunction.cs
+++ b/src/Asynkron.JsEngine/EvalHostFunction.cs
@@ -185,6 +185,33 @@ public sealed class EvalHostFunction : IJsEnvironmentAwareCallable, IEvaluationC
                 environment.RealmState);
         }
 
+        // ES2022: AllPrivateNamesValid static semantic check for eval code.
+        // For direct eval, private names from enclosing class scopes are available.
+        // For indirect eval, no private names are available.
+        // Any private name reference not found in available scopes is a SyntaxError.
+        ImmutableArray<PrivateNameScope>? evalPrivateNameScopes = null;
+        if (isDirectEval && CallingContext is not null)
+        {
+            var capturedScopes = CallingContext.CapturePrivateNameScopes();
+            if (!capturedScopes.IsDefaultOrEmpty)
+            {
+                evalPrivateNameScopes = capturedScopes;
+            }
+            else if (CallingContext.CurrentPrivateNameScope is not null)
+            {
+                evalPrivateNameScopes = ImmutableArray.Create(CallingContext.CurrentPrivateNameScope);
+            }
+        }
+
+        var invalidPrivateName = FindInvalidPrivateName(program.Typed.Body, evalPrivateNameScopes);
+        if (invalidPrivateName is not null)
+        {
+            throw StandardLibrary.ThrowSyntaxError(
+                $"Private field '{invalidPrivateName}' must be declared in an enclosing class",
+                CallingContext,
+                environment.RealmState);
+        }
+
         var isStrictEval = program.Typed.IsStrict;
         JsEnvironment lexicalEnv;
         if (!isDirectEval)
@@ -359,28 +386,16 @@ public sealed class EvalHostFunction : IJsEnvironmentAwareCallable, IEvaluationC
         try
         {
             // Evaluate directly in the constructed eval environment (direct eval is synchronous).
-            ImmutableArray<PrivateNameScope>? inheritedPrivateNameScopes = null;
-            if (isDirectEval && CallingContext is not null)
+            // Note: evalPrivateNameScopes was captured earlier for AllPrivateNamesValid validation.
+            if (evalPrivateNameScopes.HasValue && !evalPrivateNameScopes.Value.IsDefaultOrEmpty && CallingContext is not null)
             {
-                var capturedScopes = CallingContext.CapturePrivateNameScopes();
-                if (!capturedScopes.IsDefaultOrEmpty)
-                {
-                    inheritedPrivateNameScopes = capturedScopes;
-                }
-                else if (CallingContext.CurrentPrivateNameScope is not null)
-                {
-                    inheritedPrivateNameScopes = ImmutableArray.Create(CallingContext.CurrentPrivateNameScope);
-                }
-                var scopeCount = inheritedPrivateNameScopes.HasValue && !inheritedPrivateNameScopes.Value.IsDefaultOrEmpty
-                    ? inheritedPrivateNameScopes.Value.Length
-                    : 0;
                 CallingContext.RealmState.Logger?.LogInformation(
                     "Eval direct: captured {PrivateScopeCount} private scopes (class initializer={InInitializer})",
-                    scopeCount,
+                    evalPrivateNameScopes.Value.Length,
                     insideClassFieldInitializer);
             }
             var result = program.Typed.EvaluateProgram(evalEnvironment, _engine.RealmState, CancellationToken.None,
-                ExecutionKind.Eval, createStrictEnvironment: false, inheritedPrivateNameScopes: inheritedPrivateNameScopes);
+                ExecutionKind.Eval, createStrictEnvironment: false, inheritedPrivateNameScopes: evalPrivateNameScopes);
 
             return result;
         }
@@ -2480,5 +2495,589 @@ public sealed class EvalHostFunction : IJsEnvironmentAwareCallable, IEvaluationC
 
             varEnvironment.DeleteBinding(name);
         }
+    }
+
+    /// <summary>
+    ///     ES2022 AllPrivateNamesValid: Walks the AST and finds the first private name reference
+    ///     that is not declared in any of the available private name scopes.
+    ///     Returns the invalid private name (e.g., "#x") or null if all are valid.
+    /// </summary>
+    private static string? FindInvalidPrivateName(
+        ImmutableArray<StatementNode> statements,
+        ImmutableArray<PrivateNameScope>? availableScopes)
+    {
+        foreach (var statement in statements)
+        {
+            var invalid = FindInvalidPrivateNameInStatement(statement, availableScopes);
+            if (invalid is not null)
+            {
+                return invalid;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? FindInvalidPrivateNameInStatement(
+        StatementNode statement,
+        ImmutableArray<PrivateNameScope>? availableScopes)
+    {
+        while (true)
+        {
+            switch (statement)
+            {
+                case ExpressionStatement expressionStatement:
+                    return FindInvalidPrivateNameInExpression(expressionStatement.Expression, availableScopes);
+
+                case BlockStatement block:
+                    return FindInvalidPrivateName(block.Statements, availableScopes);
+
+                case IfStatement ifStatement:
+                    var thenResult = FindInvalidPrivateNameInStatement(ifStatement.Then, availableScopes);
+                    if (thenResult is not null)
+                    {
+                        return thenResult;
+                    }
+
+                    if (ifStatement.Else is not null)
+                    {
+                        statement = ifStatement.Else;
+                        continue;
+                    }
+
+                    return null;
+
+                case WhileStatement whileStatement:
+                    var whileCondition = FindInvalidPrivateNameInExpression(whileStatement.Condition, availableScopes);
+                    if (whileCondition is not null)
+                    {
+                        return whileCondition;
+                    }
+
+                    statement = whileStatement.Body;
+                    continue;
+
+                case DoWhileStatement doWhileStatement:
+                    var doBody = FindInvalidPrivateNameInStatement(doWhileStatement.Body, availableScopes);
+                    if (doBody is not null)
+                    {
+                        return doBody;
+                    }
+
+                    return FindInvalidPrivateNameInExpression(doWhileStatement.Condition, availableScopes);
+
+                case ForStatement forStatement:
+                    if (forStatement.Initializer is ExpressionStatement initExpr)
+                    {
+                        var initResult = FindInvalidPrivateNameInExpression(initExpr.Expression, availableScopes);
+                        if (initResult is not null)
+                        {
+                            return initResult;
+                        }
+                    }
+                    else if (forStatement.Initializer is VariableDeclaration initVar)
+                    {
+                        var initVarResult = FindInvalidPrivateNameInStatement(initVar, availableScopes);
+                        if (initVarResult is not null)
+                        {
+                            return initVarResult;
+                        }
+                    }
+
+                    if (forStatement.Condition is not null)
+                    {
+                        var condResult = FindInvalidPrivateNameInExpression(forStatement.Condition, availableScopes);
+                        if (condResult is not null)
+                        {
+                            return condResult;
+                        }
+                    }
+
+                    if (forStatement.Increment is not null)
+                    {
+                        var incResult = FindInvalidPrivateNameInExpression(forStatement.Increment, availableScopes);
+                        if (incResult is not null)
+                        {
+                            return incResult;
+                        }
+                    }
+
+                    if (forStatement.Body is not null)
+                    {
+                        statement = forStatement.Body;
+                        continue;
+                    }
+
+                    return null;
+
+                case ForEachStatement forEachStatement:
+                    var iterableResult = FindInvalidPrivateNameInExpression(forEachStatement.Iterable, availableScopes);
+                    if (iterableResult is not null)
+                    {
+                        return iterableResult;
+                    }
+
+                    statement = forEachStatement.Body;
+                    continue;
+
+                case SwitchStatement switchStatement:
+                    var switchExpr = FindInvalidPrivateNameInExpression(switchStatement.Discriminant, availableScopes);
+                    if (switchExpr is not null)
+                    {
+                        return switchExpr;
+                    }
+
+                    foreach (var switchCase in switchStatement.Cases)
+                    {
+                        if (switchCase.Test is not null)
+                        {
+                            var testResult = FindInvalidPrivateNameInExpression(switchCase.Test, availableScopes);
+                            if (testResult is not null)
+                            {
+                                return testResult;
+                            }
+                        }
+
+                        var caseBody = FindInvalidPrivateNameInStatement(switchCase.Body, availableScopes);
+                        if (caseBody is not null)
+                        {
+                            return caseBody;
+                        }
+                    }
+
+                    return null;
+
+                case TryStatement tryStatement:
+                    var tryBody = FindInvalidPrivateNameInStatement(tryStatement.TryBlock, availableScopes);
+                    if (tryBody is not null)
+                    {
+                        return tryBody;
+                    }
+
+                    if (tryStatement.Catch is { Body: not null } catchClause)
+                    {
+                        var catchBody = FindInvalidPrivateNameInStatement(catchClause.Body, availableScopes);
+                        if (catchBody is not null)
+                        {
+                            return catchBody;
+                        }
+                    }
+
+                    if (tryStatement.Finally is not null)
+                    {
+                        statement = tryStatement.Finally;
+                        continue;
+                    }
+
+                    return null;
+
+                case WithStatement withStatement:
+                    var withObj = FindInvalidPrivateNameInExpression(withStatement.Object, availableScopes);
+                    if (withObj is not null)
+                    {
+                        return withObj;
+                    }
+
+                    statement = withStatement.Body;
+                    continue;
+
+                case LabeledStatement labeledStatement:
+                    statement = labeledStatement.Statement;
+                    continue;
+
+                case ReturnStatement returnStatement when returnStatement.Expression is not null:
+                    return FindInvalidPrivateNameInExpression(returnStatement.Expression, availableScopes);
+
+                case ThrowStatement throwStatement:
+                    return FindInvalidPrivateNameInExpression(throwStatement.Expression, availableScopes);
+
+                case VariableDeclaration varDecl:
+                    foreach (var declarator in varDecl.Declarators)
+                    {
+                        if (declarator.Initializer is not null)
+                        {
+                            var initResult = FindInvalidPrivateNameInExpression(declarator.Initializer, availableScopes);
+                            if (initResult is not null)
+                            {
+                                return initResult;
+                            }
+                        }
+                    }
+
+                    return null;
+
+                case FunctionDeclaration functionDeclaration:
+                    // Function bodies create their own scope, but they can still reference
+                    // private names from enclosing classes. We need to check them.
+                    return FindInvalidPrivateNameInFunction(functionDeclaration.Function, availableScopes);
+
+                case ClassDeclaration classDeclaration:
+                    // Class declarations introduce their own private name scope.
+                    // The class body's private names are valid within that scope.
+                    // We don't recurse into class bodies since they define their own scope.
+                    // However, computed property names and heritage clause are evaluated
+                    // in the outer scope and may reference outer private names.
+                    if (classDeclaration.Definition.Extends is not null)
+                    {
+                        var heritage = FindInvalidPrivateNameInExpression(classDeclaration.Definition.Extends, availableScopes);
+                        if (heritage is not null)
+                        {
+                            return heritage;
+                        }
+                    }
+
+                    foreach (var member in classDeclaration.Definition.Members)
+                    {
+                        if (member.IsComputed && member.ComputedName is { } computedKey)
+                        {
+                            var keyResult = FindInvalidPrivateNameInExpression(computedKey, availableScopes);
+                            if (keyResult is not null)
+                            {
+                                return keyResult;
+                            }
+                        }
+                    }
+
+                    return null;
+
+                default:
+                    return null;
+            }
+        }
+    }
+
+    private static string? FindInvalidPrivateNameInExpression(
+        ExpressionNode expression,
+        ImmutableArray<PrivateNameScope>? availableScopes)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case MemberExpression memberExpression:
+                    // Check the target first
+                    var targetResult = FindInvalidPrivateNameInExpression(memberExpression.Target, availableScopes);
+                    if (targetResult is not null)
+                    {
+                        return targetResult;
+                    }
+
+                    // For non-computed member expressions with private names (e.g., this.#x),
+                    // the Property is a LiteralExpression containing the private name string.
+                    if (!memberExpression.IsComputed &&
+                        memberExpression.Property is LiteralExpression { Value: string propName } &&
+                        propName.IsPrivateName())
+                    {
+                        // Check if this private name is valid in available scopes
+                        if (!IsPrivateNameValid(propName, availableScopes))
+                        {
+                            return propName;
+                        }
+
+                        return null;
+                    }
+
+                    // For computed expressions, check the property expression
+                    expression = memberExpression.Property;
+                    continue;
+
+                case PrivateIdentifierExpression privateId:
+                    // Private identifier in 'in' expression (e.g., #field in obj)
+                    var privateName = "#" + privateId.Name;
+                    if (!IsPrivateNameValid(privateName, availableScopes))
+                    {
+                        return privateName;
+                    }
+
+                    return null;
+
+                case BinaryExpression binary:
+                    var leftResult = FindInvalidPrivateNameInExpression(binary.Left, availableScopes);
+                    if (leftResult is not null)
+                    {
+                        return leftResult;
+                    }
+
+                    expression = binary.Right;
+                    continue;
+
+                case UnaryExpression unary:
+                    expression = unary.Operand;
+                    continue;
+
+                case ConditionalExpression conditional:
+                    var testResult = FindInvalidPrivateNameInExpression(conditional.Test, availableScopes);
+                    if (testResult is not null)
+                    {
+                        return testResult;
+                    }
+
+                    var consequent = FindInvalidPrivateNameInExpression(conditional.Consequent, availableScopes);
+                    if (consequent is not null)
+                    {
+                        return consequent;
+                    }
+
+                    expression = conditional.Alternate;
+                    continue;
+
+                case CallExpression call:
+                    var calleeResult = FindInvalidPrivateNameInExpression(call.Callee, availableScopes);
+                    if (calleeResult is not null)
+                    {
+                        return calleeResult;
+                    }
+
+                    foreach (var argument in call.Arguments)
+                    {
+                        var argResult = FindInvalidPrivateNameInExpression(argument.Expression, availableScopes);
+                        if (argResult is not null)
+                        {
+                            return argResult;
+                        }
+                    }
+
+                    return null;
+
+                case NewExpression newExpression:
+                    var ctorResult = FindInvalidPrivateNameInExpression(newExpression.Constructor, availableScopes);
+                    if (ctorResult is not null)
+                    {
+                        return ctorResult;
+                    }
+
+                    foreach (var argument in newExpression.Arguments)
+                    {
+                        var argResult = FindInvalidPrivateNameInExpression(argument.Expression, availableScopes);
+                        if (argResult is not null)
+                        {
+                            return argResult;
+                        }
+                    }
+
+                    return null;
+
+                case AssignmentExpression assignment:
+                    expression = assignment.Value;
+                    continue;
+
+                case PropertyAssignmentExpression propertyAssignment:
+                    var paTarget = FindInvalidPrivateNameInExpression(propertyAssignment.Target, availableScopes);
+                    if (paTarget is not null)
+                    {
+                        return paTarget;
+                    }
+
+                    var paProp = FindInvalidPrivateNameInExpression(propertyAssignment.Property, availableScopes);
+                    if (paProp is not null)
+                    {
+                        return paProp;
+                    }
+
+                    expression = propertyAssignment.Value;
+                    continue;
+
+                case IndexAssignmentExpression indexAssignment:
+                    var iaTarget = FindInvalidPrivateNameInExpression(indexAssignment.Target, availableScopes);
+                    if (iaTarget is not null)
+                    {
+                        return iaTarget;
+                    }
+
+                    var iaIndex = FindInvalidPrivateNameInExpression(indexAssignment.Index, availableScopes);
+                    if (iaIndex is not null)
+                    {
+                        return iaIndex;
+                    }
+
+                    expression = indexAssignment.Value;
+                    continue;
+
+                case SequenceExpression sequence:
+                    var seqLeft = FindInvalidPrivateNameInExpression(sequence.Left, availableScopes);
+                    if (seqLeft is not null)
+                    {
+                        return seqLeft;
+                    }
+
+                    expression = sequence.Right;
+                    continue;
+
+                case DestructuringAssignmentExpression destructuring:
+                    expression = destructuring.Value;
+                    continue;
+
+                case ArrayExpression arrayExpression:
+                    foreach (var element in arrayExpression.Elements)
+                    {
+                        if (element.Expression is not null)
+                        {
+                            var elemResult = FindInvalidPrivateNameInExpression(element.Expression, availableScopes);
+                            if (elemResult is not null)
+                            {
+                                return elemResult;
+                            }
+                        }
+                    }
+
+                    return null;
+
+                case ObjectExpression objectExpression:
+                    foreach (var member in objectExpression.Members)
+                    {
+                        if (member.IsComputed && member.Key is ExpressionNode computedKey)
+                        {
+                            var keyResult = FindInvalidPrivateNameInExpression(computedKey, availableScopes);
+                            if (keyResult is not null)
+                            {
+                                return keyResult;
+                            }
+                        }
+
+                        if (member.Value is not null)
+                        {
+                            var valueResult = FindInvalidPrivateNameInExpression(member.Value, availableScopes);
+                            if (valueResult is not null)
+                            {
+                                return valueResult;
+                            }
+                        }
+
+                        if (member.Function is not null)
+                        {
+                            var funcResult = FindInvalidPrivateNameInFunction(member.Function, availableScopes);
+                            if (funcResult is not null)
+                            {
+                                return funcResult;
+                            }
+                        }
+                    }
+
+                    return null;
+
+                case TemplateLiteralExpression template:
+                    foreach (var part in template.Parts)
+                    {
+                        if (part.Expression is not null)
+                        {
+                            var partResult = FindInvalidPrivateNameInExpression(part.Expression, availableScopes);
+                            if (partResult is not null)
+                            {
+                                return partResult;
+                            }
+                        }
+                    }
+
+                    return null;
+
+                case TaggedTemplateExpression tagged:
+                    var tagResult = FindInvalidPrivateNameInExpression(tagged.Tag, availableScopes);
+                    if (tagResult is not null)
+                    {
+                        return tagResult;
+                    }
+
+                    foreach (var expr in tagged.Expressions)
+                    {
+                        var exprResult = FindInvalidPrivateNameInExpression(expr, availableScopes);
+                        if (exprResult is not null)
+                        {
+                            return exprResult;
+                        }
+                    }
+
+                    return null;
+
+                case YieldExpression yieldExpression when yieldExpression.Expression is not null:
+                    expression = yieldExpression.Expression;
+                    continue;
+
+                case AwaitExpression awaitExpression:
+                    expression = awaitExpression.Expression;
+                    continue;
+
+                case FunctionExpression functionExpression:
+                    return FindInvalidPrivateNameInFunction(functionExpression, availableScopes);
+
+                case ClassExpression classExpression:
+                    // Similar to ClassDeclaration - check heritage and computed keys
+                    if (classExpression.Definition.Extends is not null)
+                    {
+                        var heritage = FindInvalidPrivateNameInExpression(classExpression.Definition.Extends, availableScopes);
+                        if (heritage is not null)
+                        {
+                            return heritage;
+                        }
+                    }
+
+                    foreach (var member in classExpression.Definition.Members)
+                    {
+                        if (member.IsComputed && member.ComputedName is { } computedKey)
+                        {
+                            var keyResult = FindInvalidPrivateNameInExpression(computedKey, availableScopes);
+                            if (keyResult is not null)
+                            {
+                                return keyResult;
+                            }
+                        }
+                    }
+
+                    return null;
+
+                case LiteralExpression:
+                case IdentifierExpression:
+                case ThisExpression:
+                case SuperExpression:
+                case NewTargetExpression:
+                    return null;
+
+                default:
+                    return null;
+            }
+        }
+    }
+
+    private static string? FindInvalidPrivateNameInFunction(
+        FunctionExpression function,
+        ImmutableArray<PrivateNameScope>? availableScopes)
+    {
+        // Check parameter default values
+        foreach (var param in function.Parameters)
+        {
+            if (param.DefaultValue is not null)
+            {
+                var defaultResult = FindInvalidPrivateNameInExpression(param.DefaultValue, availableScopes);
+                if (defaultResult is not null)
+                {
+                    return defaultResult;
+                }
+            }
+        }
+
+        // Function bodies can reference outer private names
+        return FindInvalidPrivateName(function.Body.Statements, availableScopes);
+    }
+
+    private static bool IsPrivateNameValid(
+        string privateName,
+        ImmutableArray<PrivateNameScope>? availableScopes)
+    {
+        if (!availableScopes.HasValue || availableScopes.Value.IsDefaultOrEmpty)
+        {
+            // No private name scopes available, so any private name is invalid
+            return false;
+        }
+
+        // Check if the private name (without #) exists in any scope
+        var lexeme = privateName.StartsWith('#') ? privateName[1..] : privateName;
+        foreach (var scope in availableScopes.Value)
+        {
+            if (scope.TryGetKey(lexeme, out _))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

- Implements the ES2022 static semantic check `AllPrivateNamesValid` for eval code
- Any private name reference in eval code (`this.#x`, `#field in obj`) must be declared in an enclosing class scope
- For direct eval inside a class, private names from the enclosing class context are available
- For indirect eval or direct eval outside any class, no private names are available
- Invalid private name references now throw `SyntaxError` during early error checking, not `TypeError` at runtime

## Test plan

- [x] All 16 Test262 test cases now pass:
  - `privatename-not-valid-eval-earlyerr-1.js` through `-8.js`
  - Both strict and sloppy mode variants
- [x] Build succeeds with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds static validation of private names in eval (direct uses enclosing class scopes) with early SyntaxError and passes captured private scopes to evaluation.
> 
> - **Eval semantics (`src/Asynkron.JsEngine/EvalHostFunction.cs`)**:
>   - Implement ES2022 `AllPrivateNamesValid` for eval:
>     - Capture available private name scopes for direct eval from `CallingContext`.
>     - Validate AST to find first invalid private name reference (e.g., `this.#x`, `#field in obj`); throw `SyntaxError` early.
>   - Propagate captured scopes to `EvaluateProgram` via `inheritedPrivateNameScopes` and log captured scope count.
> - **AST utilities**:
>   - Add walkers `FindInvalidPrivateName*` and `IsPrivateNameValid` covering statements/expressions/functions, including class heritage and computed keys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a4c2e65a461405703bbdcf04f1ab67fe87cc6d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->