### PR TITLE
Fix failing variable statement tests

### DIFF
--- a/src/Asynkron.JsEngine/Ast/VariableKindExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/VariableKindExtensions.cs
@@ -1,5 +1,6 @@
 namespace Asynkron.JsEngine.Ast;
 
+using Asynkron.JsEngine.JsTypes;
 using Microsoft.Extensions.Logging;
 
 public static partial class TypedAstEvaluator
@@ -17,6 +18,16 @@ public static partial class TypedAstEvaluator
                                          IsAnonymousFunctionDefinitionNode(declarator.Initializer)
                 ? context.EnterFunctionNameHint(targetIdentifier.Name)
                 : null;
+
+            // Per ES spec 14.3.2.1: For var declarations, ResolveBinding happens BEFORE
+            // evaluating the initializer. This is important for with statements where
+            // the initializer might modify the with object (e.g., delete a property).
+            // We pre-resolve the binding target to capture any with object reference.
+            IJsObjectLike? preResolvedWithTarget = null;
+            if (kind == VariableKind.Var && targetIdentifier is not null && declarator.Initializer is not null)
+            {
+                preResolvedWithTarget = environment.ResolveVarBindingWithTarget(targetIdentifier.Name);
+            }
 
             var value = declarator.Initializer is null
                 ? Symbol.Undefined
@@ -44,6 +55,15 @@ public static partial class TypedAstEvaluator
                     environment.Depth,
                     environment.IsStrict,
                     value);
+            }
+
+            // If we pre-resolved a with target for a var declaration, use it directly.
+            // This ensures the binding goes to the with object even if the initializer
+            // modified it (e.g., deleted the property).
+            if (preResolvedWithTarget is not null && targetIdentifier is not null)
+            {
+                environment.AssignToWithTarget(preResolvedWithTarget, targetIdentifier.Name, value);
+                return;
             }
 
             // Per ES spec 13.3.1.4: Name inference only applies if IsAnonymousFunctionDefinition(Initializer) is true

--- a/src/Asynkron.JsEngine/JsEnvironment.cs
+++ b/src/Asynkron.JsEngine/JsEnvironment.cs
@@ -551,6 +551,50 @@ public sealed class JsEnvironment
         return _values.TryGetValue(name, out var binding) && binding.IsLexical;
     }
 
