### PR TITLE
Add Map/Set iterator types and generic iterable support

### DIFF
--- a/src/Asynkron.JsEngine/JsTypes/JsMapIterator.cs
+++ b/src/Asynkron.JsEngine/JsTypes/JsMapIterator.cs
@@ -1,0 +1,111 @@
+#region
+
+using Asynkron.JsEngine.Runtime;
+
+#endregion
+
+namespace Asynkron.JsEngine.JsTypes;
+
+internal sealed class JsMapIterator : IJsObjectLike, IAsJsValue, IPrototypeAccessorProvider
+{
+    private readonly JsMap _map;
+    private readonly MapIterationKind _kind;
+    private readonly RealmState _realm;
+    private readonly JsObject _properties = new();
+    private JsValue _cachedJsValue;
+    private int _index;
+    private bool _done;
+
+    internal JsMapIterator(JsMap map, MapIterationKind kind, RealmState realm, JsObject? prototype)
+    {
+        _map = map;
+        _kind = kind;
+        _realm = realm;
+        _properties.RealmState = realm;
+        if (prototype is not null)
+        {
+            _properties.SetPrototype(prototype);
+        }
+
+        _cachedJsValue = new JsValue(JsValueKind.Object, 0.0, this);
+    }
+
+    public ref readonly JsValue AsJsValue => ref _cachedJsValue;
+
+    internal JsValue Next()
+    {
+        if (_done)
+        {
+            return IteratorResultObject.DoneUndefined.AsJsValue;
+        }
+
+        if (_index >= _map.EntryCount)
+        {
+            _done = true;
+            return IteratorResultObject.DoneUndefined.AsJsValue;
+        }
+
+        var entry = _map.GetEntry(_index++);
+        var key = JsValue.FromObjectUnsafe(entry.Key);
+        var value = entry.Value;
+
+        var result = _kind switch
+        {
+            MapIterationKind.Keys => key,
+            MapIterationKind.Values => value,
+            _ => CreateEntryPair(key, value)
+        };
+
+        return IteratorResultObject.Create(result, false);
+    }
+
+    private JsValue CreateEntryPair(JsValue key, JsValue value)
+    {
+        var pair = new JsArray(_realm);
+        pair.SetElement(0, key);
+        pair.SetElement(1, value);
+        return JsValue.FromJsArray(pair);
+    }
+
+    public JsObject? Prototype => _properties.Prototype;
+    public bool IsSealed => _properties.IsSealed;
+    public bool IsFrozen => _properties.IsFrozen;
+    IEnumerable<string> IJsObjectLike.Keys => _properties.Keys;
+
+    public IJsPropertyAccessor? PrototypeAccessor =>
+        _properties is IPrototypeAccessorProvider provider ? provider.PrototypeAccessor : null;
+
+    public bool TryGetProperty(string name, out JsValue value) =>
+        _properties.TryGetProperty(name, _cachedJsValue, out value);
+
+    public bool TryGetProperty(string name, JsValue receiver, out JsValue value) =>
+        _properties.TryGetProperty(name, receiver, out value);
+
+    public void SetProperty(string name, JsValue value) =>
+        _properties.SetProperty(name, value, _cachedJsValue);
+
+    public void SetProperty(string name, JsValue value, JsValue receiver) =>
+        _properties.SetProperty(name, value, receiver);
+
+    public PropertyDescriptor? GetOwnPropertyDescriptor(string name) =>
+        _properties.GetOwnPropertyDescriptor(name);
+
+    public IEnumerable<string> GetOwnPropertyNames() =>
+        _properties.GetOwnPropertyNames();
+
+    public IEnumerable<string> GetEnumerablePropertyNames() =>
+        _properties.GetEnumerablePropertyNames();
+
+    public IEnumerable<string> GetOwnPropertyKeysInOrder(bool includeSymbols = true, bool includeNonEnumerable = true) =>
+        _properties.GetOwnPropertyKeysInOrder(includeSymbols, includeNonEnumerable);
+
+    public void DefineProperty(string name, PropertyDescriptor descriptor) =>
+        _properties.DefineProperty(name, descriptor);
+
+    public void SetPrototype(IJsPropertyAccessor? candidate) =>
+        _properties.SetPrototype(candidate);
+
+    public void Seal() => _properties.Seal();
+
+    public bool Delete(string name) => _properties.DeleteOwnProperty(name);
+}

