### PR TITLE
Narrow object? to JsValue in NumberHelper and IntlUtilities

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/Intl/IntlUtilities.cs
+++ b/src/Asynkron.JsEngine/StdLib/Intl/IntlUtilities.cs
@@ -145,7 +145,7 @@ internal static class IntlUtilities
                 continue;
             }
 
-            var tag = ResolveLocaleEntry(elementJs.ObjectValue, realm);
+            var tag = ResolveLocaleEntry(elementJs, realm);
             AppendCanonicalLocale(seen, tag, realm);
         }
 
@@ -1153,39 +1153,28 @@ internal static class IntlUtilities
         return string.Join('-', output);
     }
 
-    private static string ResolveLocaleEntry(object? candidate, RealmState realm)
+    private static string ResolveLocaleEntry(JsValue candidate, RealmState realm)
     {
-        if (candidate is null || ReferenceEquals(candidate, Symbol.Undefined))
+        if (candidate.IsNullOrUndefined)
         {
             throw StandardLibrary.ThrowTypeError(
                 "Intl locale list entries must be strings or Intl.Locale objects", realm: realm);
         }
 
-        if (candidate is bool
-            || candidate is double
-            || candidate is float
-            || candidate is decimal
-            || candidate is int
-            || candidate is uint
-            || candidate is long
-            || candidate is ulong
-            || candidate is short
-            || candidate is ushort
-            || candidate is byte
-            || candidate is sbyte
-            || candidate is JsBigInt)
+        // Reject primitive numeric types and BigInt
+        if (candidate.Kind is JsValueKind.Number or JsValueKind.Boolean or JsValueKind.BigInt)
         {
             throw StandardLibrary.ThrowTypeError(
                 "Intl locale list entries must be strings or Intl.Locale objects", realm: realm);
         }
 
-        if (candidate is JsObject jsObject &&
+        if (candidate.TryGetObject<JsObject>(out var jsObject) &&
             IntlLocalePrototype.TryBuildLocaleIdentifier(jsObject, out var localeIdentifier))
         {
             return localeIdentifier;
         }
 
-        return StandardLibrary.JsValueToString(candidate, realm);
+        return candidate.ToJsString();
     }
 
     private sealed class TimeZoneRegistry(

--- a/src/Asynkron.JsEngine/StdLib/Number/NumberHelper.cs
+++ b/src/Asynkron.JsEngine/StdLib/Number/NumberHelper.cs
@@ -359,12 +359,18 @@ public static partial class NumberHelper
         return (int)index;
     }
 
-    internal static long ToIndexAsLong(object? value, RealmState? realm = null)
+    internal static long ToIndexAsLong(JsValue value, RealmState? realm = null)
     {
         const double MaxLength = 9007199254740991d; // 2^53 - 1
         var context = realm?.CreateContext();
 
-        var numericJs = JsOps.ToNumericAsJsValue(JsValue.FromObjectUnsafe(value), context);
+        // Fast path for numbers
+        if (value.Kind == JsValueKind.Number)
+        {
+            return ToIndexAsLongFromNumber(value.NumberValue, MaxLength, context, realm);
+        }
+
+        var numericJs = JsOps.ToNumericAsJsValue(in value, context);
         if (context?.IsThrow == true)
         {
             throw new ThrowSignal(context.FlowValue);
@@ -378,11 +384,12 @@ public static partial class NumberHelper
         }
 
         var numberValue = numericJs.Kind == JsValueKind.Number ? numericJs.NumberValue : JsOps.ToNumber(numericJs);
-        if (context?.IsThrow == true)
-        {
-            throw new ThrowSignal(context.FlowValue);
-        }
+        return ToIndexAsLongFromNumber(numberValue, MaxLength, context, realm);
+    }
 
+    private static long ToIndexAsLongFromNumber(double numberValue, double maxLength, EvaluationContext? context,
+        RealmState? realm)
+    {
         var integerIndex = double.IsNaN(numberValue) || Math.Abs(numberValue) < double.Epsilon
             ? 0d
             : double.IsInfinity(numberValue)
@@ -394,7 +401,7 @@ public static partial class NumberHelper
             throw ThrowRangeError("Index must be a non-negative integer", context, realm);
         }
 
-        var index = integerIndex > MaxLength ? MaxLength : integerIndex;
+        var index = integerIndex > maxLength ? maxLength : integerIndex;
         var sameValueZero = integerIndex == index || (integerIndex == 0 && index == 0);
         if (!sameValueZero)
         {

--- a/src/Asynkron.JsEngine/StdLib/StandardLibrary.cs
+++ b/src/Asynkron.JsEngine/StdLib/StandardLibrary.cs
@@ -386,6 +386,14 @@ public static partial class StandardLibrary
     }
 
     /// <summary>
+    /// JsValue overload for JsValueToString. Avoids boxing.
+    /// </summary>
+    internal static string JsValueToString(JsValue value, RealmState? realm = null)
+    {
+        return value.ToJsString(null, realm);
+    }
+
+    /// <summary>
     /// JsValue overload for TryFormatWithIntlNumberFormat. Avoids boxing/unboxing of JsValue arguments.
     /// Returns JsValue directly to avoid unnecessary boxing.
     /// </summary>


### PR DESCRIPTION
## Summary

- Change `ToIndexAsLong` to take `JsValue` directly with fast path for numbers
- Change `ResolveLocaleEntry` to take `JsValue`, simplify type checks using `JsValueKind`
- Add `JsValue` overload for `JsValueToString` to allow callers with `JsValue` to avoid boxing

### Changes

| File | Change |
|------|--------|
| NumberHelper.cs | `ToIndexAsLong(object?)` → `ToIndexAsLong(JsValue)` with fast path + helper |
| IntlUtilities.cs | `ResolveLocaleEntry(object?)` → `ResolveLocaleEntry(JsValue)` |
| StandardLibrary.cs | Added `JsValueToString(JsValue)` overload |

### Result

- 29 insertions, 25 deletions (net +4 lines)
- Fast path for numeric indices
- Cleaner type checks using `JsValueKind`

## Test plan

- [x] ArrayBuffer tests pass (4/4)
- [x] Intl tests pass (18/18)
- [x] Full test suite: 8 pre-existing failures unrelated to these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)