### PR TITLE
Handle proxy semantics in object rest destructuring

### DIFF
--- a/continue.md
+++ b/continue.md
@@ -24,6 +24,7 @@
 - Array index assignments now walk prototype accessors/writable descriptors (including inherited setters) before falling back to element storage, so member-expression for-in targets trigger Array.prototype setters and typed array for-in over resizable buffers enumerates the expected indices.
 - `using` and `await using` declarations still TypeError on non-object initializers but now allow initializer-less for-in/of heads with per-iteration lexical environments, so the TDZ/fresh-binding for-of cases are green.
 - Typed array subclass instances now report their concrete @@toStringTag, generator/async generator functions (and their bound/proxy wrappers) are treated as non-constructors during class heritage resolution, and derived classes extending null leave `this` uninitialized until super, so the class subclass builtins/null-proto/generator superclass cases are green.
+- Object destructuring rest now walks [[OwnPropertyKeys]] with exclusions checked before GetOwnPropertyDescriptor, skips Get for non-enumerables, and uses the original object (including proxies) instead of cloning; the proxy rest destructuring get/gOPD/ownKeys-order tests are passing.
 
 ## Next Iteration Plan
 1. Re-run the Language suite to refresh the current failure set after the for-in/of using and array setter fixes.

--- a/src/Asynkron.JsEngine/Ast/ObjectBindingExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ObjectBindingExtensions.cs
@@ -55,7 +55,7 @@ public static partial class TypedAstEvaluator
                 }
 
                 usedKeys.Add(propertyName);
-                var hasProperty = obj.TryGetProperty(propertyName, obj, context, out var val);
+                var hasProperty = JsOps.TryGetPropertyValue(obj, propertyName, out var val, context);
                 if (context.ShouldStopEvaluation)
                 {
                     throw new ThrowSignal(context.FlowValue);
@@ -107,18 +107,26 @@ public static partial class TypedAstEvaluator
                 restObject.SetPrototype(context.RealmState.ObjectPrototype);
             }
 
-            foreach (var key in GetEnumerableOwnPropertyKeysInOrder(obj))
+            foreach (var key in obj.GetOwnPropertyKeysInOrder(includeSymbols: true, includeNonEnumerable: true))
             {
-                if (!usedKeys.Contains(key))
+                if (usedKeys.Contains(key))
                 {
-                    if (obj.TryGetProperty(key, obj, context, out var restValue))
-                    {
-                        restObject.SetProperty(key, restValue);
-                    }
-                    else if (context.ShouldStopEvaluation)
-                    {
-                        throw new ThrowSignal(context.FlowValue);
-                    }
+                    continue;
+                }
+
+                var descriptor = obj.GetOwnPropertyDescriptor(key);
+                if (descriptor is not { Enumerable: true })
+                {
+                    continue;
+                }
+
+                if (JsOps.TryGetPropertyValue(obj, key, out var restValue, context))
+                {
+                    restObject.SetProperty(key, restValue);
+                }
+                else if (context.ShouldStopEvaluation)
+                {
+                    throw new ThrowSignal(context.FlowValue);
                 }
             }
 

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.cs
@@ -1180,87 +1180,31 @@ public static partial class TypedAstEvaluator
         return Enumerate().GetEnumerator();
     }
 
-    private static JsObject ToObjectForDestructuring(object? value, EvaluationContext context)
+    private static IJsObjectLike ToObjectForDestructuring(object? value, EvaluationContext context)
     {
         var realm = context.RealmState;
         switch (value)
         {
-            case JsObject jsObj:
-                return jsObj;
-            case JsArray jsArray:
-            {
-                var obj = new JsObject();
-                if (realm?.ArrayPrototype is not null)
-                {
-                    obj.SetPrototype(realm.ArrayPrototype);
-                }
-
-                var length = jsArray.Length;
-                var count = length > int.MaxValue ? int.MaxValue : (int)length;
-                for (var i = 0; i < count; i++)
-                {
-                    obj.SetProperty(i.ToString(CultureInfo.InvariantCulture), jsArray.GetElement(i));
-                }
-
-                obj.SetProperty("length", length);
-                return obj;
-            }
             case null:
             case Symbol sym when ReferenceEquals(sym, Symbol.Undefined):
             case IIsHtmlDda:
                 throw StandardLibrary.ThrowTypeError("Cannot destructure undefined or null", context, realm);
-            case string s:
-                return StandardLibrary.CreateStringWrapper(s, context, realm);
-            case JsBigInt bi:
-                return StandardLibrary.CreateBigIntWrapper(bi, context, realm);
-            case TypedAstSymbol symbolValue:
-            {
-                var obj = new JsObject();
-                if (realm?.ObjectPrototype is not null)
-                {
-                    obj.SetPrototype(realm.ObjectPrototype);
-                }
-
-                obj.SetProperty("__value__", symbolValue);
-                return obj;
-            }
-            case double:
-            case float:
-            case decimal:
-            case int:
-            case uint:
-            case long:
-            case ulong:
-            case short:
-            case ushort:
-            case byte:
-            case sbyte:
-            {
-                var num = Convert.ToDouble(value, CultureInfo.InvariantCulture);
-                return StandardLibrary.CreateNumberWrapper(num, context, realm);
-            }
-            case bool b:
-            {
-                var obj = new JsObject();
-                if (realm?.BooleanPrototype is not null)
-                {
-                    obj.SetPrototype(realm.BooleanPrototype);
-                }
-
-                obj.SetProperty("__value__", b);
-                return obj;
-            }
-            default:
-            {
-                var obj = new JsObject();
-                if (realm?.ObjectPrototype is not null)
-                {
-                    obj.SetPrototype(realm.ObjectPrototype);
-                }
-
-                return obj;
-            }
+            case IJsObjectLike objectLike:
+                return objectLike;
         }
+
+        if (realm is not null && StandardLibrary.TryGetObject(value, realm, out var coerced))
+        {
+            return coerced;
+        }
+
+        var obj = new JsObject();
+        if (realm?.ObjectPrototype is not null)
+        {
+            obj.SetPrototype(realm.ObjectPrototype);
+        }
+
+        return obj;
     }
 
     private static JsObject CreateGeneratorIteratorObject(


### PR DESCRIPTION
## Summary
- preserve proxy/receiver behaviour in object rest by using JsOps.TryGetPropertyValue and [[OwnPropertyKeys]] ordering before enumerability checks
- avoid eagerly cloning values in ToObjectForDestructuring; wrap primitives via StandardLibrary.TryGetObject and keep existing object-likes
- note the rest destructuring proxy fixes in continue.md

## Testing
- dotnet test tests/Asynkron.JsEngine.Tests.Test262/Asynkron.JsEngine.Tests.Test262.csproj -c Release --filter "FullyQualifiedName~Expressions_object_dstr"