--- a/src/Asynkron.JsEngine/JsTypes/JsSetIterator.cs
+++ b/src/Asynkron.JsEngine/JsTypes/JsSetIterator.cs
@@ -1,0 +1,102 @@
+#region
+
+using Asynkron.JsEngine.Runtime;
+
+#endregion
+
+namespace Asynkron.JsEngine.JsTypes;
+
+internal sealed class JsSetIterator : IJsObjectLike, IAsJsValue, IPrototypeAccessorProvider
+{
+    private readonly JsSet _set;
+    private readonly SetIterationKind _kind;
+    private readonly RealmState _realm;
+    private readonly JsObject _properties = new();
+    private JsValue _cachedJsValue;
+    private int _index;
+    private bool _done;
+
+    internal JsSetIterator(JsSet set, SetIterationKind kind, RealmState realm, JsObject? prototype)
+    {
+        _set = set;
+        _kind = kind;
+        _realm = realm;
+        _properties.RealmState = realm;
+        if (prototype is not null)
+        {
+            _properties.SetPrototype(prototype);
+        }
+
+        _cachedJsValue = new JsValue(JsValueKind.Object, 0.0, this);
+    }
+
+    public ref readonly JsValue AsJsValue => ref _cachedJsValue;
+
+    internal JsValue Next()
+    {
+        if (_done)
+        {
+            return IteratorResultObject.DoneUndefined.AsJsValue;
+        }
+
+        if (_index >= _set.ValueCount)
+        {
+            _done = true;
+            return IteratorResultObject.DoneUndefined.AsJsValue;
+        }
+
+        var value = _set.GetValue(_index++);
+        var result = _kind == SetIterationKind.Entries ? CreateEntryPair(value) : value;
+        return IteratorResultObject.Create(result, false);
+    }
+
+    private JsValue CreateEntryPair(JsValue value)
+    {
+        var pair = new JsArray(_realm);
+        pair.SetElement(0, value);
+        pair.SetElement(1, value);
+        return JsValue.FromJsArray(pair);
+    }
+
+    public JsObject? Prototype => _properties.Prototype;
+    public bool IsSealed => _properties.IsSealed;
+    public bool IsFrozen => _properties.IsFrozen;
+    IEnumerable<string> IJsObjectLike.Keys => _properties.Keys;
+
+    public IJsPropertyAccessor? PrototypeAccessor =>
+        _properties is IPrototypeAccessorProvider provider ? provider.PrototypeAccessor : null;
+
+    public bool TryGetProperty(string name, out JsValue value) =>
+        _properties.TryGetProperty(name, _cachedJsValue, out value);
+
+    public bool TryGetProperty(string name, JsValue receiver, out JsValue value) =>
+        _properties.TryGetProperty(name, receiver, out value);
+
+    public void SetProperty(string name, JsValue value) =>
+        _properties.SetProperty(name, value, _cachedJsValue);
+
+    public void SetProperty(string name, JsValue value, JsValue receiver) =>
+        _properties.SetProperty(name, value, receiver);
+
+    public PropertyDescriptor? GetOwnPropertyDescriptor(string name) =>
+        _properties.GetOwnPropertyDescriptor(name);
+
+    public IEnumerable<string> GetOwnPropertyNames() =>
+        _properties.GetOwnPropertyNames();
+
+    public IEnumerable<string> GetEnumerablePropertyNames() =>
+        _properties.GetEnumerablePropertyNames();
+
+    public IEnumerable<string> GetOwnPropertyKeysInOrder(bool includeSymbols = true, bool includeNonEnumerable = true) =>
+        _properties.GetOwnPropertyKeysInOrder(includeSymbols, includeNonEnumerable);
+
+    public void DefineProperty(string name, PropertyDescriptor descriptor) =>
+        _properties.DefineProperty(name, descriptor);
+
+    public void SetPrototype(IJsPropertyAccessor? candidate) =>
+        _properties.SetPrototype(candidate);
+
+    public void Seal() => _properties.Seal();
+
+    public bool Delete(string name) => _properties.DeleteOwnProperty(name);
+}

--- a/src/Asynkron.JsEngine/JsTypes/MapSetIterationKind.cs
+++ b/src/Asynkron.JsEngine/JsTypes/MapSetIterationKind.cs
@@ -1,0 +1,18 @@
+#region
+
+#endregion
+
+namespace Asynkron.JsEngine.JsTypes;
+
+internal enum MapIterationKind
+{
+    Entries,
+    Keys,
+    Values
+}
+
+internal enum SetIterationKind
+{
+    Entries,
+    Values
+}

--- a/src/Asynkron.JsEngine/Runtime/RealmState.cs
+++ b/src/Asynkron.JsEngine/Runtime/RealmState.cs
@@ -59,7 +59,9 @@ public sealed class RealmState
     public JsObject? BigIntPrototype { get; set; }
     public JsObject? SymbolPrototype { get; set; }
     public JsObject? MapPrototype { get; set; }
+    public JsObject? MapIteratorPrototype { get; set; }
     public JsObject? SetPrototype { get; set; }
+    public JsObject? SetIteratorPrototype { get; set; }
     public JsObject? WeakMapPrototype { get; set; }
     public JsObject? WeakSetPrototype { get; set; }
     public HostFunction? ArrayConstructor { get; set; }