+    /// <summary>
+    /// Pre-resolves a var binding to determine if it should be assigned to a with object.
+    /// This is called BEFORE evaluating the initializer to capture the binding target per ES spec.
+    /// Returns the with object if the binding resolves to it, or null if it resolves elsewhere.
+    /// </summary>
+    internal IJsObjectLike? ResolveVarBindingWithTarget(Symbol name)
+    {
+        var current = this;
+        while (current is not null)
+        {
+            // Check if there's a lexical binding that blocks the var
+            if (current._values.TryGetValue(name, out var binding) && binding.IsLexical)
+            {
+                return null;
+            }
+
+            // Check if there's a with object with this property
+            if (current._withObject is not null && HasVisibleWithBinding(current._withObject, name))
+            {
+                return current._withObject;
+            }
+
+            current = current.Enclosing;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Assigns a value to a pre-resolved with object binding.
+    /// </summary>
+    internal void AssignToWithTarget(IJsObjectLike withTarget, Symbol name, object? value)
+    {
+        if (withTarget is JsObject jsWithObject)
+        {
+            AssignmentReferenceResolver.AssignObjectProperty(jsWithObject, name.Name, value, IsStrict, null,
+                RealmState);
+        }
+        else
+        {
+            withTarget.SetProperty(name.Name, value);
+        }
+    }
+
     internal bool TryAssignBlockedBinding(Symbol name, object? value)
     {
         var current = this;

--- a/src/Asynkron.JsEngine/JsTypes/JsObject.cs
+++ b/src/Asynkron.JsEngine/JsTypes/JsObject.cs
@@ -78,6 +78,17 @@ namespace Asynkron.JsEngine.JsTypes;
     public void SetPrototype(object? candidate)
     {
         var previous = _prototypeAccessor ?? Prototype;
+
+        // Per ES spec 9.1.2.1: If the object is not extensible and the new prototype
+        // is different from the current prototype, the operation should fail.
+        // We silently return without changing (caller can check strict mode for throwing).
+        if (!IsExtensible && !ReferenceEquals(previous, candidate) &&
+            !ReferenceEquals(previous, candidate as IJsPropertyAccessor) &&
+            !ReferenceEquals(previous, candidate as JsObject))
+        {
+            return;
+        }
+
         _prototypeAccessor = candidate as IJsPropertyAccessor;
         Prototype = candidate as JsObject;
 

--- a/src/Asynkron.JsEngine/Parser/TypedAstParser.cs
+++ b/src/Asynkron.JsEngine/Parser/TypedAstParser.cs
@@ -4091,7 +4091,19 @@ public sealed class TypedAstParser(
         {
             if (CheckIdentifierLike())
             {
-                return Advance();
+                var token = Advance();
+
+                // In strict mode, 'eval' and 'arguments' cannot be used as parameter identifiers
+                if (InStrictContext &&
+                    (string.Equals(token.Lexeme, "eval", StringComparison.Ordinal) ||
+                     string.Equals(token.Lexeme, "arguments", StringComparison.Ordinal)))
+                {
+                    throw new ParseException(
+                        $"'{token.Lexeme}' cannot be used as a parameter identifier in strict mode.",
+                        token, _source);
+                }
+
+                return token;
             }
 
             throw new ParseException(message, Peek(), _source);
@@ -4104,6 +4116,7 @@ public sealed class TypedAstParser(
 
         private Token ConsumeBindingIdentifier(string message)
         {
+            // ConsumeParameterIdentifier already handles strict mode checks for 'eval' and 'arguments'
             return ConsumeParameterIdentifier(message);
         }
 

--- a/src/Asynkron.JsEngine/StdLib/StandardLibrary.Number.cs
+++ b/src/Asynkron.JsEngine/StdLib/StandardLibrary.Number.cs
@@ -520,17 +520,23 @@ public static partial class StandardLibrary
                 false);
         }
 
-        numberConstructor.SetHostedProperty("isInteger", NumberIsInteger);
+        DefineBuiltinFunction(numberConstructor.PropertiesObject, "isInteger",
+            new HostFunction(NumberIsInteger), 1);
 
-        numberConstructor.SetHostedProperty("isFinite", NumberIsFinite);
+        DefineBuiltinFunction(numberConstructor.PropertiesObject, "isFinite",
+            new HostFunction(NumberIsFinite), 1);
 
-        numberConstructor.SetHostedProperty("isNaN", NumberIsNaN);
+        DefineBuiltinFunction(numberConstructor.PropertiesObject, "isNaN",
+            new HostFunction(NumberIsNaN), 1);
 
-        numberConstructor.SetHostedProperty("isSafeInteger", NumberIsSafeInteger);
+        DefineBuiltinFunction(numberConstructor.PropertiesObject, "isSafeInteger",
+            new HostFunction(NumberIsSafeInteger), 1);
 
-        numberConstructor.SetHostedProperty("parseFloat", NumberParseFloat);
+        DefineBuiltinFunction(numberConstructor.PropertiesObject, "parseFloat",
+            new HostFunction(NumberParseFloat), 1);
 
-        numberConstructor.SetHostedProperty("parseInt", NumberParseInt);
+        DefineBuiltinFunction(numberConstructor.PropertiesObject, "parseInt",
+            new HostFunction(NumberParseInt), 2);
 
         DefineConstantProperty(numberConstructor, "EPSILON", double.Epsilon);
 


### PR DESCRIPTION
- Add strict mode check for 'eval' and 'arguments' as binding identifiers in TypedAstParser (fixes 12.2.1-18-s, 12.2.1-22-s, 12.2.1-3-s, 12.2.1-7-s)

- Pre-resolve var binding targets before evaluating initializers to ensure correct with statement semantics (fixes binding-resolution.js test)

- Make Number static methods non-enumerable by using DefineBuiltinFunction instead of SetHostedProperty (fixes S8.6.1_A2)

- Prevent prototype changes on non-extensible objects in JsObject.SetPrototype per ES spec 9.1.2.1 (fixes S8.6.2_A8)