### PR TITLE
Implement Date.prototype.toTemporalInstant and @@toPrimitive with tests

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/Date/DatePrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/Date/DatePrototype.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using Asynkron.JsEngine.JsTypes;
 using Asynkron.JsEngine.Runtime;
 using Asynkron.JsEngine.Runtime.Prototypes;
+using Asynkron.JsEngine.StdLib.Temporal;
 using static Asynkron.JsEngine.StdLib.StandardLibrary;
 using static Asynkron.JsEngine.StdLib.DateHelper;
 
@@ -554,10 +555,71 @@ public sealed partial class DatePrototype
     [JsHostMethod("toTemporalInstant", Length = 0d)]
     public JsValue ToTemporalInstant(JsValue thisValue)
     {
-        // TODO: Implement Date.prototype.toTemporalInstant
-        // This method converts a Date to a Temporal.Instant
-        // Requires Temporal API implementation
-        throw new NotImplementedException("Date.prototype.toTemporalInstant is not yet implemented");
+        var timeValue = RequireDateValue(thisValue, Realm, out _);
+        if (double.IsNaN(timeValue) || double.IsInfinity(timeValue))
+        {
+            throw ThrowRangeError("Invalid time value", realm: Realm);
+        }
+
+        // Date -> Temporal.Instant is millisecond-based, so wrap the epoch milliseconds directly.
+        return TemporalHelper.CreateInstantFromEpochMilliseconds(Realm, timeValue);
+    }
+
+    [JsSymbolMethod("toPrimitive", Length = 1d)]
+    public JsValue ToPrimitive(JsValue thisValue, IReadOnlyList<JsValue> args)
+    {
+        RequireDateValue(thisValue, Realm, out var obj);
+
+        if (!args.GetArgument(0).TryGetString(out var hint))
+        {
+            throw ThrowTypeError("Cannot convert object to primitive value", realm: Realm);
+        }
+
+        // Date prefers string conversion for the "default" hint.
+        var preferString = hint is "string" or "default";
+        if (!preferString && hint != "number")
+        {
+            throw ThrowTypeError("Cannot convert object to primitive value", realm: Realm);
+        }
+
+        if (preferString)
+        {
+            if (TryInvokeAndReturnPrimitive(obj, "toString", out var result) ||
+                TryInvokeAndReturnPrimitive(obj, "valueOf", out result))
+            {
+                return result;
+            }
+        }
+        else
+        {
+            if (TryInvokeAndReturnPrimitive(obj, "valueOf", out var result) ||
+                TryInvokeAndReturnPrimitive(obj, "toString", out result))
+            {
+                return result;
+            }
+        }
+
+        throw ThrowTypeError("Cannot convert object to primitive value", realm: Realm);
+    }
+
+    private static bool TryInvokeAndReturnPrimitive(JsObject obj, string methodName, out JsValue result)
+    {
+        result = JsValue.Undefined;
+        if (!obj.TryGetProperty(methodName, out var method) ||
+            !method.TryGetObject<IJsCallable>(out var callable))
+        {
+            return false;
+        }
+
+        // Follow OrdinaryToPrimitive: only return if the result is not an object.
+        var value = callable.Invoke([], new JsValue(obj));
+        if (value.IsObject)
+        {
+            return false;
+        }
+
+        result = value;
+        return true;
     }
 
     protected override void ConfigurePrototype()

--- a/src/Asynkron.JsEngine/StdLib/Temporal/TemporalHelper.cs
+++ b/src/Asynkron.JsEngine/StdLib/Temporal/TemporalHelper.cs
@@ -1537,6 +1537,14 @@ public static class TemporalHelper
 
     #region Wrapper methods
 
+    internal static JsValue CreateInstantFromEpochMilliseconds(RealmState realm, double epochMilliseconds)
+    {
+        // Date-based conversions are millisecond-precision, so truncate before wrapping.
+        var instant = JsTemporalInstant.FromEpochMilliseconds((long)Math.Truncate(epochMilliseconds));
+        var prototypes = GetPrototypes(realm);
+        return WrapInstant(instant, realm, prototypes.InstantPrototype);
+    }
+
     private static JsValue WrapInstant(JsTemporalInstant instant, RealmState realm, JsObject? prototype = null)
     {
         var obj = new JsObject(prototype ?? realm.ObjectPrototype);

--- a/tests/Asynkron.JsEngine.Tests/JsEvaluatorTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/JsEvaluatorTests.cs
@@ -1870,6 +1870,46 @@ public abstract class JsEvaluatorTestsBase(ITestOutputHelper output) : FastPathT
     }
 
     [Fact(Timeout = 2000)]
+    public async Task DateToTemporalInstantReturnsEpochMilliseconds()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+
+                                           // Use a fixed epoch to keep the assertion stable.
+                                           let d = new Date(0);
+                                           d.toTemporalInstant().epochMilliseconds;
+
+                                           """);
+        Assert.Equal(0d, result);
+    }
+
+    [Fact(Timeout = 2000)]
+    public async Task DateToPrimitiveUsesStringForDefaultHint()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+
+                                           let d = new Date(0);
+                                           typeof d[Symbol.toPrimitive]("default");
+
+                                           """);
+        Assert.Equal("string", result);
+    }
+
+    [Fact(Timeout = 2000)]
+    public async Task DateToPrimitiveUsesNumberForNumberHint()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+
+                                           let d = new Date(0);
+                                           d[Symbol.toPrimitive]("number");
+
+                                           """);
+        Assert.Equal(0d, result);
+    }
+
+    [Fact(Timeout = 2000)]
     public async Task JsonParseHandlesObject()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
### Motivation

- Provide `Date.prototype.toTemporalInstant` so Date objects can be converted to `Temporal.Instant` wrappers with millisecond precision.
- Implement the Date `@@toPrimitive` behavior to follow the ECMAScript ordinary-to-primitive rules (Date prefers string for the "default" hint).
- Expose a helper to create Temporal.Instant objects from epoch milliseconds to centralize wrapping logic.
- Add unit tests that validate the new temporal conversion and primitive hint behavior.

### Description

- Added `TemporalHelper.CreateInstantFromEpochMilliseconds(RealmState, double)` which truncates to milliseconds and wraps a `JsTemporalInstant` into a JS object.
- Implemented `DatePrototype.ToTemporalInstant` to validate the internal date value and return a `Temporal.Instant` via the new helper.
- Implemented `Date` `Symbol.toPrimitive` handler and helper `TryInvokeAndReturnPrimitive` that follow the string/number hint ordering and only accept non-object primitive results.
- Added three tests in `JsEvaluatorTests.cs`: `DateToTemporalInstantReturnsEpochMilliseconds`, `DateToPrimitiveUsesStringForDefaultHint`, and `DateToPrimitiveUsesNumberForNumberHint`.

### Testing

- Attempted to run the targeted tests with `dotnet test tests/Asynkron.JsEngine.Tests --filter "Name~DateToTemporalInstantReturnsEpochMilliseconds|Name~DateToPrimitiveUsesStringForDefaultHint|Name~DateToPrimitiveUsesNumberForNumberHint"` but the environment does not have `dotnet` available, so the tests could not be executed.
- No automated tests were run successfully in this environment due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fa32b6c9483289af8c9802232ec0d)