--- a/src/Asynkron.JsEngine/StdLib/MapSet/MapConstructor.cs
+++ b/src/Asynkron.JsEngine/StdLib/MapSet/MapConstructor.cs
@@ -53,28 +53,31 @@ public sealed partial class MapConstructor(IJsObjectLike prototype, RealmState r
         var proto = ResolveConstructPrototype(newTarget, targetCtor, Realm) ?? Prototype;
         var instance = new JsMap();
         instance.SetPrototype(proto);
-        PopulateMap(instance, args);
+        PopulateMap(instance, args, Realm);
         return instance;
     }
 
-    private static void PopulateMap(JsMap map, IReadOnlyList<JsValue> args)
+    [JsConstructorSymbolGetter("species")]
+    public static JsValue GetSpecies(JsValue thisValue)
+    {
+        return thisValue;
+    }
+
+    private static void PopulateMap(JsMap map, IReadOnlyList<JsValue> args, RealmState realm)
     {
         if (args.Count == 0 || args[0].IsNull || args[0].IsUndefined)
         {
             return;
         }
 
-        if (!args[0].TryGetObject<JsArray>(out var entries))
-        {
-            return;
-        }
-
-        foreach (var entry in entries.Items)
+        MapSetIterationHelper.Iterate(args[0], realm, "Map constructor", entry =>
         {
             JsValue key;
             JsValue value;
+
             if (entry.TryGetObject<JsArray>(out var pair))
             {
+                // Common fast path: iterables of [key, value] arrays.
                 key = pair.GetElement(0);
                 value = pair.GetElement(1);
             }
@@ -85,11 +88,11 @@ public sealed partial class MapConstructor(IJsObjectLike prototype, RealmState r
             }
             else
             {
-                continue;
+                throw ThrowTypeError("Map constructor expects iterable entries", realm: realm);
             }
 
             map.Set(key, value);
-        }
+        });
     }
 
     [JsConstructorMethod("groupBy", Length = 2d)]
@@ -109,26 +112,19 @@ public sealed partial class MapConstructor(IJsObjectLike prototype, RealmState r
             throw ThrowTypeError("Map.groupBy callback must be a function", realm: realm);
         }
         
-        // Get iterable (usually an array)
-        if (!items.TryGetObject<JsArray>(out var array) || array is null)
-        {
-            throw ThrowTypeError("Map.groupBy requires an iterable as first argument", realm: realm);
-        }
-        
         // Create result Map
         var result = new JsMap();
         result.SetPrototype(realm.MapPrototype);
-        
-        // Group elements
-        var k = 0;
-        while (k < array.Length)
+
+        // Group elements from any iterable.
+        var index = 0;
+        MapSetIterationHelper.Iterate(items, realm, "Map.groupBy", element =>
         {
-            var element = array.GetElement(k);
-            
             // Call callback with (element, index)
-            var key = callback.Invoke([element, (double)k], JsValue.Undefined);
-            
-            // Get or create array for this key
+            var key = callback.Invoke([element, (double)index], JsValue.Undefined);
+            index++;
+
+            // Get or create array for this key.
             JsArray group;
             if (result.Has(key))
             {
@@ -139,7 +135,7 @@ public sealed partial class MapConstructor(IJsObjectLike prototype, RealmState r
                 }
                 else
                 {
-                    // Should not happen, but create a new array if the value is not an array
+                    // Fallback: replace non-array values with a new grouping array.
                     group = new JsArray(realm);
                     result.Set(key, JsValue.FromJsArray(group));
                 }
@@ -149,13 +145,11 @@ public sealed partial class MapConstructor(IJsObjectLike prototype, RealmState r
                 group = new JsArray(realm);
                 result.Set(key, JsValue.FromJsArray(group));
             }
-            
-            // Add element to group
+
+            // Add element to group.
             group.SetElement((uint)group.Length, element);
-            
-            k++;
-        }
-        
+        });
+
         return result.AsJsValue;
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/MapSet/MapIteratorPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/MapSet/MapIteratorPrototype.cs
@@ -1,0 +1,38 @@
+#region
+
+using Asynkron.JsEngine.JsTypes;
+using Asynkron.JsEngine.Runtime.Prototypes;
+using static Asynkron.JsEngine.StdLib.StandardLibrary;
+
+#endregion
+
+namespace Asynkron.JsEngine.StdLib;
+
+[JsPrototype("Map Iterator", ToStringTag = "Map Iterator")]
+[JsSymbolAlias("iterator", "__selfIterator")]
+public sealed partial class MapIteratorPrototype : JsPrototype
+{
+    [JsHostMethod("next", Length = 0d)]
+    public JsValue Next(JsValue thisValue)
+    {
+        if (!thisValue.TryGetObject<JsMapIterator>(out var iterator) || iterator is null)
+        {
+            throw ThrowTypeError("Map Iterator.prototype.next requires a Map Iterator instance", realm: Realm);
+        }
+
+        return iterator.Next();
+    }
+
+    [JsHostMethod("__selfIterator", Length = 0d)]
+    public static JsValue SelfIterator(JsValue thisValue) => thisValue;
+
+    protected override void ConfigurePrototype()
+    {
+        if (Prototype is JsObject { RealmState: null } jsObj)
+        {
+            jsObj.RealmState = Realm;
+        }
+
+        Realm.MapIteratorPrototype ??= Prototype as JsObject;
+    }
+}

