### PR TITLE
Remove unused object? overloads in favor of JsValue versions

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/Array/StandardLibrary.Array.Helpers.cs
+++ b/src/Asynkron.JsEngine/StdLib/Array/StandardLibrary.Array.Helpers.cs
@@ -296,43 +296,6 @@ public static partial class StandardLibrary
         throw ThrowTypeError($"{methodName} called on incompatible receiver", realm: realm);
     }
 
-    internal static IJsPropertyAccessor EnsureArrayLikeReceiver(object? receiver, string methodName, RealmState? realm)
-    {
-        // Unwrap JsValue first - this path is for callers that pass object?
-        if (receiver is JsValue jsValue)
-        {
-            return EnsureArrayLikeReceiver(jsValue, methodName, realm);
-        }
-
-        return EnsureArrayLikeReceiverObject(receiver, methodName, realm);
-    }
-
-    private static IJsPropertyAccessor EnsureArrayLikeReceiverObject(object? receiver, string methodName,
-        RealmState? realm)
-    {
-        if (receiver is null || ReferenceEquals(receiver, Symbol.Undefined))
-        {
-            throw ThrowTypeError($"{methodName} called on null or undefined", realm: realm);
-        }
-
-        if (receiver is IJsPropertyAccessor accessor)
-        {
-            return accessor;
-        }
-
-        if (receiver is JsObject jsObj)
-        {
-            return jsObj;
-        }
-
-        if (TryGetObject(receiver, realm, out var boxed))
-        {
-            return boxed;
-        }
-
-        throw ThrowTypeError($"{methodName} receiver is not object-like", realm: realm);
-    }
-
     internal static bool TryGetCallableMethod(object? target, string propertyKey, string operation, RealmState? realm,
         out IJsCallable? callable)
     {

--- a/src/Asynkron.JsEngine/StdLib/Number/NumberHelper.cs
+++ b/src/Asynkron.JsEngine/StdLib/Number/NumberHelper.cs
@@ -248,59 +248,6 @@ public static partial class NumberHelper
         return isNegative ? "-" + result : result;
     }
 
-    internal static int ToIndex(object? value, RealmState? realm = null)
-    {
-        const double MaxLength = 9007199254740991d; // 2^53 - 1
-        var context = realm?.CreateContext();
-
-        var numericJs = JsOps.ToNumericAsJsValue( JsValue.FromObjectUnsafe(value), context);
-        if (context?.IsThrow == true)
-        {
-            throw new ThrowSignal(context.FlowValue);
-        }
-
-        if (numericJs.Kind == JsValueKind.BigInt ||
-            numericJs.TryGetObject<Symbol>(out _) ||
-            numericJs.TryGetObject<TypedAstSymbol>(out _))
-        {
-            throw ThrowTypeError("Index must be a non-negative integer", context, realm);
-        }
-
-        var numberValue = numericJs.Kind == JsValueKind.Number ? numericJs.NumberValue : JsOps.ToNumber(numericJs);
-        if (context?.IsThrow == true)
-        {
-            throw new ThrowSignal(context.FlowValue);
-        }
-
-        var integerIndex = double.IsNaN(numberValue) || Math.Abs(numberValue) < double.Epsilon
-            ? 0d
-            : double.IsInfinity(numberValue)
-                ? numberValue > 0 ? double.PositiveInfinity : double.NegativeInfinity
-                : Math.Truncate(numberValue);
-
-        if (double.IsPositiveInfinity(integerIndex) || integerIndex < 0)
-        {
-            throw ThrowRangeError("Index must be a non-negative integer", context, realm);
-        }
-
-        var index = integerIndex > MaxLength ? MaxLength : integerIndex;
-        var sameValueZero = integerIndex == index || (integerIndex == 0 && index == 0);
-        if (!sameValueZero)
-        {
-            throw ThrowRangeError("Index must be a non-negative integer", context, realm);
-        }
-
-        if (index > int.MaxValue)
-        {
-            throw ThrowRangeError("Index is too large", context, realm);
-        }
-
-        return (int)index;
-    }
-
-    /// <summary>
-    /// JsValue overload for ToIndex. Converts a JsValue to an index.
-    /// </summary>
     internal static int ToIndex(JsValue value, RealmState? realm = null)
     {
         const double MaxLength = 9007199254740991d; // 2^53 - 1

--- a/src/Asynkron.JsEngine/StdLib/String/StringHelper.cs
+++ b/src/Asynkron.JsEngine/StdLib/String/StringHelper.cs
@@ -32,21 +32,6 @@ public static class StringHelper
         return wrapper;
     }
 
-    internal static string RequireStringReceiver(object? receiver, RealmState? realm = null)
-    {
-        return receiver switch
-        {
-            string s => s,
-            JsObject obj when obj.TryGetProperty("__value__", out var inner) && inner.TryGetString(out var s) => s,
-            IJsPropertyAccessor accessor when accessor.TryGetProperty("__value__", out var inner)
-                                              && inner.TryGetString(out var s) => s,
-            _ => throw ThrowTypeError("String.prototype valueOf called on non-string object", realm: realm)
-        };
-    }
-
-    /// <summary>
-    /// JsValue overload for RequireStringReceiver.
-    /// </summary>
     internal static string RequireStringReceiver(JsValue receiver, RealmState? realm = null)
     {
         // Fast path for string kind


### PR DESCRIPTION
## Summary
- Removed `ToIndex(object?)` overload from NumberHelper.cs - only `JsValue` version retained
- Removed `RequireStringReceiver(object?)` overload from StringHelper.cs - only `JsValue` version retained
- Removed `EnsureArrayLikeReceiver(object?)` and helper method from StandardLibrary.Array.Helpers.cs - only `JsValue` version retained

All callers now use the JsValue-based versions which provide better type safety and avoid unnecessary boxing/unboxing.

## Test plan
- [x] Build succeeds
- [x] All existing tests pass (known ForAwaitOf failures are pre-existing in main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)