### PR TITLE
Unify object pooling with ObjectPool<T> and IRentable

### DIFF
--- a/src/Asynkron.JsEngine/ActionMicrotask.cs
+++ b/src/Asynkron.JsEngine/ActionMicrotask.cs
@@ -4,10 +4,9 @@ namespace Asynkron.JsEngine;
 ///     Poolable wrapper that allows arbitrary Action delegates to be queued as microtasks.
 ///     Used for legacy code paths and user-provided callbacks.
 /// </summary>
-internal sealed class ActionMicrotask : IMicrotask
+internal sealed class ActionMicrotask : IMicrotask, IRentable
 {
-    [ThreadStatic]
-    private static ActionMicrotask? Cached;
+    private static readonly ObjectPool<ActionMicrotask> Pool = new(32, static () => new ActionMicrotask());
 
     private Action? _action;
 
@@ -15,8 +14,7 @@ internal sealed class ActionMicrotask : IMicrotask
 
     public static IMicrotask Rent(Action action)
     {
-        var task = Cached ?? new ActionMicrotask();
-        Cached = null;
+        var task = Pool.Rent();
         task._action = action;
         return task;
     }
@@ -24,15 +22,19 @@ internal sealed class ActionMicrotask : IMicrotask
     public void Execute()
     {
         var action = _action!;
-        _action = null;
-
         try
         {
             action();
         }
         finally
         {
-            Cached = this;
+            Pool.Return(this);
         }
+    }
+
+    public void Reset()
+    {
+        _action = null;
+        Epoch = 0;
     }
 }

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.TypedFunction.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.TypedFunction.cs
@@ -19,7 +19,8 @@ public static partial class TypedAstEvaluator
         ICallableMetadata, IFunctionNameTarget, IPrivateBrandHolder, IPropertyDefinitionHost,
         IExtensibilityControl, IPrototypeAccessorProvider
     {
-        private static readonly ConcurrentBag<HashSet<Symbol>> SymbolSetPool = [];
+        private static readonly ObjectPool<HashSet<Symbol>> SymbolSetPool = new(32,
+            static () => new HashSet<Symbol>(ReferenceEqualityComparer<Symbol>.Instance));
         private readonly bool _allowIdentifierCache;
         private readonly bool _argumentsObjectNeeded;
         private readonly ImmutableArray<Symbol> _bodyLexicalTemplate;
@@ -1244,13 +1245,7 @@ public static partial class TypedAstEvaluator
 
         private static HashSet<Symbol> RentSymbolSet()
         {
-            if (!SymbolSetPool.TryTake(out var set))
-            {
-                return new HashSet<Symbol>(ReferenceEqualityComparer<Symbol>.Instance);
-            }
-
-            set.Clear();
-            return set;
+            return SymbolSetPool.Rent();
         }
 
         private static HashSet<Symbol> RentSymbolSet(IEnumerable<Symbol> seed)
@@ -1263,7 +1258,7 @@ public static partial class TypedAstEvaluator
         private static void ReturnSymbolSet(HashSet<Symbol> set)
         {
             set.Clear();
-            SymbolSetPool.Add(set);
+            SymbolSetPool.Return(set);
         }
 
         /// <summary>

--- a/src/Asynkron.JsEngine/EvaluationContext.cs
+++ b/src/Asynkron.JsEngine/EvaluationContext.cs
@@ -18,7 +18,7 @@ namespace Asynkron.JsEngine;
 public sealed class EvaluationContext(
     RealmState realmState,
     CancellationToken cancellationToken = default,
-    ExecutionKind executionKind = ExecutionKind.Script)
+    ExecutionKind executionKind = ExecutionKind.Script) : IRentable
 {
     private readonly Stack<Symbol> _functionNameHints = new();
 
@@ -485,6 +485,11 @@ public sealed class EvaluationContext(
         _returnValue = state.ReturnValue;
         CurrentSignal = state.Signal;
     }
+
+    /// <summary>
+    ///     Resets the context for reuse. Clears all stacks and signals.
+    /// </summary>
+    void IRentable.Reset() => Reset();
 
     /// <summary>
     ///     Resets the context for reuse. Clears all stacks and signals.

--- a/src/Asynkron.JsEngine/Execution/IteratorDriverState.cs
+++ b/src/Asynkron.JsEngine/Execution/IteratorDriverState.cs
@@ -8,7 +8,7 @@ using Asynkron.JsEngine.JsTypes;
 
 namespace Asynkron.JsEngine.Execution;
 
-internal sealed class IteratorDriverState
+internal sealed class IteratorDriverState : IRentable
 {
     public IJsObjectLike? IteratorObject { get; set; }
     public IEnumerator<JsValue>? Enumerator { get; set; }
@@ -43,10 +43,10 @@ internal sealed class IteratorDriverState
     public JsEnvironment? LoopScopeEnvironment { get; set; }
 
     /// <summary>
-    /// Clears the state for reuse from pool.
+    /// Resets the state for reuse from pool.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Clear()
+    public void Reset()
     {
         IteratorObject = null;
         Enumerator = null;
@@ -62,44 +62,15 @@ internal sealed class IteratorDriverState
 }
 
 /// <summary>
-/// Simple pool for IteratorDriverState instances to reduce per-loop allocations.
-/// Uses a lock-free fixed-size array with Interlocked operations for thread-safety.
+/// Pool for IteratorDriverState instances to reduce per-loop allocations.
 /// </summary>
 internal static class IteratorDriverStatePool
 {
-    private const int PoolSize = 32;
-    private static readonly IteratorDriverState?[] Pool = new IteratorDriverState?[PoolSize];
+    private static readonly ObjectPool<IteratorDriverState> Pool = new(32, static () => new IteratorDriverState());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IteratorDriverState Rent()
-    {
-        // Try to get from pool using lock-free compare-exchange
-        for (var i = 0; i < PoolSize; i++)
-        {
-            var state = Pool[i];
-            if (state is not null && Interlocked.CompareExchange(ref Pool[i], null, state) == state)
-            {
-                return state;
-            }
-        }
-
-        return new IteratorDriverState();
-    }
+    public static IteratorDriverState Rent() => Pool.Rent();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Return(IteratorDriverState state)
-    {
-        // Clear to a neutral state
-        state.Clear();
-
-        // Try to return to pool using lock-free compare-exchange
-        for (var i = 0; i < PoolSize; i++)
-        {
-            if (Pool[i] is null && Interlocked.CompareExchange(ref Pool[i], state, null) is null)
-            {
-                return;
-            }
-        }
-        // Pool full, state will be GC'd
-    }
+    public static void Return(IteratorDriverState state) => Pool.Return(state);
 }

--- a/src/Asynkron.JsEngine/JsCallableMicrotask.cs
+++ b/src/Asynkron.JsEngine/JsCallableMicrotask.cs
@@ -6,10 +6,9 @@ namespace Asynkron.JsEngine;
 ///     Poolable microtask that wraps a JavaScript callable (IJsCallable).
 ///     Used by the queueMicrotask global function to schedule user callbacks.
 /// </summary>
-internal sealed class JsCallableMicrotask : IMicrotask
+internal sealed class JsCallableMicrotask : IMicrotask, IRentable
 {
-    [ThreadStatic]
-    private static JsCallableMicrotask? Cached;
+    private static readonly ObjectPool<JsCallableMicrotask> Pool = new(32, static () => new JsCallableMicrotask());
 
     private IJsCallable? _callback;
 
@@ -17,8 +16,7 @@ internal sealed class JsCallableMicrotask : IMicrotask
 
     public static IMicrotask Rent(IJsCallable callback)
     {
-        var task = Cached ?? new JsCallableMicrotask();
-        Cached = null;
+        var task = Pool.Rent();
         task._callback = callback;
         return task;
     }
@@ -26,15 +24,19 @@ internal sealed class JsCallableMicrotask : IMicrotask
     public void Execute()
     {
         var callback = _callback!;
-        _callback = null;
-
         try
         {
             callback.Invoke([], JsValue.Undefined);
         }
         finally
         {
-            Cached = this;
+            Pool.Return(this);
         }
+    }
+
+    public void Reset()
+    {
+        _callback = null;
+        Epoch = 0;
     }
 }

--- a/src/Asynkron.JsEngine/JsEnvironment.cs
+++ b/src/Asynkron.JsEngine/JsEnvironment.cs
@@ -16,7 +16,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Asynkron.JsEngine;
 
-public sealed class JsEnvironment
+public sealed class JsEnvironment : IRentable
 {
     private const int MaxDepth = 1_000;
     internal static readonly object Uninitialized = new();
@@ -215,6 +215,15 @@ public sealed class JsEnvironment
         _thisValue = default;
         _hasThisValue = false;
         ScopeId = -1;
+    }
+
+    /// <summary>
+    ///     Resets the environment to a neutral state for pool return.
+    ///     Implements IRentable.Reset().
+    /// </summary>
+    void IRentable.Reset()
+    {
+        Reset(null, false, false);
     }
 
     /// <summary>

--- a/src/Asynkron.JsEngine/JsEnvironmentPool.cs
+++ b/src/Asynkron.JsEngine/JsEnvironmentPool.cs
@@ -8,13 +8,12 @@ using Asynkron.JsEngine.Parser;
 namespace Asynkron.JsEngine;
 
 /// <summary>
-/// Simple pool for JsEnvironment instances to reduce per-iteration allocations in hot loops.
-/// Uses a lock-free fixed-size array with Interlocked operations for thread-safety.
+/// Pool for JsEnvironment instances to reduce per-iteration allocations in hot loops.
 /// </summary>
 internal static class JsEnvironmentPool
 {
-    private const int PoolSize = 32;
-    private static readonly JsEnvironment?[] Pool = new JsEnvironment?[PoolSize];
+    private static readonly ObjectPool<JsEnvironment> Pool = new(32,
+        static () => new JsEnvironment(null, false, false));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JsEnvironment Rent(
@@ -26,36 +25,12 @@ internal static class JsEnvironmentPool
         bool isParameterEnvironment = false,
         bool isBodyEnvironment = false)
     {
-        // Try to get from pool using lock-free compare-exchange
-        for (var i = 0; i < PoolSize; i++)
-        {
-            var env = Pool[i];
-            if (env is not null && Interlocked.CompareExchange(ref Pool[i], null, env) == env)
-            {
-                env.Reset(enclosing, isFunctionScope, isStrict, creatingSource, description,
-                    isParameterEnvironment, isBodyEnvironment);
-                return env;
-            }
-        }
-
-        return new JsEnvironment(enclosing, isFunctionScope, isStrict, creatingSource, description, null,
+        var env = Pool.Rent();
+        env.Reset(enclosing, isFunctionScope, isStrict, creatingSource, description,
             isParameterEnvironment, isBodyEnvironment);
+        return env;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Return(JsEnvironment environment)
-    {
-        // Clear to a neutral state
-        environment.Reset(null, false, false);
-
-        // Try to return to pool using lock-free compare-exchange
-        for (var i = 0; i < PoolSize; i++)
-        {
-            if (Pool[i] is null && Interlocked.CompareExchange(ref Pool[i], environment, null) is null)
-            {
-                return;
-            }
-        }
-        // Pool full, environment will be GC'd
-    }
+    public static void Return(JsEnvironment environment) => Pool.Return(environment);
 }

--- a/src/Asynkron.JsEngine/JsTypes/PromiseMicrotasks.cs
+++ b/src/Asynkron.JsEngine/JsTypes/PromiseMicrotasks.cs
@@ -4,10 +4,10 @@ namespace Asynkron.JsEngine.JsTypes;
 ///     Poolable microtask for resolved promise pass-through (no callback).
 ///     Implements IMicrotask directly to avoid Action delegate allocation.
 /// </summary>
-internal sealed class ResolvedPromisePassthroughMicrotask : IMicrotask
+internal sealed class ResolvedPromisePassthroughMicrotask : IMicrotask, IRentable
 {
-    [ThreadStatic]
-    private static ResolvedPromisePassthroughMicrotask? Cached;
+    private static readonly ObjectPool<ResolvedPromisePassthroughMicrotask> Pool = new(32,
+        static () => new ResolvedPromisePassthroughMicrotask());
 
     private JsValue _value;
     private JsPromise? _nextPromise;
@@ -16,8 +16,7 @@ internal sealed class ResolvedPromisePassthroughMicrotask : IMicrotask
 
     public static IMicrotask Rent(JsValue value, JsPromise promise)
     {
-        var task = Cached ?? new ResolvedPromisePassthroughMicrotask();
-        Cached = null;
+        var task = Pool.Rent();
         task._value = value;
         task._nextPromise = promise;
         return task;
@@ -28,11 +27,15 @@ internal sealed class ResolvedPromisePassthroughMicrotask : IMicrotask
         var value = _value;
         var nextPromise = _nextPromise!;
 
+        nextPromise.Resolve(value);
+        Pool.Return(this);
+    }
+
+    public void Reset()
+    {
         _value = JsValue.Undefined;
         _nextPromise = null;
-
-        nextPromise.Resolve(value);
-        Cached = this;
+        Epoch = 0;
     }
 }
 
@@ -40,10 +43,10 @@ internal sealed class ResolvedPromisePassthroughMicrotask : IMicrotask
 ///     Poolable microtask for finally handlers.
 ///     Implements IMicrotask directly to avoid Action delegate allocation.
 /// </summary>
-internal sealed class ResolvedPromiseFinallyMicrotask : IMicrotask
+internal sealed class ResolvedPromiseFinallyMicrotask : IMicrotask, IRentable
 {
-    [ThreadStatic]
-    private static ResolvedPromiseFinallyMicrotask? Cached;
+    private static readonly ObjectPool<ResolvedPromiseFinallyMicrotask> Pool = new(32,
+        static () => new ResolvedPromiseFinallyMicrotask());
 
     private IJsCallable? _callback;
     private JsValue _value;
@@ -53,8 +56,7 @@ internal sealed class ResolvedPromiseFinallyMicrotask : IMicrotask
 
     public static IMicrotask Rent(IJsCallable callback, JsValue value, JsPromise promise)
     {
-        var task = Cached ?? new ResolvedPromiseFinallyMicrotask();
-        Cached = null;
+        var task = Pool.Rent();
         task._callback = callback;
         task._value = value;
         task._nextPromise = promise;
@@ -66,10 +68,6 @@ internal sealed class ResolvedPromiseFinallyMicrotask : IMicrotask
         var callback = _callback!;
         var value = _value;
         var nextPromise = _nextPromise!;
-
-        _callback = null;
-        _value = JsValue.Undefined;
-        _nextPromise = null;
 
         try
         {
@@ -86,7 +84,15 @@ internal sealed class ResolvedPromiseFinallyMicrotask : IMicrotask
         }
         finally
         {
-            Cached = this;
+            Pool.Return(this);
         }
+    }
+
+    public void Reset()
+    {
+        _callback = null;
+        _value = JsValue.Undefined;
+        _nextPromise = null;
+        Epoch = 0;
     }
 }

--- a/src/Asynkron.JsEngine/JsTypes/ResolvedPromiseFulfilledMicrotask.cs
+++ b/src/Asynkron.JsEngine/JsTypes/ResolvedPromiseFulfilledMicrotask.cs
@@ -4,10 +4,10 @@ namespace Asynkron.JsEngine.JsTypes;
 ///     Poolable microtask for resolved promise callbacks with onFulfilled handler.
 ///     Implements IMicrotask directly to avoid Action delegate allocation.
 /// </summary>
-internal sealed class ResolvedPromiseFulfilledMicrotask : IMicrotask
+internal sealed class ResolvedPromiseFulfilledMicrotask : IMicrotask, IRentable
 {
-    [ThreadStatic]
-    private static ResolvedPromiseFulfilledMicrotask? TCached;
+    private static readonly ObjectPool<ResolvedPromiseFulfilledMicrotask> Pool = new(32,
+        static () => new ResolvedPromiseFulfilledMicrotask());
 
     private IJsCallable? _callback;
     private JsValue _value;
@@ -17,8 +17,7 @@ internal sealed class ResolvedPromiseFulfilledMicrotask : IMicrotask
 
     public static IMicrotask Rent(IJsCallable callback, JsValue value, JsPromise promise)
     {
-        var task = TCached ?? new ResolvedPromiseFulfilledMicrotask();
-        TCached = null;
+        var task = Pool.Rent();
         task._callback = callback;
         task._value = value;
         task._nextPromise = promise;
@@ -30,11 +29,6 @@ internal sealed class ResolvedPromiseFulfilledMicrotask : IMicrotask
         var callback = _callback!;
         var value = _value;
         var nextPromise = _nextPromise!;
-
-        // Clear state before execution to allow re-pooling even if exception occurs
-        _callback = null;
-        _value = JsValue.Undefined;
-        _nextPromise = null;
 
         // Rent a single-element array from the cache to pass the value
         var args = JsValueCache.RentJsValueArray(1);
@@ -55,7 +49,15 @@ internal sealed class ResolvedPromiseFulfilledMicrotask : IMicrotask
         finally
         {
             JsValueCache.ReturnJsValueArray(args);
-            TCached = this;
+            Pool.Return(this);
         }
+    }
+
+    public void Reset()
+    {
+        _callback = null;
+        _value = JsValue.Undefined;
+        _nextPromise = null;
+        Epoch = 0;
     }
 }

--- a/src/Asynkron.JsEngine/Runtime/RealmState.cs
+++ b/src/Asynkron.JsEngine/Runtime/RealmState.cs
@@ -1,6 +1,5 @@
 #region
 
-using System.Collections.Concurrent;
 using Asynkron.JsEngine.JsTypes;
 using Asynkron.JsEngine.Parser;
 using Microsoft.Extensions.Logging;
@@ -15,10 +14,14 @@ namespace Asynkron.JsEngine.Runtime;
 /// </summary>
 public sealed class RealmState
 {
-    private const int MaxContextPoolSize = 16;
-    private const int MaxEnvironmentPoolSize = 32;
-    private readonly ConcurrentStack<EvaluationContext> _contextPool = new();
-    private readonly ConcurrentStack<JsEnvironment> _environmentPool = new();
+    private readonly ObjectPool<EvaluationContext> _contextPool;
+    private readonly ObjectPool<JsEnvironment> _environmentPool;
+
+    public RealmState()
+    {
+        _contextPool = new ObjectPool<EvaluationContext>(16, () => new EvaluationContext(this));
+        _environmentPool = new ObjectPool<JsEnvironment>(32, static () => new JsEnvironment(null, false, false));
+    }
 
     public IJsEngineOptions Options { get; internal init; } = JsEngineOptions.Default;
     internal JsEngine? Engine { get; init; }
@@ -108,14 +111,8 @@ public sealed class RealmState
         ExecutionKind executionKind = ExecutionKind.Script,
         bool pushScope = true)
     {
-        if (_contextPool.TryPop(out var context))
-        {
-            context.Reset();
-        }
-        else
-        {
-            context = new EvaluationContext(this, cancellationToken, executionKind);
-        }
+        var context = _contextPool.Rent();
+        context.Reset();
 
         if (pushScope)
         {
@@ -128,13 +125,7 @@ public sealed class RealmState
     /// <summary>
     /// Returns an EvaluationContext to the pool for reuse.
     /// </summary>
-    public void ReturnContext(EvaluationContext context)
-    {
-        if (_contextPool.Count < MaxContextPoolSize)
-        {
-            _contextPool.Push(context);
-        }
-    }
+    public void ReturnContext(EvaluationContext context) => _contextPool.Return(context);
 
     /// <summary>
     /// Rents a JsEnvironment from the pool or creates a new one.
@@ -149,27 +140,16 @@ public sealed class RealmState
         bool isParameterEnvironment = false,
         bool isBodyEnvironment = false)
     {
-        if (_environmentPool.TryPop(out var env))
-        {
-            env.Reset(enclosing, isFunctionScope, isStrict, creatingSource, description, isParameterEnvironment,
-                isBodyEnvironment);
-            return env;
-        }
-
-        return new JsEnvironment(enclosing, isFunctionScope, isStrict, creatingSource, description,
-            isParameterEnvironment: isParameterEnvironment, isBodyEnvironment: isBodyEnvironment);
+        var env = _environmentPool.Rent();
+        env.Reset(enclosing, isFunctionScope, isStrict, creatingSource, description, isParameterEnvironment,
+            isBodyEnvironment);
+        return env;
     }
 
     /// <summary>
     /// Returns a JsEnvironment to the pool for reuse.
     /// </summary>
-    public void ReturnEnvironment(JsEnvironment env)
-    {
-        if (_environmentPool.Count < MaxEnvironmentPoolSize)
-        {
-            _environmentPool.Push(env);
-        }
-    }
+    public void ReturnEnvironment(JsEnvironment env) => _environmentPool.Return(env);
 
     public EvaluationContext CreateStrictContext(
         ScopeKind kind = ScopeKind.Function,


### PR DESCRIPTION
## Summary
- Introduces a unified `ObjectPool<T>` pattern with `IRentable` interface for consistent object pooling across the codebase
- Converts ThreadStatic single-instance-per-thread patterns to lock-free global pools (32 slots each)
- Converts ConcurrentStack pools to use the same ObjectPool<T> infrastructure
- Adds `PooledObject<T>` struct for auto-return on dispose pattern

## Changes
**New pooling infrastructure:**
- `IRentable` interface with `Reset()` method for poolable objects
- `PooledObject<T>` struct for `using var x = pool.RentOrCreate()` pattern

**Microtask pools converted (ThreadStatic → ObjectPool):**
- ActionMicrotask
- JsCallableMicrotask
- ResolvedPromisePassthroughMicrotask
- ResolvedPromiseFinallyMicrotask
- ResolvedPromiseFulfilledMicrotask

**Other pools converted:**
- JsEnvironmentPool (static pool)
- IteratorDriverStatePool
- SymbolSetPool (in TypedFunction)
- RealmState context/environment pools (per-realm pools)

**Types now implementing IRentable:**
- JsEnvironment
- EvaluationContext
- IteratorDriverState
- All microtask classes

## Test plan
- [x] Build passes with no new errors
- [x] All tests pass (1 pre-existing failure unrelated to this change)
- [ ] Run CPU profiler to verify no regression
- [ ] Run memory profiler to verify allocation patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)