--- a/src/Asynkron.JsEngine/StdLib/MapSet/MapPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/MapSet/MapPrototype.cs
@@ -1,6 +1,5 @@
 #region
 
-using Asynkron.JsEngine.Ast;
 using Asynkron.JsEngine.JsTypes;
 using Asynkron.JsEngine.Runtime.Prototypes;
 using static Asynkron.JsEngine.StdLib.StandardLibrary;
@@ -67,21 +66,21 @@ public sealed partial class MapPrototype
     public JsValue Entries(JsValue thisValue, IReadOnlyList<JsValue> _)
     {
         var map = RequireInstance(thisValue);
-        return new JsValue(CreateMapIterator(map, MapIterationKind.Entries));
+        return CreateMapIterator(map, MapIterationKind.Entries);
     }
 
     [JsHostMethod("keys", Length = 0d)]
     public JsValue Keys(JsValue thisValue, IReadOnlyList<JsValue> _)
     {
         var map = RequireInstance(thisValue);
-        return new JsValue(CreateMapIterator(map, MapIterationKind.Keys));
+        return CreateMapIterator(map, MapIterationKind.Keys);
     }
 
     [JsHostMethod("values", Length = 0d)]
     public JsValue Values(JsValue thisValue, IReadOnlyList<JsValue> _)
     {
         var map = RequireInstance(thisValue);
-        return new JsValue(CreateMapIterator(map, MapIterationKind.Values));
+        return CreateMapIterator(map, MapIterationKind.Values);
     }
 
     [JsHostGetter("size")]
@@ -103,53 +102,11 @@ public sealed partial class MapPrototype
         // [Symbol.iterator] is registered via code generation from [JsSymbolAlias] attribute
     }
 
