### PR TITLE
DataView: throw RangeError on OOB and fix BigInt64/BigUint64 conversions

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/DataView/DataViewPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/DataView/DataViewPrototype.cs
@@ -1,6 +1,7 @@
 #region
 
 using System;
+using System.Numerics;
 using Asynkron.JsEngine.JsTypes;
 using Asynkron.JsEngine.Runtime;
 using Asynkron.JsEngine.Runtime.Prototypes;
@@ -39,7 +40,7 @@ public sealed partial class DataViewPrototype
     {
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
-        return (double)dv.GetInt8(offset);
+        return WithRangeError(() => (double)dv.GetInt8(offset));
     }
 
     [JsHostMethod("setInt8", Length = 2d)]
@@ -48,8 +49,11 @@ public sealed partial class DataViewPrototype
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var value = args.Count > 1 ? (sbyte)(int)JsOps.ToNumber(args[1]) : (sbyte)0;
-        dv.SetInt8(offset, value);
-        return JsValue.Undefined;
+        return WithRangeError(() =>
+        {
+            dv.SetInt8(offset, value);
+            return JsValue.Undefined;
+        });
     }
 
     [JsHostMethod("getUint8", Length = 1d)]
@@ -57,7 +61,7 @@ public sealed partial class DataViewPrototype
     {
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
-        return (double)dv.GetUint8(offset);
+        return WithRangeError(() => (double)dv.GetUint8(offset));
     }
 
     [JsHostMethod("setUint8", Length = 2d)]
@@ -66,8 +70,11 @@ public sealed partial class DataViewPrototype
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var value = args.Count > 1 ? (byte)(int)JsOps.ToNumber(args[1]) : (byte)0;
-        dv.SetUint8(offset, value);
-        return JsValue.Undefined;
+        return WithRangeError(() =>
+        {
+            dv.SetUint8(offset, value);
+            return JsValue.Undefined;
+        });
     }
 
     [JsHostMethod("getInt16", Length = 1d)]
@@ -76,7 +83,7 @@ public sealed partial class DataViewPrototype
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var littleEndian = args.Count > 1 && args[1].IsTruthy;
-        return (double)dv.GetInt16(offset, littleEndian);
+        return WithRangeError(() => (double)dv.GetInt16(offset, littleEndian));
     }
 
     [JsHostMethod("setInt16", Length = 2d)]
@@ -86,8 +93,11 @@ public sealed partial class DataViewPrototype
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var value = args.Count > 1 ? (short)(int)JsOps.ToNumber(args[1]) : (short)0;
         var littleEndian = args.Count > 2 && args[2].IsTruthy;
-        dv.SetInt16(offset, value, littleEndian);
-        return JsValue.Undefined;
+        return WithRangeError(() =>
+        {
+            dv.SetInt16(offset, value, littleEndian);
+            return JsValue.Undefined;
+        });
     }
 
     [JsHostMethod("getUint16", Length = 1d)]
@@ -96,7 +106,7 @@ public sealed partial class DataViewPrototype
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var littleEndian = args.Count > 1 && args[1].IsTruthy;
-        return (double)dv.GetUint16(offset, littleEndian);
+        return WithRangeError(() => (double)dv.GetUint16(offset, littleEndian));
     }
 
     [JsHostMethod("setUint16", Length = 2d)]
@@ -106,8 +116,11 @@ public sealed partial class DataViewPrototype
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var value = args.Count > 1 ? (ushort)(int)JsOps.ToNumber(args[1]) : (ushort)0;
         var littleEndian = args.Count > 2 && args[2].IsTruthy;
-        dv.SetUint16(offset, value, littleEndian);
-        return JsValue.Undefined;
+        return WithRangeError(() =>
+        {
+            dv.SetUint16(offset, value, littleEndian);
+            return JsValue.Undefined;
+        });
     }
 
     [JsHostMethod("getInt32", Length = 1d)]
@@ -116,7 +129,7 @@ public sealed partial class DataViewPrototype
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var littleEndian = args.Count > 1 && args[1].IsTruthy;
-        return (double)dv.GetInt32(offset, littleEndian);
+        return WithRangeError(() => (double)dv.GetInt32(offset, littleEndian));
     }
 
     [JsHostMethod("setInt32", Length = 2d)]
@@ -126,8 +139,11 @@ public sealed partial class DataViewPrototype
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var value = args.Count > 1 ? (int)JsOps.ToNumber(args[1]) : 0;
         var littleEndian = args.Count > 2 && args[2].IsTruthy;
-        dv.SetInt32(offset, value, littleEndian);
-        return JsValue.Undefined;
+        return WithRangeError(() =>
+        {
+            dv.SetInt32(offset, value, littleEndian);
+            return JsValue.Undefined;
+        });
     }
 
     [JsHostMethod("getUint32", Length = 1d)]
