### PR TITLE
Fix for-in enumeration to follow ECMAScript spec

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.cs
@@ -192,9 +192,57 @@ public static partial class TypedAstEvaluator
 
             case JsArray array:
             {
+                // First, enumerate numeric indices (array elements)
                 for (var i = 0; i < array.Items.Count; i++)
                 {
                     yield return i.ToString(CultureInfo.InvariantCulture);
+                }
+
+                // Track seen keys to properly handle shadowing
+                var seenArrayKeys = new HashSet<string>(StringComparer.Ordinal);
+
+                // Add all numeric indices as seen (already enumerated above)
+                for (var i = 0; i < array.Items.Count; i++)
+                {
+                    seenArrayKeys.Add(i.ToString(CultureInfo.InvariantCulture));
+                }
+
+                // Now enumerate non-index properties on the array and its prototype chain
+                IJsPropertyAccessor? currentArray = array;
+                while (currentArray is not null)
+                {
+                    var keys = currentArray.GetOwnPropertyNames().ToList();
+
+                    foreach (var key in keys)
+                    {
+                        // Skip if we've already seen this key
+                        if (!seenArrayKeys.Add(key))
+                        {
+                            continue;
+                        }
+
+                        // Skip 'length' - it's not enumerable
+                        if (string.Equals(key, "length", StringComparison.Ordinal))
+                        {
+                            continue;
+                        }
+
+                        var desc = currentArray.GetOwnPropertyDescriptor(key);
+                        if (desc is null || desc is { Enumerable: false })
+                        {
+                            continue;
+                        }
+
+                        yield return key;
+                    }
+
+                    // Move to prototype
+                    currentArray = currentArray switch
+                    {
+                        IJsObjectLike objectLike => objectLike.Prototype,
+                        IPrototypeAccessorProvider provider => provider.PrototypeAccessor,
+                        _ => null
+                    };
                 }
 
                 yield break;
@@ -212,15 +260,49 @@ public static partial class TypedAstEvaluator
 
             case IJsObjectLike accessor:
             {
-                foreach (var key in accessor.GetOwnPropertyNames())
+                // Track seen keys to properly handle shadowing - prototype properties
+                // with the same name as own properties should not be enumerated
+                var seenKeys = new HashSet<string>(StringComparer.Ordinal);
+
+                // Walk prototype chain, starting with the object itself
+                IJsPropertyAccessor? current = accessor;
+                while (current is not null)
                 {
-                    var desc = accessor.GetOwnPropertyDescriptor(key);
-                    if (desc is { Enumerable: false })
+                    // Collect keys from this object in the chain - we snapshot to avoid
+                    // concurrent modification issues during iteration
+                    var keys = current.GetOwnPropertyNames().ToList();
+
+                    foreach (var key in keys)
                     {
-                        continue;
+                        // Skip if we've already seen this key (shadowed by own/earlier property)
+                        if (!seenKeys.Add(key))
+                        {
+                            continue;
+                        }
+
+                        // Per ECMAScript spec, skip properties that were deleted during enumeration.
+                        // Check that the property still exists on this object in the chain.
+                        var desc = current.GetOwnPropertyDescriptor(key);
+                        if (desc is null)
+                        {
+                            // Property was deleted since we collected the keys
+                            continue;
+                        }
+                        if (desc is { Enumerable: false })
+                        {
+                            continue;
+                        }
+
+                        yield return key;
                     }
 
-                    yield return key;
+                    // Move to prototype
+                    current = current switch
+                    {
+                        IJsObjectLike objectLike => objectLike.Prototype,
+                        IPrototypeAccessorProvider provider => provider.PrototypeAccessor,
+                        _ => null
+                    };
                 }
 
                 yield break;

--- a/src/Asynkron.JsEngine/StdLib/StandardLibrary.Object.cs
+++ b/src/Asynkron.JsEngine/StdLib/StandardLibrary.Object.cs
@@ -207,23 +207,75 @@ public static partial class StandardLibrary
                 realm.ErrorPrototype.SetPrototype(objectProtoObj);
             }
 
-            // Object.prototype.toString
-            objectProtoObj.SetHostedProperty("toString", ObjectPrototypeToString);
+            // Object.prototype.toString - must be non-enumerable per ES spec
+            objectProtoObj.DefineProperty("toString",
+                new PropertyDescriptor
+                {
+                    Value = new HostFunction(ObjectPrototypeToString),
+                    Writable = true,
+                    Enumerable = false,
+                    Configurable = true
+                });
 
-            // Object.prototype.valueOf
-            objectProtoObj.SetHostedProperty("valueOf", ObjectPrototypeValueOf);
+            // Object.prototype.valueOf - must be non-enumerable per ES spec
+            objectProtoObj.DefineProperty("valueOf",
+                new PropertyDescriptor
+                {
+                    Value = new HostFunction(ObjectPrototypeValueOf),
+                    Writable = true,
+                    Enumerable = false,
+                    Configurable = true
+                });
 
             var hasOwn = new HostFunction(ObjectPrototypeHasOwnProperty);
 
-            objectProtoObj.SetProperty("hasOwnProperty", hasOwn);
+            // Object.prototype.hasOwnProperty - must be non-enumerable per ES spec
+            objectProtoObj.DefineProperty("hasOwnProperty",
+                new PropertyDescriptor
+                {
+                    Value = hasOwn,
+                    Writable = true,
+                    Enumerable = false,
+                    Configurable = true
+                });
 
-            // Object.prototype.propertyIsEnumerable
-            objectProtoObj.SetHostedProperty("propertyIsEnumerable", ObjectPrototypePropertyIsEnumerable);
+            // Object.prototype.propertyIsEnumerable - must be non-enumerable per ES spec
+            objectProtoObj.DefineProperty("propertyIsEnumerable",
+                new PropertyDescriptor
+                {
+                    Value = new HostFunction(ObjectPrototypePropertyIsEnumerable),
+                    Writable = true,
+                    Enumerable = false,
+                    Configurable = true
+                });
 
-            // Object.prototype.isPrototypeOf
-            objectProtoObj.SetHostedProperty("isPrototypeOf", ObjectPrototypeIsPrototypeOf);
-            objectProtoObj.SetHostedProperty("__lookupGetter__", ObjectPrototypeLookupGetter);
-            objectProtoObj.SetHostedProperty("__lookupSetter__", ObjectPrototypeLookupSetter);
+            // Object.prototype.isPrototypeOf - must be non-enumerable per ES spec
+            objectProtoObj.DefineProperty("isPrototypeOf",
+                new PropertyDescriptor
+                {
+                    Value = new HostFunction(ObjectPrototypeIsPrototypeOf),
+                    Writable = true,
+                    Enumerable = false,
+                    Configurable = true
+                });
+
+            // __lookupGetter__ and __lookupSetter__ - must be non-enumerable per ES spec
+            objectProtoObj.DefineProperty("__lookupGetter__",
+                new PropertyDescriptor
+                {
+                    Value = new HostFunction(ObjectPrototypeLookupGetter),
+                    Writable = true,
+                    Enumerable = false,
+                    Configurable = true
+                });
+            objectProtoObj.DefineProperty("__lookupSetter__",
+                new PropertyDescriptor
+                {
+                    Value = new HostFunction(ObjectPrototypeLookupSetter),
+                    Writable = true,
+                    Enumerable = false,
+                    Configurable = true
+                });
 
             var protoGetter = new HostFunction(ObjectPrototypeGetProto, realm, isConstructor: false);
             protoGetter.TryDefineProperty("name", new PropertyDescriptor


### PR DESCRIPTION
## Summary
- Walk prototype chain for property enumeration, handling shadowing correctly (own properties shadow prototype properties with the same name)
- Mark Object.prototype methods as non-enumerable per ES spec (toString, valueOf, hasOwnProperty, etc.)
- Handle deleted properties during enumeration (properties deleted during iteration are skipped)
- Fix JsArray to enumerate named string properties, not just numeric indices

## Test262 Tests Fixed
- `S12.6.4_A6.1.js` - prototype property shadowing
- `S12.6.4_A6.js` - prototype property shadowing  
- `S12.6.4_A7_T2.js` - deleted properties during enumeration
- `order-property-on-prototype.js` - prototype chain enumeration
- `order-after-define-property.js` - array named property enumeration

## Test plan
- [x] All originally failing for-in tests pass (10 of 11 - `head-lhs-let.js` is a separate parser issue)
- [x] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)