-    private JsObject CreateMapIterator(JsMap map, MapIterationKind kind)
+    private JsValue CreateMapIterator(JsMap map, MapIterationKind kind)
     {
-        var iterator = new JsObject { RealmState = Realm };
-        var index = 0;
-
-        iterator.SetHostedProperty("next", (_, _) =>
-        {
-            var result = new JsObject { RealmState = Realm };
-            if (index < map.EntryCount)
-            {
-                var entry = map.GetEntry(index++);
-                var value = kind switch
-                {
-                    MapIterationKind.Keys => entry.Key,
-                    MapIterationKind.Values => entry.Value,
-                    _ => CreateEntryPair(entry.Key, entry.Value)
-                };
-
-                result.SetProperty("value", JsValue.FromObjectUnsafe(value));
-                result.SetProperty("done", false);
-            }
-            else
-            {
-                result.SetProperty("value", Symbol.Undefined);
-                result.SetProperty("done", true);
-            }
-
-            return result;
-        });
-
-        var iteratorKey = SymbolKeys.Iterator;
-        iterator.SetHostedProperty(iteratorKey, (_, _) => iterator);
-        return iterator;
-    }
-
-    private JsArray CreateEntryPair(object? first, object? second)
-    {
-        var pair = new JsArray(Realm);
-        pair.SetElement(0, first);
-        pair.SetElement(1, second);
-        return pair;
-    }
-
-    private enum MapIterationKind
-    {
-        Entries,
-        Keys,
-        Values
+        // Use the shared MapIteratorPrototype so @@iterator wiring stays consistent.
+        var iteratorPrototype = Realm.MapIteratorPrototype ??= MapIteratorPrototype.CreatePrototype(Realm);
+        var iterator = new JsMapIterator(map, kind, Realm, iteratorPrototype);
+        return iterator.AsJsValue;
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/MapSet/MapSetIterationHelper.cs
+++ b/src/Asynkron.JsEngine/StdLib/MapSet/MapSetIterationHelper.cs
@@ -1,0 +1,136 @@
+#region
+
+using Asynkron.JsEngine.Ast;
+using Asynkron.JsEngine.JsTypes;
+using Asynkron.JsEngine.Runtime;
+
+#endregion
+
+namespace Asynkron.JsEngine.StdLib;
+
+internal static class MapSetIterationHelper
+{
+    internal static IJsObjectLike GetIterator(JsValue iterable, RealmState realm, string operation)
+    {
+        if (iterable.IsNullOrUndefined)
+        {
+            throw StandardLibrary.ThrowTypeError($"{operation} requires an iterable", realm: realm);
+        }
+
+        // Strings are iterable, so synthesize a string iterator when needed.
+        if (iterable.TryGetString(out var str) && str is not null)
+        {
+            return CreateStringIterator(str, realm);
+        }
+
+        if (!iterable.TryGetObject(out var obj) || obj is null)
+        {
+            throw StandardLibrary.ThrowTypeError($"{operation} requires an iterable", realm: realm);
+        }
+
+        // Prefer Symbol.iterator if present.
+        if (obj.TryGetProperty(SymbolKeys.Iterator, out var iterMethod) &&
+            iterMethod.TryGetObject<IJsCallable>(out var iterCallable) &&
+            iterCallable is not null)
+        {
+            var iteratorValue = iterCallable.Invoke([], iterable);
+            if (!iteratorValue.TryGetObject(out var iteratorObj) || iteratorObj is null)
+            {
+                throw StandardLibrary.ThrowTypeError($"{operation} iterator method must return an object", realm: realm);
+            }
+
+            return iteratorObj;
+        }
+
+        // Fall back to iterator-like objects with a callable next().
+        if (obj.TryGetProperty("next", out var nextProp) &&
+            nextProp.TryGetObject<IJsCallable>(out _))
+        {
+            return obj;
+        }
+
+        throw StandardLibrary.ThrowTypeError($"{operation} requires an iterable", realm: realm);
+    }
+
+    internal static void Iterate(JsValue iterable, RealmState realm, string operation, Action<JsValue> onValue)
+    {
+        var iterator = GetIterator(iterable, realm, operation);
+        while (true)
+        {
+            if (!TryIteratorStep(iterator, realm, operation, out var value))
+            {
+                break;
+            }
+
+            try
+            {
+                // Keep processing simple: delegate handling to the caller.
+                onValue(value);
+            }
+            catch
+            {
+                StandardLibrary.IteratorClose(iterator, realm, operation);
+                throw;
+            }
+        }
+    }
+
+    private static bool TryIteratorStep(IJsObjectLike iterator, RealmState realm, string operation, out JsValue value)
+    {
+        if (!iterator.TryGetProperty("next", out var nextProp) ||
+            !nextProp.TryGetObject<IJsCallable>(out var nextMethod) ||
+            nextMethod is null)
+        {
+            throw StandardLibrary.ThrowTypeError($"{operation} iterator must have a callable next method", realm: realm);
+        }
+
+        var resultValue = nextMethod.Invoke([], JsValue.FromObjectUnsafe(iterator));
+        if (!resultValue.TryGetObject(out var resultObj) || resultObj is null)
+        {
+            throw StandardLibrary.ThrowTypeError($"{operation} iterator result must be an object", realm: realm);
+        }
+
+        if (resultObj.TryGetProperty("done", out var doneProp) && JsOps.ToBoolean(doneProp))
+        {
+            value = JsValue.Undefined;
+            return false;
+        }
+
+        value = resultObj.TryGetProperty("value", out var valueProp) ? valueProp : JsValue.Undefined;
+        return true;
+    }
+
+    private static JsObject CreateStringIterator(string str, RealmState realm)
+    {
+        var iterator = new JsObject { RealmState = realm };
+        var index = 0;
+
+        iterator.SetHostedProperty("next", (_, _) =>
+        {
+            if (index >= str.Length)
+            {
+                return IteratorResultObject.DoneUndefined.AsJsValue;
+            }
+
+            // Iterate by code point to handle surrogate pairs correctly.
+            var first = str[index];
+            string charValue;
+            if (char.IsHighSurrogate(first) && index + 1 < str.Length &&
+                char.IsLowSurrogate(str[index + 1]))
+            {
+                charValue = str.Substring(index, 2);
+                index += 2;
+            }
+            else
+            {
+                charValue = first.ToString();
+                index++;
+            }
+
+            return IteratorResultObject.Create(new JsValue(charValue), false);
+        });
+
+        iterator.SetHostedProperty(SymbolKeys.Iterator, (_, _) => iterator);
+        return iterator;
+    }
+}

--- a/src/Asynkron.JsEngine/StdLib/MapSet/SetConstructor.cs
+++ b/src/Asynkron.JsEngine/StdLib/MapSet/SetConstructor.cs
@@ -52,25 +52,23 @@ public sealed partial class SetConstructor(IJsObjectLike prototype, RealmState r
         var proto = ResolveConstructPrototype(newTarget, targetCtor, Realm) ?? Prototype;
         var instance = new JsSet();
         instance.SetPrototype(proto);
-        PopulateSet(instance, args);
+        PopulateSet(instance, args, Realm);
         return instance;
     }
 
-    private static void PopulateSet(JsSet set, IReadOnlyList<JsValue> args)
+    [JsConstructorSymbolGetter("species")]
+    public static JsValue GetSpecies(JsValue thisValue)
+    {
+        return thisValue;
+    }
+
+    private static void PopulateSet(JsSet set, IReadOnlyList<JsValue> args, RealmState realm)
     {
         if (args.Count == 0 || args[0].IsNull || args[0].IsUndefined)
         {
             return;
         }
 
-        if (!args[0].TryGetObject<JsArray>(out var values))
-        {
-            return;
-        }
-
-        foreach (var value in values.Items)
-        {
-            set.Add(value);
-        }
+        MapSetIterationHelper.Iterate(args[0], realm, "Set constructor", value => set.Add(value));
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/MapSet/SetIteratorPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/MapSet/SetIteratorPrototype.cs
@@ -1,0 +1,38 @@
+#region
+
+using Asynkron.JsEngine.JsTypes;
+using Asynkron.JsEngine.Runtime.Prototypes;
+using static Asynkron.JsEngine.StdLib.StandardLibrary;
+
+#endregion
+
+namespace Asynkron.JsEngine.StdLib;
+
+[JsPrototype("Set Iterator", ToStringTag = "Set Iterator")]
+[JsSymbolAlias("iterator", "__selfIterator")]
+public sealed partial class SetIteratorPrototype : JsPrototype
+{
+    [JsHostMethod("next", Length = 0d)]
+    public JsValue Next(JsValue thisValue)
+    {
+        if (!thisValue.TryGetObject<JsSetIterator>(out var iterator) || iterator is null)
+        {
+            throw ThrowTypeError("Set Iterator.prototype.next requires a Set Iterator instance", realm: Realm);
+        }
+
+        return iterator.Next();
+    }
+
+    [JsHostMethod("__selfIterator", Length = 0d)]
+    public static JsValue SelfIterator(JsValue thisValue) => thisValue;
+
+    protected override void ConfigurePrototype()
+    {
+        if (Prototype is JsObject { RealmState: null } jsObj)
+        {
+            jsObj.RealmState = Realm;
+        }
+
+        Realm.SetIteratorPrototype ??= Prototype as JsObject;
+    }
+}

--- a/src/Asynkron.JsEngine/StdLib/MapSet/SetPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/MapSet/SetPrototype.cs
@@ -1,6 +1,5 @@
 #region
 
-using Asynkron.JsEngine.Ast;
 using Asynkron.JsEngine.JsTypes;
 using Asynkron.JsEngine.Runtime.Prototypes;
 
@@ -60,7 +59,7 @@ public sealed partial class SetPrototype
     public JsValue Entries(JsValue thisValue, IReadOnlyList<JsValue> _)
     {
         var set = RequireInstance(thisValue);
-        return new JsValue(CreateSetIterator(set, SetIterationKind.Entries));
+        return CreateSetIterator(set, SetIterationKind.Entries);
     }
 
     // keys is registered via code generation from [JsMethodAlias] attribute (ES spec: Set.prototype.keys === Set.prototype.values)
@@ -69,7 +68,7 @@ public sealed partial class SetPrototype
     public JsValue Values(JsValue thisValue, IReadOnlyList<JsValue> _)
     {
         var set = RequireInstance(thisValue);
-        return new JsValue(CreateSetIterator(set, SetIterationKind.Values));
+        return CreateSetIterator(set, SetIterationKind.Values);
     }
 
     [JsHostGetter("size")]
@@ -91,52 +90,12 @@ public sealed partial class SetPrototype
         // [Symbol.iterator] is registered via code generation from [JsSymbolAlias] attribute
     }
 
-    private JsObject CreateSetIterator(JsSet set, SetIterationKind kind)
+    private JsValue CreateSetIterator(JsSet set, SetIterationKind kind)
     {
-        var iterator = new JsObject { RealmState = Realm };
-        var index = 0;
-
-        iterator.SetHostedProperty("next", (_, _) =>
-        {
-            var result = new JsObject { RealmState = Realm };
-            if (index < set.ValueCount)
-            {
-                var current = set.GetValue(index++);
-                var value = kind switch
-                {
-                    SetIterationKind.Entries => JsValue.FromJsArray(CreateEntryPair(current, current)),
-                    _ => current
-                };
-
-                result.SetProperty("value", value);
-                result.SetProperty("done", false);
-            }
-            else
-            {
-                result.SetProperty("value", Symbol.Undefined);
-                result.SetProperty("done", true);
-            }
-
-            return result;
-        });
-
-        var iteratorKey = SymbolKeys.Iterator;
-        iterator.SetHostedProperty(iteratorKey, (_, _) => iterator);
-        return iterator;
-    }
-
-    private JsArray CreateEntryPair(JsValue first, JsValue second)
-    {
-        var pair = new JsArray(Realm);
-        pair.SetElement(0, first);
-        pair.SetElement(1, second);
-        return pair;
-    }
-
-    private enum SetIterationKind
-    {
-        Entries,
-        Values
+        // Use the shared SetIteratorPrototype so @@iterator wiring stays consistent.
+        var iteratorPrototype = Realm.SetIteratorPrototype ??= SetIteratorPrototype.CreatePrototype(Realm);
+        var iterator = new JsSetIterator(set, kind, Realm, iteratorPrototype);
+        return iterator.AsJsValue;
     }
 
     [JsHostMethod("difference", Length = 1d)]
@@ -144,26 +103,23 @@ public sealed partial class SetPrototype
     {
         var thisSet = RequireInstance(thisValue);
         var otherValue = args.GetArgument(0);
-        
+
         // Create result set
         var resultSet = new JsSet();
         resultSet.SetPrototype(Realm.SetPrototype);
-        
-        // Get other set - it could be a Set or any iterable
-        if (!otherValue.TryGetObject<JsSet>(out var otherSet) || otherSet is null)
-        {
-            throw StandardLibrary.ThrowTypeError("Set.prototype.difference requires a Set argument", realm: Realm);
-        }
-        
+
+        var otherSet = GetOtherSetForMembership(otherValue, "Set.prototype.difference");
+
         // Add elements from this set that are not in the other set
-        foreach (var value in thisSet.Values())
+        for (var i = 0; i < thisSet.ValueCount; i++)
         {
+            var value = thisSet.GetValue(i);
             if (!otherSet.Has(value))
             {
                 resultSet.Add(value);
             }
         }
-        
+
         return resultSet.AsJsValue;
     }
 
@@ -172,26 +128,23 @@ public sealed partial class SetPrototype
     {
         var thisSet = RequireInstance(thisValue);
         var otherValue = args.GetArgument(0);
-        
+
         // Create result set
         var resultSet = new JsSet();
         resultSet.SetPrototype(Realm.SetPrototype);
-        
-        // Get other set
-        if (!otherValue.TryGetObject<JsSet>(out var otherSet) || otherSet is null)
-        {
-            throw StandardLibrary.ThrowTypeError("Set.prototype.intersection requires a Set argument", realm: Realm);
-        }
-        
+
+        var otherSet = GetOtherSetForMembership(otherValue, "Set.prototype.intersection");
+
         // Add elements that exist in both sets
-        foreach (var value in thisSet.Values())
+        for (var i = 0; i < thisSet.ValueCount; i++)
         {
+            var value = thisSet.GetValue(i);
             if (otherSet.Has(value))
             {
                 resultSet.Add(value);
             }
         }
-        
+
         return resultSet.AsJsValue;
     }
 
@@ -200,22 +153,18 @@ public sealed partial class SetPrototype
     {
         var thisSet = RequireInstance(thisValue);
         var otherValue = args.GetArgument(0);
-        
-        // Get other set
-        if (!otherValue.TryGetObject<JsSet>(out var otherSet) || otherSet is null)
-        {
-            throw StandardLibrary.ThrowTypeError("Set.prototype.isDisjointFrom requires a Set argument", realm: Realm);
-        }
-        
+
+        var otherSet = GetOtherSetForMembership(otherValue, "Set.prototype.isDisjointFrom");
+
         // Check if there are any common elements
-        foreach (var value in thisSet.Values())
+        for (var i = 0; i < thisSet.ValueCount; i++)
         {
-            if (otherSet.Has(value))
+            if (otherSet.Has(thisSet.GetValue(i)))
             {
                 return false; // Found a common element, sets are not disjoint
             }
         }
-        
+
         return true;
     }
 
@@ -224,22 +173,18 @@ public sealed partial class SetPrototype
     {
         var thisSet = RequireInstance(thisValue);
         var otherValue = args.GetArgument(0);
-        
-        // Get other set
-        if (!otherValue.TryGetObject<JsSet>(out var otherSet) || otherSet is null)
-        {
-            throw StandardLibrary.ThrowTypeError("Set.prototype.isSubsetOf requires a Set argument", realm: Realm);
-        }
-        
+
+        var otherSet = GetOtherSetForMembership(otherValue, "Set.prototype.isSubsetOf");
+
         // Check if all elements of this set are in the other set
-        foreach (var value in thisSet.Values())
+        for (var i = 0; i < thisSet.ValueCount; i++)
         {
-            if (!otherSet.Has(value))
+            if (!otherSet.Has(thisSet.GetValue(i)))
             {
                 return false; // Found an element not in other set
             }
         }
-        
+
         return true;
     }
 
@@ -248,22 +193,18 @@ public sealed partial class SetPrototype
     {
         var thisSet = RequireInstance(thisValue);
         var otherValue = args.GetArgument(0);
-        
-        // Get other set
-        if (!otherValue.TryGetObject<JsSet>(out var otherSet) || otherSet is null)
-        {
-            throw StandardLibrary.ThrowTypeError("Set.prototype.isSupersetOf requires a Set argument", realm: Realm);
-        }
-        
+
+        var otherSet = GetOtherSetForMembership(otherValue, "Set.prototype.isSupersetOf");
+
         // Check if all elements of the other set are in this set
-        foreach (var value in otherSet.Values())
+        for (var i = 0; i < otherSet.ValueCount; i++)
         {
-            if (!thisSet.Has(value))
+            if (!thisSet.Has(otherSet.GetValue(i)))
             {
                 return false; // Found an element of other set not in this set
             }
         }
-        
+
         return true;
     }
 
@@ -272,35 +213,33 @@ public sealed partial class SetPrototype
     {
         var thisSet = RequireInstance(thisValue);
         var otherValue = args.GetArgument(0);
-        
+
         // Create result set
         var resultSet = new JsSet();
         resultSet.SetPrototype(Realm.SetPrototype);
-        
-        // Get other set
-        if (!otherValue.TryGetObject<JsSet>(out var otherSet) || otherSet is null)
-        {
-            throw StandardLibrary.ThrowTypeError("Set.prototype.symmetricDifference requires a Set argument", realm: Realm);
-        }
-        
+
+        var otherSet = GetOtherSetForMembership(otherValue, "Set.prototype.symmetricDifference");
+
         // Add elements from this set that are not in the other set
-        foreach (var value in thisSet.Values())
+        for (var i = 0; i < thisSet.ValueCount; i++)
         {
+            var value = thisSet.GetValue(i);
             if (!otherSet.Has(value))
             {
                 resultSet.Add(value);
             }
         }
-        
+
         // Add elements from the other set that are not in this set
-        foreach (var value in otherSet.Values())
+        for (var i = 0; i < otherSet.ValueCount; i++)
         {
+            var value = otherSet.GetValue(i);
             if (!thisSet.Has(value))
             {
                 resultSet.Add(value);
             }
         }
-        
+
         return resultSet.AsJsValue;
     }
 
@@ -309,29 +248,39 @@ public sealed partial class SetPrototype
     {
         var thisSet = RequireInstance(thisValue);
         var otherValue = args.GetArgument(0);
-        
+
         // Create result set
         var resultSet = new JsSet();
         resultSet.SetPrototype(Realm.SetPrototype);
-        
-        // Get other set
-        if (!otherValue.TryGetObject<JsSet>(out var otherSet) || otherSet is null)
-        {
-            throw StandardLibrary.ThrowTypeError("Set.prototype.union requires a Set argument", realm: Realm);
-        }
-        
+
         // Add all elements from this set
-        foreach (var value in thisSet.Values())
+        for (var i = 0; i < thisSet.ValueCount; i++)
         {
-            resultSet.Add(value);
+            resultSet.Add(thisSet.GetValue(i));
         }
-        
-        // Add all elements from the other set (duplicates will be ignored)
-        foreach (var value in otherSet.Values())
-        {
-            resultSet.Add(value);
-        }
-        
+
+        // Add all elements from the other iterable (duplicates will be ignored).
+        AddValuesFromIterable(resultSet, otherValue, "Set.prototype.union");
+
         return resultSet.AsJsValue;
+    }
+
+    private void AddValuesFromIterable(JsSet target, JsValue iterable, string methodName)
+    {
+        MapSetIterationHelper.Iterate(iterable, Realm, methodName, value => target.Add(value));
+    }
+
+    private JsSet GetOtherSetForMembership(JsValue otherValue, string methodName)
+    {
+        if (otherValue.TryGetObject<JsSet>(out var otherSet) && otherSet is not null)
+        {
+            return otherSet;
+        }
+
+        // Build a temporary Set so we can use SameValueZero membership semantics.
+        var tempSet = new JsSet();
+        tempSet.SetPrototype(Realm.SetPrototype);
+        AddValuesFromIterable(tempSet, otherValue, methodName);
+        return tempSet;
     }
 }