@@ -136,7 +152,7 @@ public sealed partial class DataViewPrototype
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var littleEndian = args.Count > 1 && args[1].IsTruthy;
-        return (double)dv.GetUint32(offset, littleEndian);
+        return WithRangeError(() => (double)dv.GetUint32(offset, littleEndian));
     }
 
     [JsHostMethod("setUint32", Length = 2d)]
@@ -146,8 +162,11 @@ public sealed partial class DataViewPrototype
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var value = args.Count > 1 ? (uint)JsOps.ToNumber(args[1]) : 0u;
         var littleEndian = args.Count > 2 && args[2].IsTruthy;
-        dv.SetUint32(offset, value, littleEndian);
-        return JsValue.Undefined;
+        return WithRangeError(() =>
+        {
+            dv.SetUint32(offset, value, littleEndian);
+            return JsValue.Undefined;
+        });
     }
 
     [JsHostMethod("getFloat32", Length = 1d)]
@@ -156,7 +175,7 @@ public sealed partial class DataViewPrototype
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var littleEndian = args.Count > 1 && args[1].IsTruthy;
-        return (double)dv.GetFloat32(offset, littleEndian);
+        return WithRangeError(() => (double)dv.GetFloat32(offset, littleEndian));
     }
 
     [JsHostMethod("setFloat32", Length = 2d)]
@@ -166,8 +185,11 @@ public sealed partial class DataViewPrototype
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var value = args.Count > 1 ? (float)JsOps.ToNumber(args[1]) : 0f;
         var littleEndian = args.Count > 2 && args[2].IsTruthy;
-        dv.SetFloat32(offset, value, littleEndian);
-        return JsValue.Undefined;
+        return WithRangeError(() =>
+        {
+            dv.SetFloat32(offset, value, littleEndian);
+            return JsValue.Undefined;
+        });
     }
 
     [JsHostMethod("getFloat64", Length = 1d)]
@@ -176,7 +198,7 @@ public sealed partial class DataViewPrototype
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var littleEndian = args.Count > 1 && args[1].IsTruthy;
-        return dv.GetFloat64(offset, littleEndian);
+        return WithRangeError(() => dv.GetFloat64(offset, littleEndian));
     }
 
     [JsHostMethod("setFloat64", Length = 2d)]
@@ -186,8 +208,11 @@ public sealed partial class DataViewPrototype
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var value = args.Count > 1 ? JsOps.ToNumber(args[1]) : 0.0;
         var littleEndian = args.Count > 2 && args[2].IsTruthy;
-        dv.SetFloat64(offset, value, littleEndian);
-        return JsValue.Undefined;
+        return WithRangeError(() =>
+        {
+            dv.SetFloat64(offset, value, littleEndian);
+            return JsValue.Undefined;
+        });
     }
 
     [JsHostMethod("getBigInt64", Length = 1d)]
@@ -196,9 +221,12 @@ public sealed partial class DataViewPrototype
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var littleEndian = args.Count > 1 && args[1].IsTruthy;
-        var value = dv.GetBigInt64(offset, littleEndian);
-        // Convert to BigInt JsValue
-        return JsValue.FromObjectUnsafe(new JsBigInt(value));
+        return WithRangeError(() =>
+        {
+            var value = dv.GetBigInt64(offset, littleEndian);
+            // Convert to BigInt JsValue for JavaScript BigInt semantics.
+            return JsValue.FromObjectUnsafe(new JsBigInt(value));
+        });
     }
 
     [JsHostMethod("getBigUint64", Length = 1d)]
@@ -207,9 +235,12 @@ public sealed partial class DataViewPrototype
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var littleEndian = args.Count > 1 && args[1].IsTruthy;
-        var value = dv.GetBigUint64(offset, littleEndian);
-        // Convert to BigInt JsValue - cast ulong to long for BigInt constructor
-        return JsValue.FromObjectUnsafe(new JsBigInt((long)value));
+        return WithRangeError(() =>
+        {
+            var value = dv.GetBigUint64(offset, littleEndian);
+            // Preserve full unsigned range by constructing BigInteger directly.
+            return JsValue.FromObjectUnsafe(new JsBigInt(new BigInteger(value)));
+        });
     }
 
     [JsHostMethod("getFloat16", Length = 1d)]
@@ -218,9 +249,12 @@ public sealed partial class DataViewPrototype
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var littleEndian = args.Count > 1 && args[1].IsTruthy;
-        var value = dv.GetFloat16(offset, littleEndian);
-        // Convert Half to double for JavaScript
-        return (double)value;
+        return WithRangeError(() =>
+        {
+            var value = dv.GetFloat16(offset, littleEndian);
+            // Convert Half to double for JavaScript.
+            return (double)value;
+        });
     }
 
     [JsHostMethod("setBigInt64", Length = 2d)]
