### PR TITLE
Fix String builtins range handling

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/String/StringConstructor.cs
+++ b/src/Asynkron.JsEngine/StdLib/String/StringConstructor.cs
@@ -35,15 +35,16 @@ public sealed partial class StringConstructor(IJsObjectLike prototype, RealmStat
         foreach (var arg in args)
         {
             var num = JsOps.ToNumber(arg);
-            if (double.IsNaN(num) || double.IsInfinity(num))
+            // Per spec, reject NaN, Infinity, and non-integers.
+            if (double.IsNaN(num) || double.IsInfinity(num) || num % 1 != 0)
             {
-                continue;
+                throw StandardLibrary.ThrowRangeError("Invalid code point");
             }
 
             var codePoint = (int)num;
             if (codePoint is < 0 or > 0x10FFFF)
             {
-                throw new Exception("RangeError: Invalid code point " + codePoint);
+                throw StandardLibrary.ThrowRangeError($"Invalid code point {codePoint}");
             }
 
             if (codePoint <= 0xFFFF)
@@ -73,12 +74,8 @@ public sealed partial class StringConstructor(IJsObjectLike prototype, RealmStat
         foreach (var arg in args)
         {
             var num = JsOps.ToNumber(arg);
-            if (double.IsNaN(num) || double.IsInfinity(num))
-            {
-                continue;
-            }
-
-            var charCode = (int)num & 0xFFFF;
+            // ToUint16 behavior: NaN/Infinity -> +0, then mod 2^16.
+            var charCode = ToUint16(num);
             result.Append((char)charCode);
         }
 
@@ -289,5 +286,23 @@ public sealed partial class StringConstructor(IJsObjectLike prototype, RealmStat
         {
             instance.SetPrototype(proto);
         }
+    }
+
+    private static int ToUint16(double number)
+    {
+        if (double.IsNaN(number) || double.IsInfinity(number) || number == 0)
+        {
+            return 0;
+        }
+
+        // Convert to a truncated integer, then wrap into 16-bit range.
+        var integer = Math.Sign(number) * Math.Floor(Math.Abs(number));
+        var modulo = (long)integer % 65536;
+        if (modulo < 0)
+        {
+            modulo += 65536;
+        }
+
+        return (int)modulo;
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/String/StringPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/String/StringPrototype.cs
@@ -1166,21 +1166,15 @@ public sealed partial class StringPrototype
         var value = ResolveString(thisValue);
         var form = args.Count > 0 && !args[0].IsUndefined ? JsOps.ToJsString(args[0]) : "NFC";
 
-        try
+        return new JsValue(form switch
         {
-            return new JsValue(form switch
-            {
-                "NFC" => value.Normalize(NormalizationForm.FormC),
-                "NFD" => value.Normalize(NormalizationForm.FormD),
-                "NFKC" => value.Normalize(NormalizationForm.FormKC),
-                "NFKD" => value.Normalize(NormalizationForm.FormKD),
-                _ => throw new Exception("RangeError: The normalization form should be one of NFC, NFD, NFKC, NFKD.")
-            });
-        }
-        catch
-        {
-            return new JsValue(value);
-        }
+            // Normalize uses explicit forms; invalid names should raise RangeError.
+            "NFC" => value.Normalize(NormalizationForm.FormC),
+            "NFD" => value.Normalize(NormalizationForm.FormD),
+            "NFKC" => value.Normalize(NormalizationForm.FormKC),
+            "NFKD" => value.Normalize(NormalizationForm.FormKD),
+            _ => throw ThrowRangeError("The normalization form should be one of NFC, NFD, NFKC, NFKD.", realm: Realm)
+        });
     }
 
     [JsHostMethod("matchAll", Length = 1d)]


### PR DESCRIPTION
### Motivation
- Bring `String` builtin behavior into closer compliance with the ECMAScript spec for `fromCodePoint` and `fromCharCode`.
- Ensure invalid code points and malformed inputs produce a `RangeError` instead of being silently ignored or producing generic exceptions.
- Align `fromCharCode` with the `ToUint16` semantics (NaN/Infinity -> +0, then mod 2^16) instead of skipping values.
- Ensure `String.prototype.normalize` raises a `RangeError` for invalid normalization form names rather than swallowing errors.

### Description
- Updated `FromCodePoint` to reject `NaN`, `Infinity`, and non-integer numeric inputs and to throw a `RangeError` via `StandardLibrary.ThrowRangeError` for invalid code points.
- Reworked `FromCharCode` to use a new private helper `ToUint16(double)` which implements the spec `ToUint16` conversion (truncate, wrap modulo 2^16, treat NaN/Infinity as +0).
- Added the `ToUint16` helper method to `StringConstructor` to centralize the conversion logic.
- Replaced the previous try/catch behavior in `StringPrototype.Normalize` with an explicit `RangeError` (`ThrowRangeError`) for unknown normalization form names.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fa3ceac5083289dc1a110efeede82)