### PR DESCRIPTION
### Motivation
- Provide first-class iterator objects for `Map` and `Set` so `next`/`@@iterator` behavior is consistent with spec and share per-realm prototypes.
- Allow `Map`/`Set` constructors and utility methods such as `Map.groupBy` and `Set` relation/combination methods to accept generic iterables (not only arrays).
- Centralize iteration handling (including strings and iterator-like objects) to avoid duplicated iterator code paths and ensure proper iterator closing on errors.
- Use consistent membership semantics for set operations by materializing temporary `JsSet` when needed.

### Description
- Added iterator types `JsMapIterator` and `JsSetIterator` and new enums `MapIterationKind`/`SetIterationKind` to represent iteration modes.
- Introduced `MapIteratorPrototype` and `SetIteratorPrototype` and wired them into the realm via new `RealmState` properties `MapIteratorPrototype` and `SetIteratorPrototype`.
- Implemented `MapSetIterationHelper` with `GetIterator`/`Iterate` to handle generic iterables, synthesized string iterators, iterator-like objects with `next`, and proper `IteratorClose` behavior on errors.
- Updated `MapConstructor`, `SetConstructor`, `MapPrototype`, `SetPrototype`, and `Map.groupBy` to use the helper and return iterator `JsValue`s, added `species` getters, and refactored Set relation/combination methods to accept iterables using `GetOtherSetForMembership` and `AddValuesFromIterable`.

### Testing
- No automated tests were executed in this environment because `dotnet` was not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fa41f27d08328b3158faaf4c73681)