### PR TITLE
Remove unused object? overloads for JsValueToString and CanonicalizeLocaleList

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/Intl/IntlUtilities.cs
+++ b/src/Asynkron.JsEngine/StdLib/Intl/IntlUtilities.cs
@@ -80,9 +80,6 @@ internal static class IntlUtilities
         Array.Sort(NumberingSystemValues, StringComparer.Ordinal);
     }
 
-    /// <summary>
-    /// JsValue overload that avoids boxing.
-    /// </summary>
     public static IReadOnlyList<string> CanonicalizeLocaleList(JsValue locales, RealmState realm)
     {
         if (locales.Kind == JsValueKind.Undefined)
@@ -95,32 +92,9 @@ internal static class IntlUtilities
             throw StandardLibrary.ThrowTypeError("Intl locale list cannot be null", realm: realm);
         }
 
-        if (locales is { Kind: JsValueKind.String, ObjectValue: string single })
-        {
-            var seen = new List<string>();
-            AppendCanonicalLocale(seen, single, realm);
-            return seen;
-        }
-
-        // Fall back to object version for other types
-        return CanonicalizeLocaleList(locales.ObjectValue, realm);
-    }
-
-    public static IReadOnlyList<string> CanonicalizeLocaleList(object? locales, RealmState realm)
-    {
-        if (locales is null)
-        {
-            throw StandardLibrary.ThrowTypeError("Intl locale list cannot be null", realm: realm);
-        }
-
-        if (ReferenceEquals(locales, Symbol.Undefined))
-        {
-            return [];
-        }
-
         var seen = new List<string>();
 
-        if (locales is string single)
+        if (locales is { Kind: JsValueKind.String, ObjectValue: string single })
         {
             AppendCanonicalLocale(seen, single, realm);
             return seen;

--- a/src/Asynkron.JsEngine/StdLib/StandardLibrary.cs
+++ b/src/Asynkron.JsEngine/StdLib/StandardLibrary.cs
@@ -380,14 +380,6 @@ public static partial class StandardLibrary
     ///     Converts a JavaScript value to its string representation, handling functions appropriately.
     ///     Exposed internally so prototype helpers can reuse the same semantics.
     /// </summary>
-    internal static string JsValueToString(object? value, RealmState? realm = null)
-    {
-        return value.ToJsString(null, realm);
-    }
-
-    /// <summary>
-    /// JsValue overload for JsValueToString. Avoids boxing.
-    /// </summary>
     internal static string JsValueToString(JsValue value, RealmState? realm = null)
     {
         return value.ToJsString(null, realm);


### PR DESCRIPTION
## Summary
- Removed `JsValueToString(object?)` overload since all callers pass `JsValue` directly
- Merged `CanonicalizeLocaleList(object?)` into the `JsValue` version since it was only called from the JsValue overload

## Test plan
- [x] All 1985 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)