### PR TITLE
Add %TypedArray%.from and %TypedArray%.of static methods

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/TypedArray/TypedArrayConstructor.cs
+++ b/src/Asynkron.JsEngine/StdLib/TypedArray/TypedArrayConstructor.cs
@@ -1,5 +1,6 @@
 #region
 
+using System.Globalization;
 using Asynkron.JsEngine.JsTypes;
 using Asynkron.JsEngine.Runtime;
 using Asynkron.JsEngine.Runtime.Prototypes;
@@ -39,5 +40,213 @@ public sealed partial class TypedArrayConstructor(IJsObjectLike prototype, Realm
 
             throw ThrowTypeError("TypedArray is not a constructor", realm: Realm);
         });
+
+        // Add %TypedArray%.from static method
+        var fromFn = new HostFunction(TypedArrayFrom, isConstructor: false) { RealmState = Realm };
+        fromFn.DefineProperty("length", new PropertyDescriptor
+        {
+            Value = JsValue.FromDouble(1),
+            Writable = false,
+            Enumerable = false,
+            Configurable = true
+        });
+        fromFn.DefineProperty("name", new PropertyDescriptor
+        {
+            Value = (JsValue)"from",
+            Writable = false,
+            Enumerable = false,
+            Configurable = true
+        });
+        constructor.DefineProperty("from", new PropertyDescriptor
+        {
+            Value = (JsValue)fromFn,
+            Writable = true,
+            Enumerable = false,
+            Configurable = true
+        });
+
+        // Add %TypedArray%.of static method
+        var ofFn = new HostFunction(TypedArrayOf, isConstructor: false) { RealmState = Realm };
+        ofFn.DefineProperty("length", new PropertyDescriptor
+        {
+            Value = JsValue.FromDouble(0),
+            Writable = false,
+            Enumerable = false,
+            Configurable = true
+        });
+        ofFn.DefineProperty("name", new PropertyDescriptor
+        {
+            Value = (JsValue)"of",
+            Writable = false,
+            Enumerable = false,
+            Configurable = true
+        });
+        constructor.DefineProperty("of", new PropertyDescriptor
+        {
+            Value = (JsValue)ofFn,
+            Writable = true,
+            Enumerable = false,
+            Configurable = true
+        });
+    }
+
+    /// <summary>
+    /// %TypedArray%.from ( source [ , mapfn [ , thisArg ] ] )
+    /// </summary>
+    private JsValue TypedArrayFrom(JsValue thisValue, IReadOnlyList<JsValue> args)
+    {
+        // 1. Let C be the this value.
+        // 2. If IsConstructor(C) is false, throw a TypeError exception.
+        if (!thisValue.TryGetObject<IJsCallable>(out var ctor) ||
+            (ctor is HostFunction hf && hf.DisallowConstruct))
+        {
+            throw ThrowTypeError("%TypedArray%.from requires a constructor as 'this'", realm: Realm);
+        }
+
+        // 3. If mapfn is undefined, let mapping be false.
+        // 4. Else, if IsCallable(mapfn) is false, throw a TypeError.
+        IJsCallable? mapFn = null;
+        var mapThis = JsValue.Undefined;
+        if (args.Count > 1 && !args[1].IsUndefined)
+        {
+            if (!args[1].TryGetObject<IJsCallable>(out var callableMap))
+            {
+                throw ThrowTypeError("mapfn is not callable", realm: Realm);
+            }
+            mapFn = callableMap;
+            mapThis = args.GetArgument(2);
+        }
+
+        if (args.Count == 0)
+        {
+            return CreateAndPopulateTypedArray(ctor, [], mapFn, mapThis);
+        }
+
+        var source = args[0];
+
+        // Check for iterable
+        var iteratorKey = SymbolKeys.Iterator;
+        if (source.TryGetObject<IJsPropertyAccessor>(out var accessor) &&
+            accessor.TryGetProperty(iteratorKey, out var methodVal) &&
+            !methodVal.IsUndefined)
+        {
+            if (!methodVal.TryGetObject<IJsCallable>(out var callableIterator))
+            {
+                throw ThrowTypeError("Iterator method is not callable", realm: Realm);
+            }
+
+            var iteratorObj = callableIterator.Invoke([], source);
+            if (!iteratorObj.TryGetObject<IJsPropertyAccessor>(out var iteratorAccessor))
+            {
+                throw ThrowTypeError("Iterator method did not return an object", realm: Realm);
+            }
+
+            if (!iteratorAccessor.TryGetProperty("next", out var nextVal) ||
+                !nextVal.TryGetObject<IJsCallable>(out var nextCallable))
+            {
+                throw ThrowTypeError("Iterator result does not expose next", realm: Realm);
+            }
+
+            var collected = new List<JsValue>();
+            while (true)
+            {
+                var nextResult = nextCallable.Invoke([], iteratorObj);
+                if (!nextResult.TryGetObject<IJsPropertyAccessor>(out var nextResultAccessor))
+                {
+                    throw ThrowTypeError("Iterator result is not an object", realm: Realm);
+                }
+
+                var done = nextResultAccessor.TryGetProperty("done", out var doneVal) &&
+                           JsOps.ToBoolean(doneVal);
+                if (done)
+                {
+                    return CreateAndPopulateTypedArray(ctor, collected, mapFn, mapThis);
+                }
+
+                var value = nextResultAccessor.TryGetProperty("value", out var valueVal)
+                    ? valueVal
+                    : JsValue.Undefined;
+                collected.Add(value);
+            }
+        }
+
+        // Array-like fallback
+        if (source.TryGetObject<IJsPropertyAccessor>(out var arrayLike) &&
+            arrayLike.TryGetProperty("length", out var lengthVal))
+        {
+            var lenNumber = JsOps.ToNumber(lengthVal);
+            var length = double.IsNaN(lenNumber) || lenNumber < 0
+                ? 0
+                : (int)Math.Min(lenNumber, int.MaxValue);
+
+            var collected = new List<JsValue>(length);
+            for (var i = 0; i < length; i++)
+            {
+                var key = i.ToString(CultureInfo.InvariantCulture);
+                var hasElement = arrayLike.TryGetProperty(key, out var element);
+                collected.Add(hasElement ? element : JsValue.Undefined);
+            }
+
+            return CreateAndPopulateTypedArray(ctor, collected, mapFn, mapThis);
+        }
+
+        return CreateAndPopulateTypedArray(ctor, [], mapFn, mapThis);
+    }
+
+    private JsValue CreateAndPopulateTypedArray(IJsCallable ctor, IList<JsValue> values, IJsCallable? mapFn, JsValue mapThis)
+    {
+        var length = values.Count;
+        var taObj = ctor.Invoke([JsValue.FromDouble(length)], (JsValue)ctor);
+        if (!taObj.TryGetObject<TypedArrayBase>(out var typed))
+        {
+            throw ThrowTypeError("%TypedArray%.from: constructor did not return a typed array", realm: Realm);
+        }
+
+        for (var i = 0; i < length; i++)
+        {
+            var value = values[i];
+            if (mapFn != null)
+            {
+                value = mapFn.Invoke([value, JsValue.FromDouble(i)], mapThis);
+            }
+            typed.SetValue(i, value);
+        }
+
+        return taObj;
+    }
+
+    /// <summary>
+    /// %TypedArray%.of ( ...items )
+    /// </summary>
+    private JsValue TypedArrayOf(JsValue thisValue, IReadOnlyList<JsValue> args)
+    {
+        // 1. Let len be the actual number of arguments passed to this function.
+        var length = args.Count;
+
+        // 2. Let items be the List of arguments passed to this function.
+        // 3. Let C be the this value.
+        // 4. If IsConstructor(C) is false, throw a TypeError exception.
+        if (!thisValue.TryGetObject<IJsCallable>(out var ctor) ||
+            (ctor is HostFunction hf && hf.DisallowConstruct))
+        {
+            throw ThrowTypeError("%TypedArray%.of requires a constructor as 'this'", realm: Realm);
+        }
+
+        // 5. Let newObj be ? TypedArrayCreate(C, « 𝔽(len) »).
+        var taObj = ctor.Invoke([JsValue.FromDouble(length)], (JsValue)ctor);
+        if (!taObj.TryGetObject<TypedArrayBase>(out var typed))
+        {
+            throw ThrowTypeError("%TypedArray%.of: constructor did not return a typed array", realm: Realm);
+        }
+
+        // 6. Let k be 0.
+        // 7. Repeat, while k < len,
+        for (var i = 0; i < length; i++)
+        {
+            typed.SetValue(i, args[i]);
+        }
+
+        // 8. Return newObj.
+        return taObj;
     }
 }


### PR DESCRIPTION
## Summary
- Added `from()` and `of()` methods to the `%TypedArray%` intrinsic constructor
- Proper property descriptors (length, name) per ECMAScript spec
- Fixes Test262 tests for `TypedArray.from/of` length, name, and prop-desc

## Test plan
- [x] Existing TypedArray tests pass
- [ ] Test262 TypedArray.from/of tests should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)