### PR TITLE
Narrow object? to JsValue in ArrayBuffer helpers

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Mutators.cs
+++ b/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Mutators.cs
@@ -440,7 +440,7 @@ public sealed partial class ArrayPrototype
         {
             if (IsConcatSpreadable(sourceValue, Realm, out var spreadAccessor))
             {
-                var spreadLength = LengthOfArrayLike(spreadAccessor, Realm, MethodName);
+                var spreadLength = LengthOfArrayLike(spreadAccessor, Realm);
                 const long MaxSafeIntegerLength = 9007199254740991L; // 2^53 - 1
                 if (resultIndex + spreadLength > MaxSafeIntegerLength)
                 {

--- a/src/Asynkron.JsEngine/StdLib/Array/StandardLibrary.Array.Helpers.cs
+++ b/src/Asynkron.JsEngine/StdLib/Array/StandardLibrary.Array.Helpers.cs
@@ -22,26 +22,6 @@ public static partial class StandardLibrary
         return JsOps.StrictEquals(left, right);
     }
 
-    internal static IJsObjectLike ToArrayLike(object? value, RealmState? realm)
-    {
-        if (value is IJsObjectLike accessor)
-        {
-            return accessor;
-        }
-
-        if (value is null || ReferenceEquals(value, Symbol.Undefined))
-        {
-            throw ThrowTypeError("Array method called on null or undefined", realm: realm);
-        }
-
-        if (TryGetObject(value, realm ?? new RealmState(), out var boxed))
-        {
-            return boxed;
-        }
-
-        throw ThrowTypeError("Array method receiver is not object-like", realm: realm);
-    }
-
     internal static int GetArrayLikeLength(IJsObjectLike obj)
     {
         if (!obj.TryGetProperty("length", out var lengthVal))
@@ -76,14 +56,8 @@ public static partial class StandardLibrary
         target.SetProperty("length", (double)Math.Max(length, 0));
     }
 
-    internal static long LengthOfArrayLike(object? target, RealmState? realm, string operation)
+    internal static long LengthOfArrayLike(IJsPropertyAccessor accessor, RealmState? realm)
     {
-        if (target is null || ReferenceEquals(target, Symbol.Undefined))
-        {
-            throw ThrowTypeError($"{operation} requires an object", realm: realm);
-        }
-
-        var accessor = target as IJsPropertyAccessor ?? ToPropertyAccessor(target, operation, realm);
         var context = realm?.CreateContext();
         var value = accessor.TryGetProperty("length", out var lengthValue) ? lengthValue : 0d;
         return (long)ToLengthOrZero(value, context);

--- a/src/Asynkron.JsEngine/StdLib/ArrayBuffer/ArrayBufferHelper.cs
+++ b/src/Asynkron.JsEngine/StdLib/ArrayBuffer/ArrayBufferHelper.cs
@@ -16,48 +16,31 @@ public static class ArrayBufferHelper
         obj.SetProperty("_internalArrayBuffer", JsValue.FromObjectUnsafe(buffer));
     }
 
-    internal static JsArrayBuffer RequireArrayBuffer(object? thisVal, RealmState realm)
+    internal static JsArrayBuffer RequireArrayBuffer(JsValue thisVal, RealmState realm)
     {
-        // Handle boxed JsValue struct first - unwrap to get the underlying object
-        if (thisVal is JsValue jsVal)
+        if (thisVal.IsNullOrUndefined)
         {
-            if (jsVal is { Kind: JsValueKind.Object, ObjectValue: { } objVal })
-            {
-                thisVal = objVal;
-            }
-            else
-            {
-                if (jsVal.IsNullOrUndefined)
-                {
-                    throw ThrowTypeError("ArrayBuffer method called on incompatible receiver", realm: realm);
-                }
-
-                thisVal = jsVal.ObjectValue;
-            }
+            throw ThrowTypeError("ArrayBuffer method called on incompatible receiver", realm: realm);
         }
 
-        if (thisVal is JsArrayBuffer directBuffer)
+        // Direct JsArrayBuffer
+        if (thisVal.TryGetObject<JsArrayBuffer>(out var directBuffer))
         {
             return directBuffer;
         }
 
-        if (thisVal is JsObject obj)
+        // JsObject with internal slot
+        if (thisVal.TryGetObject<JsObject>(out var obj))
         {
             var descriptor = obj.GetOwnPropertyDescriptor("_internalArrayBuffer");
-            if ((descriptor != null ? descriptor.JsValue.ToObject() : null) is JsArrayBuffer internalBuffer)
+            if (descriptor?.JsValue.TryGetObject<JsArrayBuffer>(out var internalBuffer) == true)
             {
                 return internalBuffer;
             }
-
-            // Handle case where value is boxed JsValue struct
-            if ((descriptor != null ? descriptor.JsValue.ToObject() : null) is JsValue bufJsVal &&
-                bufJsVal.TryGetObject<JsArrayBuffer>(out var bufferFromJsValue))
-            {
-                return bufferFromJsValue;
-            }
         }
 
-        if (thisVal is IJsPropertyAccessor accessor &&
+        // IJsPropertyAccessor with internal slot
+        if (thisVal.TryGetObject<IJsPropertyAccessor>(out var accessor) &&
             accessor.TryGetProperty("_internalArrayBuffer", out var internalVal) &&
             internalVal.TryGetObject<JsArrayBuffer>(out var bufferFromAccessor))
         {
@@ -67,23 +50,10 @@ public static class ArrayBufferHelper
         throw ThrowTypeError("ArrayBuffer method called on incompatible receiver", realm: realm);
     }
 
-    internal static IJsCallable ArrayBufferSpeciesCreate(object? thisVal, RealmState realm,
+    internal static IJsCallable ArrayBufferSpeciesCreate(JsValue thisVal, RealmState realm,
         HostFunction defaultConstructor)
     {
-        // Handle boxed JsValue struct first - unwrap to get the underlying object
-        if (thisVal is JsValue jsVal)
-        {
-            if (jsVal is { Kind: JsValueKind.Object, ObjectValue: { } objVal })
-            {
-                thisVal = objVal;
-            }
-            else
-            {
-                return defaultConstructor;
-            }
-        }
-
-        if (thisVal is not IJsPropertyAccessor accessor ||
+        if (!thisVal.TryGetObject<IJsPropertyAccessor>(out var accessor) ||
             !accessor.TryGetProperty("constructor", out var ctorVal))
         {
             return defaultConstructor;

--- a/src/Asynkron.JsEngine/StdLib/SharedArrayBuffer/SharedArrayBufferPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/SharedArrayBuffer/SharedArrayBufferPrototype.cs
@@ -114,7 +114,7 @@ public sealed partial class SharedArrayBufferPrototype : JsPrototype
                 throw ThrowTypeError("SharedArrayBuffer species constructor did not return an object", realm: Realm);
             }
 
-            targetBuffer = RequireArrayBuffer(newBuffer, Realm);
+            targetBuffer = RequireArrayBuffer(JsValue.FromObjectUnsafe(newBuffer), Realm);
             if (!ReferenceEquals(targetBuffer, newBuffer))
             {
                 if (newBuffer is JsObject obj)


### PR DESCRIPTION
## Summary

- Narrow `object?` parameters to more specific types in ArrayBuffer-related helpers
- Remove unused dead code

### Changes

| File | Change |
|------|--------|
| ArrayBufferHelper.cs | `RequireArrayBuffer(object?)` → `RequireArrayBuffer(JsValue)` |
| ArrayBufferHelper.cs | `ArrayBufferSpeciesCreate(object?)` → `ArrayBufferSpeciesCreate(JsValue)` |
| StandardLibrary.Array.Helpers.cs | Removed unused `ToArrayLike(object?)` method |
| StandardLibrary.Array.Helpers.cs | `LengthOfArrayLike(object?)` → `LengthOfArrayLike(IJsPropertyAccessor)` |

### Result

- 15 insertions, 71 deletions (net -56 lines)
- Cleaner code using JsValue methods directly
- Removed dead code

## Test plan

- [x] ArrayBuffer tests pass (4/4)
- [x] Full test suite: 8 pre-existing failures unrelated to these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)