### PR TITLE
Fix yield expression tests for template literals, with statements, and iterator protocol

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.DelegatedYieldState.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.DelegatedYieldState.cs
@@ -119,66 +119,66 @@ public static partial class TypedAstEvaluator
                         // Use Symbol.Undefined for null sendValue to match JavaScript undefined semantics.
                         candidate = _iterator.InvokeIteratorNext(_nextMethod, sendValue ?? Symbol.Undefined, true, context);
                     }
+
+                    // Per spec: if return method is undefined, return Completion(received)
+                    // This means we should signal immediate completion to the outer generator
+                    if (propagateReturn && !methodInvoked)
+                    {
+                        // Inner iterator has no return method - signal delegated completion
+                        // The outer generator should complete with the received value
+                        return (sendValue, true, true, false, null);
+                    }
+
+                    // Per spec: if throw method is null/undefined, call IteratorClose and throw TypeError
+                    if (propagateThrow && !methodInvoked)
+                    {
+                        // Call IteratorClose before throwing - this calls the return method if it exists
+                        _iterator.IteratorClose(context, preserveExistingThrow: false);
+
+                        // Throw TypeError as per spec - this will be caught below and returned as delegated completion
+                        throw StandardLibrary.ThrowTypeError(
+                            "The iterator does not provide a 'throw' method.",
+                            context,
+                            context.RealmState);
+                    }
+
+                    if (!methodInvoked && candidate is null)
+                    {
+                        return (Symbol.Undefined, true, propagateThrow, propagateThrow, null);
+                    }
+
+                    if (methodInvoked && candidate is null)
+                    {
+                        throw StandardLibrary.ThrowTypeError("Iterator result is not an object.", context);
+                    }
+
+                    var nextCandidate = candidate ?? throw new InvalidOperationException("Iterator result missing.");
+                    object? awaitedCandidate;
+                    if (nextCandidate is IJsObjectLike promiseCandidate && IsPromiseLike(promiseCandidate))
+                    {
+                        awaitedPromise = true;
+                        if (!AwaitScheduler.TryAwaitPromiseSync(promiseCandidate, context, out awaitedCandidate))
+                        {
+                            return (Symbol.Undefined, true, true, propagateThrow, null);
+                        }
+                    }
+                    else
+                    {
+                        awaitedCandidate = nextCandidate;
+                    }
+
+                    if (awaitedCandidate is not IJsObjectLike resolvedObject)
+                    {
+                        throw StandardLibrary.ThrowTypeError("Iterator result is not an object.", context);
+                    }
+
+                    nextResult = resolvedObject;
                 }
                 catch (ThrowSignal signal)
                 {
                     // Convert ThrowSignal to delegated completion so generator's try/catch can handle it
                     return (signal.ThrownValue, true, true, true, null);
                 }
-
-                // Per spec: if return method is undefined, return Completion(received)
-                // This means we should signal immediate completion to the outer generator
-                if (propagateReturn && !methodInvoked)
-                {
-                    // Inner iterator has no return method - signal delegated completion
-                    // The outer generator should complete with the received value
-                    return (sendValue, true, true, false, null);
-                }
-
-                // Per spec: if throw method is null/undefined, call IteratorClose and throw TypeError
-                if (propagateThrow && !methodInvoked)
-                {
-                    // Call IteratorClose before throwing - this calls the return method if it exists
-                    _iterator.IteratorClose(context, preserveExistingThrow: false);
-
-                    // Throw TypeError as per spec
-                    throw StandardLibrary.ThrowTypeError(
-                        "The iterator does not provide a 'throw' method.",
-                        context,
-                        context.RealmState);
-                }
-
-                if (!methodInvoked && candidate is null)
-                {
-                    return (Symbol.Undefined, true, propagateThrow, propagateThrow, null);
-                }
-
-                if (methodInvoked && candidate is null)
-                {
-                    throw StandardLibrary.ThrowTypeError("Iterator result is not an object.", context);
-                }
-
-                var nextCandidate = candidate ?? throw new InvalidOperationException("Iterator result missing.");
-                object? awaitedCandidate;
-                if (nextCandidate is IJsObjectLike promiseCandidate && IsPromiseLike(promiseCandidate))
-                {
-                    awaitedPromise = true;
-                    if (!AwaitScheduler.TryAwaitPromiseSync(promiseCandidate, context, out awaitedCandidate))
-                    {
-                        return (Symbol.Undefined, true, true, propagateThrow, null);
-                    }
-                }
-                else
-                {
-                    awaitedCandidate = nextCandidate;
-                }
-
-                if (awaitedCandidate is not IJsObjectLike resolvedObject)
-                {
-                    throw StandardLibrary.ThrowTypeError("Iterator result is not an object.", context);
-                }
-
-                nextResult = resolvedObject;
 
                 // Use JsOps for context-aware property access to propagate getter errors
                 var gotDone = JsOps.TryGetPropertyValue(nextResult, "done", out var doneValue, context);

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.TypedGeneratorInstance.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.TypedGeneratorInstance.cs
@@ -28,6 +28,8 @@ public static partial class TypedAstEvaluator
         private readonly HashSet<int> _consumedYieldIndices = new();
         private readonly object? _thisValue;
         private readonly Stack<TryFrame> _tryStack = new();
