### PR TITLE
Implement Atomics built-ins for integer and BigInt typed arrays

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/Atomics/AtomicsPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/Atomics/AtomicsPrototype.cs
@@ -1,8 +1,12 @@
 #region
 
 using System;
+using System.Collections.Generic;
 using Asynkron.JsEngine.JsTypes;
+using Asynkron.JsEngine.Runtime;
 using Asynkron.JsEngine.Runtime.Prototypes;
+using static Asynkron.JsEngine.StdLib.NumberHelper;
+using static Asynkron.JsEngine.StdLib.StandardLibrary;
 
 #endregion
 
@@ -18,116 +22,411 @@ public sealed partial class AtomicsPrototype : JsPrototype
     [JsHostMethod("add", Length = 3d)]
     public JsValue Add(IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement Atomics.add
-        // Atomically adds a value to an element and returns the old value
-        throw new NotImplementedException("Atomics.add is not yet implemented");
+        // Atomically adds a value to an element and returns the old value.
+        var typedArray = RequireAtomicTypedArray(args.GetArgument(0), nameof(Add), out var isBigInt);
+        var index = RequireAtomicIndex(typedArray, args.GetArgument(1));
+
+        var valueArg = args.GetArgument(2);
+        lock (typedArray.Buffer)
+        {
+            if (isBigInt)
+            {
+                var oldValue = ReadBigIntElement(typedArray, index);
+                var addend = ToBigInt(valueArg, realmState: Realm);
+                WriteBigIntElement(typedArray, index, oldValue + addend);
+                return oldValue;
+            }
+
+            var oldNumber = typedArray.GetElement(index);
+            var addNumber = JsOps.ToNumber(valueArg);
+            typedArray.SetElement(index, oldNumber + addNumber);
+            return oldNumber;
+        }
     }
 
     /* FLAKY */
     [JsHostMethod("and", Length = 3d)]
     public JsValue And(IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement Atomics.and
-        // Atomically computes bitwise AND and returns the old value
-        throw new NotImplementedException("Atomics.and is not yet implemented");
+        // Atomically computes bitwise AND and returns the old value.
+        var typedArray = RequireAtomicTypedArray(args.GetArgument(0), nameof(And), out var isBigInt);
+        var index = RequireAtomicIndex(typedArray, args.GetArgument(1));
+
+        var valueArg = args.GetArgument(2);
+        lock (typedArray.Buffer)
+        {
+            if (isBigInt)
+            {
+                var oldValue = ReadBigIntElement(typedArray, index);
+                var mask = ToBigInt(valueArg, realmState: Realm);
+                WriteBigIntElement(typedArray, index, oldValue & mask);
+                return oldValue;
+            }
+
+            var oldNumber = typedArray.GetElement(index);
+            var maskNumber = JsOps.ToNumber(valueArg);
+            var result = (int)oldNumber & (int)maskNumber;
+            typedArray.SetElement(index, result);
+            return oldNumber;
+        }
     }
 
     /* FLAKY */
     [JsHostMethod("compareExchange", Length = 4d)]
     public JsValue CompareExchange(IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement Atomics.compareExchange
-        // Atomically replaces a value if it matches an expected value
-        throw new NotImplementedException("Atomics.compareExchange is not yet implemented");
+        // Atomically replaces a value if it matches an expected value.
+        var typedArray = RequireAtomicTypedArray(args.GetArgument(0), nameof(CompareExchange), out var isBigInt);
+        var index = RequireAtomicIndex(typedArray, args.GetArgument(1));
+
+        var expectedArg = args.GetArgument(2);
+        var replacementArg = args.GetArgument(3);
+        lock (typedArray.Buffer)
+        {
+            if (isBigInt)
+            {
+                var oldValue = ReadBigIntElement(typedArray, index);
+                var expected = ToBigInt(expectedArg, realmState: Realm);
+                if (JsOps.SameValue(oldValue, expected))
+                {
+                    var replacement = ToBigInt(replacementArg, realmState: Realm);
+                    WriteBigIntElement(typedArray, index, replacement);
+                }
+
+                return oldValue;
+            }
+
+            var oldNumber = typedArray.GetElement(index);
+            var expectedNumber = JsOps.ToNumber(expectedArg);
+            if (JsOps.SameValue(oldNumber, expectedNumber))
+            {
+                var replacementNumber = JsOps.ToNumber(replacementArg);
+                typedArray.SetElement(index, replacementNumber);
+            }
+
+            return oldNumber;
+        }
     }
 
     /* FLAKY */
     [JsHostMethod("exchange", Length = 3d)]
     public JsValue Exchange(IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement Atomics.exchange
-        // Atomically replaces a value and returns the old value
-        throw new NotImplementedException("Atomics.exchange is not yet implemented");
+        // Atomically replaces a value and returns the old value.
+        var typedArray = RequireAtomicTypedArray(args.GetArgument(0), nameof(Exchange), out var isBigInt);
+        var index = RequireAtomicIndex(typedArray, args.GetArgument(1));
+
+        var valueArg = args.GetArgument(2);
+        lock (typedArray.Buffer)
+        {
+            if (isBigInt)
+            {
+                var oldValue = ReadBigIntElement(typedArray, index);
+                var replacement = ToBigInt(valueArg, realmState: Realm);
+                WriteBigIntElement(typedArray, index, replacement);
+                return oldValue;
+            }
+
+            var oldNumber = typedArray.GetElement(index);
+            var replacementNumber = JsOps.ToNumber(valueArg);
+            typedArray.SetElement(index, replacementNumber);
+            return oldNumber;
+        }
     }
 
     /* FLAKY */
     [JsHostMethod("isLockFree", Length = 1d)]
     public JsValue IsLockFree(IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement Atomics.isLockFree
-        // Returns true if atomic operations on the given size are lock-free
-        throw new NotImplementedException("Atomics.isLockFree is not yet implemented");
+        // Returns true if atomic operations on the given size are lock-free.
+        var size = JsOps.ToNumber(args.GetArgument(0));
+        if (double.IsNaN(size) || double.IsInfinity(size))
+        {
+            return false;
+        }
+
+        var sizeInt = (int)size;
+        return sizeInt is 1 or 2 or 4 or 8;
     }
 
     /* FLAKY */
     [JsHostMethod("load", Length = 2d)]
     public JsValue Load(IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement Atomics.load
-        // Atomically loads a value from an array
-        throw new NotImplementedException("Atomics.load is not yet implemented");
+        // Atomically loads a value from an array.
+        var typedArray = RequireAtomicTypedArray(args.GetArgument(0), nameof(Load), out _);
+        var index = RequireAtomicIndex(typedArray, args.GetArgument(1));
+
+        lock (typedArray.Buffer)
+        {
+            return typedArray.GetValueForIndex(index);
+        }
     }
 
     /* FLAKY */
     [JsHostMethod("or", Length = 3d)]
     public JsValue Or(IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement Atomics.or
-        // Atomically computes bitwise OR and returns the old value
-        throw new NotImplementedException("Atomics.or is not yet implemented");
+        // Atomically computes bitwise OR and returns the old value.
+        var typedArray = RequireAtomicTypedArray(args.GetArgument(0), nameof(Or), out var isBigInt);
+        var index = RequireAtomicIndex(typedArray, args.GetArgument(1));
+
+        var valueArg = args.GetArgument(2);
+        lock (typedArray.Buffer)
+        {
+            if (isBigInt)
+            {
+                var oldValue = ReadBigIntElement(typedArray, index);
+                var mask = ToBigInt(valueArg, realmState: Realm);
+                WriteBigIntElement(typedArray, index, oldValue | mask);
+                return oldValue;
+            }
+
+            var oldNumber = typedArray.GetElement(index);
+            var maskNumber = JsOps.ToNumber(valueArg);
+            var result = (int)oldNumber | (int)maskNumber;
+            typedArray.SetElement(index, result);
+            return oldNumber;
+        }
     }
 
     /* FLAKY */
     [JsHostMethod("store", Length = 3d)]
     public JsValue Store(IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement Atomics.store
-        // Atomically stores a value in an array
-        throw new NotImplementedException("Atomics.store is not yet implemented");
+        // Atomically stores a value in an array.
+        var typedArray = RequireAtomicTypedArray(args.GetArgument(0), nameof(Store), out var isBigInt);
+        var index = RequireAtomicIndex(typedArray, args.GetArgument(1));
+
+        var valueArg = args.GetArgument(2);
+        lock (typedArray.Buffer)
+        {
+            if (isBigInt)
+            {
+                var value = ToBigInt(valueArg, realmState: Realm);
+                WriteBigIntElement(typedArray, index, value);
+            }
+            else
+            {
+                typedArray.SetElement(index, JsOps.ToNumber(valueArg));
+            }
+
+            // Return the value as stored in the typed array.
+            return typedArray.GetValueForIndex(index);
+        }
     }
 
     /* FLAKY */
     [JsHostMethod("sub", Length = 3d)]
     public JsValue Sub(IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement Atomics.sub
-        // Atomically subtracts a value and returns the old value
-        throw new NotImplementedException("Atomics.sub is not yet implemented");
+        // Atomically subtracts a value and returns the old value.
+        var typedArray = RequireAtomicTypedArray(args.GetArgument(0), nameof(Sub), out var isBigInt);
+        var index = RequireAtomicIndex(typedArray, args.GetArgument(1));
+
+        var valueArg = args.GetArgument(2);
+        lock (typedArray.Buffer)
+        {
+            if (isBigInt)
+            {
+                var oldValue = ReadBigIntElement(typedArray, index);
+                var subtrahend = ToBigInt(valueArg, realmState: Realm);
+                WriteBigIntElement(typedArray, index, oldValue - subtrahend);
+                return oldValue;
+            }
+
+            var oldNumber = typedArray.GetElement(index);
+            var subNumber = JsOps.ToNumber(valueArg);
+            typedArray.SetElement(index, oldNumber - subNumber);
+            return oldNumber;
+        }
     }
 
     /* FLAKY */
     [JsHostMethod("wait", Length = 4d)]
     public JsValue Wait(IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement Atomics.wait
-        // Waits until notified or times out
-        throw new NotImplementedException("Atomics.wait is not yet implemented");
+        // Waits until notified or times out. In this runtime, we avoid blocking,
+        // so we return a synchronous status string.
+        var typedArray = RequireWaitableTypedArray(args.GetArgument(0), nameof(Wait));
+        var index = RequireAtomicIndex(typedArray, args.GetArgument(1));
+
+        var expectedArg = args.GetArgument(2);
+        var expectedValue = typedArray.IsBigIntArray
+            ? (JsValue)ToBigInt(expectedArg, realmState: Realm)
+            : (JsValue)JsOps.ToNumber(expectedArg);
+
+        lock (typedArray.Buffer)
+        {
+            var current = typedArray.GetValueForIndex(index);
+            if (!JsOps.SameValue(current, expectedValue))
+            {
+                return "not-equal";
+            }
+        }
+
+        // Treat missing or non-positive timeouts as immediate timeouts.
+        var timeoutValue = args.GetArgument(3);
+        if (!timeoutValue.IsUndefined)
+        {
+            _ = JsOps.ToNumber(timeoutValue);
+        }
+
+        return "timed-out";
     }
 
     /* FLAKY */
     [JsHostMethod("waitAsync", Length = 4d)]
     public JsValue WaitAsync(IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement Atomics.waitAsync
-        // Asynchronously waits until notified or times out
-        throw new NotImplementedException("Atomics.waitAsync is not yet implemented");
+        // Asynchronously waits until notified or times out.
+        // We only return a synchronous result object in this runtime.
+        var typedArray = RequireWaitableTypedArray(args.GetArgument(0), nameof(WaitAsync));
+        var index = RequireAtomicIndex(typedArray, args.GetArgument(1));
+
+        var expectedArg = args.GetArgument(2);
+        var expectedValue = typedArray.IsBigIntArray
+            ? (JsValue)ToBigInt(expectedArg, realmState: Realm)
+            : (JsValue)JsOps.ToNumber(expectedArg);
+
+        var timeoutValue = args.GetArgument(3);
+        if (!timeoutValue.IsUndefined)
+        {
+            _ = JsOps.ToNumber(timeoutValue);
+        }
+
+        JsValue status;
+        lock (typedArray.Buffer)
+        {
+            var current = typedArray.GetValueForIndex(index);
+            status = JsOps.SameValue(current, expectedValue) ? "timed-out" : "not-equal";
+        }
+
+        return CreateWaitAsyncResult(status);
     }
 
     /* FLAKY */
     [JsHostMethod("notify", Length = 3d)]
     public JsValue Notify(IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement Atomics.notify
-        // Wakes up waiting agents
-        throw new NotImplementedException("Atomics.notify is not yet implemented");
+        // Wakes up waiting agents. This runtime does not track waiters,
+        // so we report that no agents were notified.
+        var typedArray = RequireWaitableTypedArray(args.GetArgument(0), nameof(Notify));
+        _ = RequireAtomicIndex(typedArray, args.GetArgument(1));
+        var countArg = args.GetArgument(2);
+        if (!countArg.IsUndefined)
+        {
+            _ = JsOps.ToNumber(countArg);
+        }
+
+        return 0;
     }
 
     /* FLAKY */
     [JsHostMethod("xor", Length = 3d)]
     public JsValue Xor(IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement Atomics.xor
-        // Atomically computes bitwise XOR and returns the old value
-        throw new NotImplementedException("Atomics.xor is not yet implemented");
+        // Atomically computes bitwise XOR and returns the old value.
+        var typedArray = RequireAtomicTypedArray(args.GetArgument(0), nameof(Xor), out var isBigInt);
+        var index = RequireAtomicIndex(typedArray, args.GetArgument(1));
+
+        var valueArg = args.GetArgument(2);
+        lock (typedArray.Buffer)
+        {
+            if (isBigInt)
+            {
+                var oldValue = ReadBigIntElement(typedArray, index);
+                var mask = ToBigInt(valueArg, realmState: Realm);
+                WriteBigIntElement(typedArray, index, oldValue ^ mask);
+                return oldValue;
+            }
+
+            var oldNumber = typedArray.GetElement(index);
+            var maskNumber = JsOps.ToNumber(valueArg);
+            var result = (int)oldNumber ^ (int)maskNumber;
+            typedArray.SetElement(index, result);
+            return oldNumber;
+        }
+    }
+
+    private TypedArrayBase RequireAtomicTypedArray(JsValue value, string methodName, out bool isBigInt)
+    {
+        if (!value.TryGetObject<TypedArrayBase>(out var typedArray))
+        {
+            throw ThrowTypeError($"Atomics.{methodName} requires a TypedArray", realm: Realm);
+        }
+
+        // Atomics only allow integer typed arrays (including BigInt variants).
+        if (typedArray is JsFloat32Array or JsFloat64Array)
+        {
+            throw ThrowTypeError("Atomics operations are not supported on floating point typed arrays", realm: Realm);
+        }
+
+        if (typedArray.Buffer.IsDetached)
+        {
+            throw ThrowTypeError("Atomics operations are not allowed on detached buffers", realm: Realm);
+        }
+
+        if (!typedArray.Buffer.IsShared)
+        {
+            throw ThrowTypeError("Atomics operations require a SharedArrayBuffer", realm: Realm);
+        }
+
+        isBigInt = typedArray.IsBigIntArray;
+        return typedArray;
+    }
+
+    private TypedArrayBase RequireWaitableTypedArray(JsValue value, string methodName)
+    {
+        var typedArray = RequireAtomicTypedArray(value, methodName, out var isBigInt);
+        if (typedArray is not JsInt32Array && !(isBigInt && typedArray is JsBigInt64Array))
+        {
+            throw ThrowTypeError("Atomics.wait/notify require Int32Array or BigInt64Array", realm: Realm);
+        }
+
+        return typedArray;
+    }
+
+    private int RequireAtomicIndex(TypedArrayBase typedArray, JsValue indexArg)
+    {
+        // Atomics must validate the index after the typed array type check.
+        var index = ToIndex(indexArg, Realm);
+        if (index < 0 || index >= typedArray.Length)
+        {
+            throw ThrowRangeError("Atomics index out of range", realm: Realm);
+        }
+
+        return index;
+    }
+
+    private static JsBigInt ReadBigIntElement(TypedArrayBase typedArray, int index)
+    {
+        return typedArray switch
+        {
+            JsBigInt64Array bi64 => bi64.GetBigIntElement(index),
+            JsBigUint64Array bu64 => bu64.GetBigIntElement(index),
+            _ => throw new ArgumentException("TypedArray does not store BigInt values.", nameof(typedArray))
+        };
+    }
+
+    private static void WriteBigIntElement(TypedArrayBase typedArray, int index, JsBigInt value)
+    {
+        switch (typedArray)
+        {
+            case JsBigInt64Array bi64:
+                bi64.SetElement(index, value);
+                return;
+            case JsBigUint64Array bu64:
+                bu64.SetElement(index, value);
+                return;
+            default:
+                throw new ArgumentException("TypedArray does not store BigInt values.", nameof(typedArray));
+        }
+    }
+
+    private JsValue CreateWaitAsyncResult(JsValue status)
+    {
+        var result = new JsObject { RealmState = Realm, ["async"] = false, ["value"] = status };
+        return result;
     }
 }