@@ -228,17 +262,15 @@ public sealed partial class DataViewPrototype
     {
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
-        
-        // Extract BigInt value
-        long value = 0;
-        if (args.Count > 1 && args[1].TryGetObject<JsBigInt>(out var bigInt) && bigInt is not null)
-        {
-            value = (long)bigInt.Value;
-        }
-        
+
+        // Convert to BigInt and wrap to signed 64-bit as the spec expects.
+        var value = args.Count > 1 ? ToBigInt64(ToBigInt(args[1], realmState: Realm).Value) : 0L;
         var littleEndian = args.Count > 2 && args[2].IsTruthy;
-        dv.SetBigInt64(offset, value, littleEndian);
-        return JsValue.Undefined;
+        return WithRangeError(() =>
+        {
+            dv.SetBigInt64(offset, value, littleEndian);
+            return JsValue.Undefined;
+        });
     }
 
     [JsHostMethod("setBigUint64", Length = 2d)]
@@ -246,17 +278,15 @@ public sealed partial class DataViewPrototype
     {
         var dv = RequireInstance(thisValue);
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
-        
-        // Extract BigInt value
-        ulong value = 0;
-        if (args.Count > 1 && args[1].TryGetObject<JsBigInt>(out var bigInt) && bigInt is not null)
-        {
-            value = (ulong)bigInt.Value;
-        }
-        
+
+        // Convert to BigInt and wrap to unsigned 64-bit as the spec expects.
+        var value = args.Count > 1 ? ToBigUint64(ToBigInt(args[1], realmState: Realm).Value) : 0UL;
         var littleEndian = args.Count > 2 && args[2].IsTruthy;
-        dv.SetBigUint64(offset, value, littleEndian);
-        return JsValue.Undefined;
+        return WithRangeError(() =>
+        {
+            dv.SetBigUint64(offset, value, littleEndian);
+            return JsValue.Undefined;
+        });
     }
 
     [JsHostMethod("setFloat16", Length = 2d)]
@@ -266,8 +296,11 @@ public sealed partial class DataViewPrototype
         var offset = args.Count > 0 ? (int)JsOps.ToNumber(args[0]) : 0;
         var value = args.Count > 1 ? (Half)JsOps.ToNumber(args[1]) : (Half)0;
         var littleEndian = args.Count > 2 && args[2].IsTruthy;
-        dv.SetFloat16(offset, value, littleEndian);
-        return JsValue.Undefined;
+        return WithRangeError(() =>
+        {
+            dv.SetFloat16(offset, value, littleEndian);
+            return JsValue.Undefined;
+        });
     }
 
     protected override void ConfigurePrototype()
@@ -278,5 +311,18 @@ public sealed partial class DataViewPrototype
         }
 
         Realm.DataViewPrototype ??= Prototype as JsObject;
+    }
+
+    private JsValue WithRangeError(Func<JsValue> action)
+    {
+        try
+        {
+            return action();
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // Align with JS: DataView bounds checks throw RangeError.
+            throw ThrowRangeError("Offset is outside the bounds of the DataView", realm: Realm);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Align `DataView` get/set behavior with the JavaScript spec by converting .NET `ArgumentOutOfRangeException` into a JS `RangeError` for out-of-bounds access. 
- Preserve full unsigned ranges when converting `BigUint64` values to JavaScript `BigInt`. 
- Ensure `BigInt64`/`BigUint64` set paths correctly convert incoming JS `BigInt` values and wrap to 64-bit signed/unsigned as the spec expects. 
- Improve clarity with concise in-code comments for conversion and bounds handling.

### Description
- Added `using System.Numerics;` and introduced a helper `WithRangeError(Func<JsValue>)` that catches `ArgumentOutOfRangeException` and rethrows a JS `RangeError` via `ThrowRangeError`. 
- Wrapped all `DataView` `get*` and `set*` implementations in `WithRangeError` so out-of-bounds .NET exceptions map to JS `RangeError`. 
- Changed `GetBigUint64` to construct a `JsBigInt` from `BigInteger` to preserve the full unsigned 64-bit range, and updated `GetBigInt64` to use the same bounds-wrapped pattern. 
- Reworked `SetBigInt64` and `SetBigUint64` to use `ToBigInt(...)` plus `ToBigInt64`/`ToBigUint64` helpers (with `realm`) and to perform the write inside `WithRangeError`.

### Testing
- No automated tests were executed as part of this change. 
- Changes were staged and committed locally with the message `Improve DataView BigInt conversions and bounds errors`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fa36e76c083288d1691af013f1219)