+        // Track active with-scope slots for restoration after yield/resume
+        private readonly Stack<Symbol> _activeWithScopes = new();
         private HashSet<Symbol>? _blockedFunctionVarNames;
         private bool _asyncStepMode;
         private EvaluationContext? _context;
@@ -389,6 +391,24 @@ public static partial class TypedAstEvaluator
             var context = EnsureEvaluationContext();
             StoreSymbolValue(environment, Symbol.YieldTrackerSymbol, new YieldTracker(_consumedYieldIndices));
 
+            // Restore active with-scopes when resuming
+            // The _activeWithScopes stack contains the slots in reverse order (bottom to top)
+            // We need to restore environments from bottom to top
+            if (_activeWithScopes.Count > 0)
+            {
+                var scopesToRestore = _activeWithScopes.ToArray();
+                // The array is in stack order (top first), so reverse to get bottom-to-top order
+                for (var i = scopesToRestore.Length - 1; i >= 0; i--)
+                {
+                    var slot = scopesToRestore[i];
+                    if (TryGetSymbolValue(environment, slot, out var storedEnvObj) &&
+                        storedEnvObj is JsEnvironment storedWithEnv)
+                    {
+                        environment = storedWithEnv;
+                    }
+                }
+            }
+
             // If we are resuming after a pending await, thread the resolved
             // value into the per-site await state so subsequent evaluations
             // of the AwaitExpression see the fulfilled value instead of the