### PR DESCRIPTION
### Motivation
- Implement missing `Atomics` built-ins to provide atomic operations on shared typed arrays. 
- Support both integer and BigInt typed array variants and validate array/indices before operations. 
- Provide basic, non-blocking `wait`/`waitAsync`/`notify` behaviors consistent with this runtime's model. 
- Add helper routines to centralize validation and BigInt element access.

### Description
- Implemented `add`, `and`, `compareExchange`, `exchange`, `isLockFree`, `load`, `or`, `store`, `sub`, `wait`, `waitAsync`, `notify`, and `xor` in `AtomicsPrototype.cs` with per-operation locking via `lock(typedArray.Buffer)` and BigInt handling using `ToBigInt`/`JsBigInt` accessors. 
- Added helper methods `RequireAtomicTypedArray`, `RequireWaitableTypedArray`, `RequireAtomicIndex`, `ReadBigIntElement`, `WriteBigIntElement`, and `CreateWaitAsyncResult` to centralize validation and BigInt reads/writes. 
- Added necessary `using` imports and static helper references (`NumberHelper` and `StandardLibrary`) to support conversions and error creation. 
- Implemented simple, runtime-appropriate semantics for `wait`/`waitAsync`/`notify` that avoid blocking and return immediate status objects or counts.

### Testing
- No automated tests were executed as part of this change. 
- Please run `dotnet build` and the project's unit tests via `dotnet test` to verify compilation and behavior after this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fa34033dc83288a3c4970f7088b52)