@@ -667,19 +687,12 @@ public static partial class TypedAstEvaluator
 
                                 if (iteratorResult.IsDelegatedCompletion)
                                 {
-                                    var pendingKind = propagateThrow ? AbruptKind.Throw : AbruptKind.Return;
-                                    object? abruptValue;
-                                    if (pendingKind == AbruptKind.Throw && context.IsThrow)
-                                    {
-                                        abruptValue = context.FlowValue;
-                                        context.Clear();
-                                    }
-                                    else
-                                    {
-                                        abruptValue = pendingKind == AbruptKind.Throw
-                                            ? sendValue
-                                            : iteratorResult.Value;
-                                    }
+                                    // Check PropagateThrow from the result - this is true when MoveNext itself threw
+                                    // (e.g., iterator.next() returned non-object), not just when we called throw()
+                                    var isThrowCompletion = propagateThrow || iteratorResult.PropagateThrow;
+                                    var pendingKind = isThrowCompletion ? AbruptKind.Throw : AbruptKind.Return;
+                                    // The thrown/returned value is in iteratorResult.Value
+                                    var abruptValue = iteratorResult.Value;
 
                                     if (!iteratorResult.Done)
                                     {
@@ -1194,6 +1207,61 @@ public static partial class TypedAstEvaluator
                             _done = true;
                             _tryStack.Clear();
                             return CreateIteratorResult(returnValue, true);
+
+                        case EnterWithInstruction enterWithInstruction:
+                        {
+                            var objValue = EvaluateExpression(enterWithInstruction.ObjectExpression, environment, context);
+                            if (context.IsThrow)
+                            {
+                                var thrownWith = context.FlowValue;
+                                context.Clear();
+                                if (HandleAbruptCompletion(AbruptKind.Throw, thrownWith, environment))
+                                {
+                                    continue;
+                                }
+
+                                _tryStack.Clear();
+                                throw new ThrowSignal(thrownWith);
+                            }
+
+                            // Create the with-environment and store it in the slot
+                            if (TryConvertToWithBindingObject(objValue, context, out var withObject))
+                            {
+                                var withEnv = new JsEnvironment(environment, false, context.CurrentScope.IsStrict,
+                                    enterWithInstruction.ObjectExpression.Source, "with", withObject);
+                                // Store the with-environment in the root environment slot so it persists across yields
+                                StoreSymbolValue(_executionEnvironment!, enterWithInstruction.WithScopeSlot, withEnv);
+                                // Track this with-scope as active
+                                _activeWithScopes.Push(enterWithInstruction.WithScopeSlot);
+                                // Update the local environment reference to use the with-environment
+                                environment = withEnv;
+                            }
+                            // If we couldn't create a with-environment, just continue with the same environment
+
+                            _programCounter = enterWithInstruction.Next;
+                            continue;
+                        }
+
+                        case LeaveWithInstruction leaveWithInstruction:
+                        {
+                            // Remove this with-scope from active tracking
+                            if (_activeWithScopes.Count > 0 &&
+                                ReferenceEquals(_activeWithScopes.Peek(), leaveWithInstruction.WithScopeSlot))
+                            {
+                                _activeWithScopes.Pop();
+                            }
+
+                            // Restore the previous environment by getting it from the enclosing scope of the stored with-env
+                            if (TryGetSymbolValue(_executionEnvironment!, leaveWithInstruction.WithScopeSlot, out var storedEnvObj) &&
+                                storedEnvObj is JsEnvironment storedWithEnv)
+                            {
+                                // The with-environment's Enclosing is the original environment
+                                environment = storedWithEnv.Enclosing ?? environment;
+                            }
+
+                            _programCounter = leaveWithInstruction.Next;
+                            continue;
+                        }
 
                         default:
                             throw new InvalidOperationException(

--- a/src/Asynkron.JsEngine/Execution/GeneratorIr.cs
+++ b/src/Asynkron.JsEngine/Execution/GeneratorIr.cs
@@ -107,3 +107,21 @@ internal sealed record IteratorMoveNextInstruction(
     int BreakIndex,
     int Next)
     : GeneratorInstruction(Next);
+
+/// <summary>
+///     Marks the beginning of a <c>with</c> statement. Evaluates the object expression
+///     and pushes a with-environment onto the scope chain.
+/// </summary>
+internal sealed record EnterWithInstruction(
+    ExpressionNode ObjectExpression,
+    Symbol WithScopeSlot,
+    int Next)
+    : GeneratorInstruction(Next);
+
+/// <summary>
+///     Marks the end of a <c>with</c> statement. Pops the with-environment from the scope chain.
+/// </summary>
+internal sealed record LeaveWithInstruction(
+    Symbol WithScopeSlot,
+    int Next)
+    : GeneratorInstruction(Next);

--- a/src/Asynkron.JsEngine/Execution/SyncGeneratorIrBuilder.cs
+++ b/src/Asynkron.JsEngine/Execution/SyncGeneratorIrBuilder.cs
@@ -19,12 +19,14 @@ internal sealed class SyncGeneratorIrBuilder
     private const string ResumeSlotPrefix = "\u0001_resume";
     private const string CatchSlotPrefix = "\u0001_catch";
     private const string YieldStarStatePrefix = "\u0001_yieldstar";
+    private const string WithScopeSlotPrefix = "\u0001_with";
     private readonly List<GeneratorInstruction> _instructions = [];
     private readonly Stack<LoopScope> _loopScopes = new();
     private int _catchSlotCounter;
     private string? _failureReason;
     private int _resumeSlotCounter;
     private int _yieldStarStateCounter;
+    private int _withScopeSlotCounter;
 
     private SyncGeneratorIrBuilder()
     {
@@ -318,14 +320,21 @@ internal sealed class SyncGeneratorIrBuilder
                     return TryBuildContinue(continueStatement, out entryIndex);
 
                 case WithStatement withStatement:
-                    if (AstShapeAnalyzer.ContainsYield(withStatement.Object) ||
-                        AstShapeAnalyzer.StatementContainsYield(withStatement.Body))
+                    // Yield is not allowed in the object expression
+                    if (AstShapeAnalyzer.ContainsYield(withStatement.Object))
                     {
                         entryIndex = -1;
-                        _failureReason ??= "With statement contains unsupported yield shape.";
+                        _failureReason ??= "With statement object expression contains unsupported yield shape.";
                         return false;
                     }
 
+                    // If the body contains yield, we need to use EnterWith/LeaveWith instructions
+                    if (AstShapeAnalyzer.StatementContainsYield(withStatement.Body))
+                    {
+                        return TryBuildWithStatement(withStatement, nextIndex, out entryIndex, activeLabel);
+                    }
+
+                    // If no yield in body, emit as a simple statement instruction
                     entryIndex = Append(new StatementInstruction(nextIndex, withStatement));
                     return true;
 
@@ -932,6 +941,33 @@ internal sealed class SyncGeneratorIrBuilder
     {
         var symbolName = $"{YieldStarStatePrefix}{_yieldStarStateCounter++}";
         return Symbol.Intern(symbolName);
+    }
+
+    private Symbol CreateWithScopeSlotSymbol()
+    {
+        var symbolName = $"{WithScopeSlotPrefix}{_withScopeSlotCounter++}";
+        return Symbol.Intern(symbolName);
+    }
+
+    private bool TryBuildWithStatement(WithStatement statement, int nextIndex, out int entryIndex, Symbol? activeLabel)
+    {
+        var instructionStart = _instructions.Count;
+        var withScopeSlot = CreateWithScopeSlotSymbol();
+
+        // Build the leave with instruction first (it comes after the body)
+        var leaveWithIndex = Append(new LeaveWithInstruction(withScopeSlot, nextIndex));
+
+        // Build the body (jumps to the leave with instruction when done)
+        if (!TryBuildStatement(statement.Body, leaveWithIndex, out var bodyEntry, activeLabel))
+        {
+            _instructions.RemoveRange(instructionStart, _instructions.Count - instructionStart);
+            entryIndex = -1;
+            return false;
+        }
+
+        // Build the enter with instruction (comes before the body)
+        entryIndex = Append(new EnterWithInstruction(statement.Object, withScopeSlot, bodyEntry));
+        return true;
     }
 
     private static bool IsStrictBlock(StatementNode statement)

--- a/src/Asynkron.JsEngine/Parser/TypedAstParser.cs
+++ b/src/Asynkron.JsEngine/Parser/TypedAstParser.cs
@@ -2981,7 +2981,17 @@ public sealed class TypedAstParser(
             var wrappedSource = $"({trimmed});";
             var lexer = new Lexer(wrappedSource);
             var tokens = lexer.Tokenize();
-            var embeddedParser = new TypedAstParser(tokens, wrappedSource, options: _options);
+
+            // Create a new DirectParser directly to preserve the current function context (generator/async).
+            // This allows yield/await to be recognized inside template interpolations within generators/async functions.
+            var embeddedParser = new DirectParser(tokens, wrappedSource, InStrictContext, _allowTopLevelAwait, _options);
+
+            // Propagate the current function context to the embedded parser
+            if (InGeneratorContext || InAsyncContext)
+            {
+                embeddedParser._functionContexts.Push(new FunctionContext(InAsyncContext, InGeneratorContext));
+            }
+
             var program = embeddedParser.ParseProgram();
             if (program.Body.Length == 0 || program.Body[0] is not ExpressionStatement expressionStatement)
             {


### PR DESCRIPTION
## Summary
- Fix 23 of 31 failing Test262 yield expression tests
- Add support for `yield` in template literal interpolations
- Add support for `yield` in `with` statement bodies (generators)
- Improve iterator protocol error handling in `yield*` delegation

## Test plan
- [x] All 23 targeted tests now pass
- [x] Build succeeds with no errors
- [x] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)