### PR TITLE
Rename generator/async types for consistency

### DIFF
--- a/src/Asynkron.JsEngine/Ast/ClassFieldInitializer.cs
+++ b/src/Asynkron.JsEngine/Ast/ClassFieldInitializer.cs
@@ -86,10 +86,10 @@ public static partial class TypedAstEvaluator
                 case TypedFunction typedFunction:
                     typedFunction.EnsureHasName(displayName, true);
                     break;
-                case TypedGeneratorFactory generatorFactory:
+                case GeneratorFunctionCallable generatorFactory:
                     generatorFactory.EnsureHasName(displayName, true);
                     break;
-                case AsyncGeneratorFactory asyncGeneratorFactory:
+                case AsyncGeneratorFunctionCallable asyncGeneratorFactory:
                     asyncGeneratorFactory.EnsureHasName(displayName, true);
                     break;
             }

--- a/src/Asynkron.JsEngine/Ast/FunctionExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/FunctionExpressionExtensions.cs
@@ -408,10 +408,10 @@ public static partial class TypedAstEvaluator
 
             IJsCallable callable = functionExpression.IsGenerator switch
             {
-                true when functionExpression.IsAsync => new AsyncGeneratorFactory(functionExpression,
+                true when functionExpression.IsAsync => new AsyncGeneratorFunctionCallable(functionExpression,
                     closureEnvironment,
                     context.RealmState, isLexicallyStrict, hasFunctionNameEnvironment, isConstructorFunction),
-                true => new TypedGeneratorFactory(functionExpression, closureEnvironment, context.RealmState,
+                true => new GeneratorFunctionCallable(functionExpression, closureEnvironment, context.RealmState,
                     isLexicallyStrict, hasFunctionNameEnvironment, isConstructorFunction),
                 _ => new TypedFunction(functionExpression, closureEnvironment, context.RealmState,
                     isLexicallyStrict, hasFunctionNameEnvironment, isConstructorFunction)
@@ -428,20 +428,20 @@ public static partial class TypedAstEvaluator
                 case TypedFunction typed:
                     typed.SetCapturedPrivateNameScopes(capturedPrivateScopes);
                     break;
-                case TypedGeneratorFactory generatorFactory when context.CurrentPrivateNameScope is not null &&
+                case GeneratorFunctionCallable generatorFactory when context.CurrentPrivateNameScope is not null &&
                                                                  generatorFactory.PrivateNameScope is null:
                     generatorFactory.SetPrivateNameScope(context.CurrentPrivateNameScope);
                     generatorFactory.SetCapturedPrivateNameScopes(capturedPrivateScopes);
                     break;
-                case TypedGeneratorFactory generatorFactory:
+                case GeneratorFunctionCallable generatorFactory:
                     generatorFactory.SetCapturedPrivateNameScopes(capturedPrivateScopes);
                     break;
-                case AsyncGeneratorFactory asyncGeneratorFactory when context.CurrentPrivateNameScope is not null &&
+                case AsyncGeneratorFunctionCallable asyncGeneratorFactory when context.CurrentPrivateNameScope is not null &&
                                                                       asyncGeneratorFactory.PrivateNameScope is null:
                     asyncGeneratorFactory.SetPrivateNameScope(context.CurrentPrivateNameScope);
                     asyncGeneratorFactory.SetCapturedPrivateNameScopes(capturedPrivateScopes);
                     break;
-                case AsyncGeneratorFactory asyncGeneratorFactory:
+                case AsyncGeneratorFunctionCallable asyncGeneratorFactory:
                     asyncGeneratorFactory.SetCapturedPrivateNameScopes(capturedPrivateScopes);
                     break;
             }

--- a/src/Asynkron.JsEngine/Ast/ImmutableArrayClassMemberExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ImmutableArrayClassMemberExtensions.cs
@@ -91,7 +91,7 @@ public static partial class TypedAstEvaluator
                         typedFunction.DisableConstruction();
                         typedFunction.EnsureHasName(displayName, true);
                         break;
-                    case TypedGeneratorFactory generatorFactory:
+                    case GeneratorFunctionCallable generatorFactory:
                         generatorFactory.SetPrivateNameScope(privateNameScope);
                         if (homeObject is not null)
                         {
@@ -102,7 +102,7 @@ public static partial class TypedAstEvaluator
                         generatorFactory.DisableConstruction();
                         generatorFactory.EnsureHasName(displayName, true);
                         break;
-                    case AsyncGeneratorFactory asyncGeneratorFactory:
+                    case AsyncGeneratorFunctionCallable asyncGeneratorFactory:
                         asyncGeneratorFactory.SetPrivateNameScope(privateNameScope);
                         if (homeObject is not null)
                         {

--- a/src/Asynkron.JsEngine/Ast/NewExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/NewExpressionExtensions.cs
@@ -129,7 +129,7 @@ public static partial class TypedAstEvaluator
                 throw new ThrowSignal(errorJs);
             }
 
-            if (constructor is TypedGeneratorFactory)
+            if (constructor is GeneratorFunctionCallable)
             {
                 var errorJs = realm.TypeErrorConstructor is IJsCallable typeErrorCtor
                     ? typeErrorCtor.Invoke([(JsValue)"Generator functions cannot be constructed with 'new'"],

--- a/src/Asynkron.JsEngine/Ast/ObjectExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ObjectExpressionExtensions.cs
@@ -80,12 +80,12 @@ public static partial class TypedAstEvaluator
                             typed.SetHomeObject(obj);
                             typed.DisableConstruction();
                         }
-                        else if (callable is TypedGeneratorFactory generatorFactory)
+                        else if (callable is GeneratorFunctionCallable generatorFactory)
                         {
                             generatorFactory.SetHomeObject(obj);
                             generatorFactory.DisableConstruction();
                         }
-                        else if (callable is AsyncGeneratorFactory asyncGeneratorFactory)
+                        else if (callable is AsyncGeneratorFunctionCallable asyncGeneratorFactory)
                         {
                             asyncGeneratorFactory.SetHomeObject(obj);
                             asyncGeneratorFactory.DisableConstruction();

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.AsyncFunctionDriver.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.AsyncFunctionDriver.cs
@@ -12,10 +12,10 @@ public static partial class TypedAstEvaluator
 {
     /// <summary>
     ///     Drives an async function to completion using the generator IR executor.
-    ///     Unlike AsyncGeneratorInstance which exposes .next()/.return()/.throw() methods,
+    ///     Unlike AsyncGeneratorIterator which exposes .next()/.return()/.throw() methods,
     ///     this class drives execution automatically and returns a single Promise.
     /// </summary>
-    internal sealed class AsyncFunctionExecutor
+    internal sealed class AsyncFunctionDriver
     {
         private readonly IReadOnlyList<JsValue> _arguments;
         private readonly IJsCallable _callable;
@@ -31,7 +31,7 @@ public static partial class TypedAstEvaluator
 
         private ExecutionPlanRunner? _inner;
 
-        public AsyncFunctionExecutor(
+        public AsyncFunctionDriver(
             FunctionExpression function,
             JsEnvironment closure,
             IReadOnlyList<JsValue> arguments,
@@ -254,14 +254,14 @@ public static partial class TypedAstEvaluator
             private static readonly ObjectPool<AsyncResumeCallback> FulfilledPool = new(32, static () => new AsyncResumeCallback());
             private static readonly ObjectPool<AsyncResumeCallback> RejectedPool = new(32, static () => new AsyncResumeCallback());
 
-            private AsyncFunctionExecutor? _executor;
+            private AsyncFunctionDriver? _executor;
             private IJsCallable? _resolve;
             private IJsCallable? _reject;
             private bool _isRejection;
             private AsyncResumeCallback? _sibling; // The other callback in the pair
 
             public static (AsyncResumeCallback fulfilled, AsyncResumeCallback rejected) Rent(
-                AsyncFunctionExecutor executor,
+                AsyncFunctionDriver executor,
                 IJsCallable resolve,
                 IJsCallable reject)
             {

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.AsyncGeneratorFunctionCallable.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.AsyncGeneratorFunctionCallable.cs
@@ -15,9 +15,9 @@ public static partial class TypedAstEvaluator
     /// Callable for async generator functions (async function*).
     /// Returns an async iterator when invoked.
     /// </summary>
-    private sealed class AsyncGeneratorFactory : GeneratorFunctionBase
+    private sealed class AsyncGeneratorFunctionCallable : GeneratorFunctionBase
     {
-        public AsyncGeneratorFactory(
+        public AsyncGeneratorFunctionCallable(
             FunctionExpression function,
             JsEnvironment closure,
             RealmState realmState,
@@ -38,7 +38,7 @@ public static partial class TypedAstEvaluator
 
         public override JsValue Invoke(IReadOnlyList<JsValue> arguments, JsValue thisValue)
         {
-            var instance = new AsyncGeneratorInstance(
+            var instance = new AsyncGeneratorIterator(
                 _function,
                 _closure,
                 arguments,

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.AsyncGeneratorIterator.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.AsyncGeneratorIterator.cs
@@ -10,7 +10,7 @@ namespace Asynkron.JsEngine.Ast;
 
 public static partial class TypedAstEvaluator
 {
-    private sealed class AsyncGeneratorInstance(
+    private sealed class AsyncGeneratorIterator(
         FunctionExpression function,
         JsEnvironment closure,
         IReadOnlyList<JsValue> arguments,
@@ -256,13 +256,13 @@ public static partial class TypedAstEvaluator
             [ThreadStatic]
             private static AsyncResumeCallback? TCachedRejected;
 
-            private AsyncGeneratorInstance? _executor;
+            private AsyncGeneratorIterator? _executor;
             private IJsCallable? _resolve;
             private IJsCallable? _reject;
             private bool _isRejection;
 
             public static (AsyncResumeCallback fulfilled, AsyncResumeCallback rejected) Rent(
-                AsyncGeneratorInstance executor,
+                AsyncGeneratorIterator executor,
                 IJsCallable resolve,
                 IJsCallable reject)
             {

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -2408,7 +2408,7 @@ public static partial class TypedAstEvaluator
             }
 
             // Async-aware mode: surface promise-like values as pending steps
-            // so AsyncGeneratorInstance can resume via the event queue.
+            // so AsyncGeneratorIterator can resume via the event queue.
             // awaitedValue is already JsValue
             if (TryResolvePromiseOrYield(awaitedValue, context, out var resolved))
             {

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.GeneratorFunctionCallable.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.GeneratorFunctionCallable.cs
@@ -15,9 +15,9 @@ public static partial class TypedAstEvaluator
     /// Callable for synchronous generator functions (function*).
     /// Returns a sync iterator when invoked.
     /// </summary>
-    private sealed class TypedGeneratorFactory : GeneratorFunctionBase
+    private sealed class GeneratorFunctionCallable : GeneratorFunctionBase
     {
-        public TypedGeneratorFactory(
+        public GeneratorFunctionCallable(
             FunctionExpression function,
             JsEnvironment closure,
             RealmState realmState,
@@ -199,7 +199,7 @@ public static partial class TypedAstEvaluator
 
             var created = JsValue.FromObjectUnsafe(createdObj);
 
-            // The result should now be a TypedGeneratorFactory
+            // The result should now be a GeneratorFunctionCallable
             if (created.TryUnwrap(out IJsObjectLike? objectLike))
             {
                 // Resolve the prototype from the newTarget

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ModuleFunctionFactory.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ModuleFunctionFactory.cs
@@ -35,7 +35,7 @@ public static partial class TypedAstEvaluator
             if (funcExpr.IsAsync)
             {
                 var asyncGen =
-                    new AsyncGeneratorFactory(funcExpr, moduleEnv, realmState, isStrict, hasNameInEnvironment);
+                    new AsyncGeneratorFunctionCallable(funcExpr, moduleEnv, realmState, isStrict, hasNameInEnvironment);
                 if (functionName != null)
                 {
                     asyncGen.EnsureHasName(functionName, true);
@@ -45,7 +45,7 @@ public static partial class TypedAstEvaluator
             }
             else
             {
-                var gen = new TypedGeneratorFactory(funcExpr, moduleEnv, realmState, isStrict, hasNameInEnvironment);
+                var gen = new GeneratorFunctionCallable(funcExpr, moduleEnv, realmState, isStrict, hasNameInEnvironment);
                 if (functionName != null)
                 {
                     gen.EnsureHasName(functionName, true);

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.TypedFunction.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.TypedFunction.cs
@@ -648,7 +648,7 @@ public static partial class TypedAstEvaluator
                 RealmState.ReturnContext(context);
                 try
                 {
-                    var executor = new AsyncFunctionExecutor(
+                    var executor = new AsyncFunctionDriver(
                         _function,
                         _closure,
                         arguments,
@@ -1610,10 +1610,10 @@ public static partial class TypedAstEvaluator
                 case TypedFunction typedFunction:
                     typedFunction.EnsureHasName(displayName, true);
                     break;
-                case TypedGeneratorFactory generatorFactory:
+                case GeneratorFunctionCallable generatorFactory:
                     generatorFactory.EnsureHasName(displayName, true);
                     break;
-                case AsyncGeneratorFactory asyncGeneratorFactory:
+                case AsyncGeneratorFunctionCallable asyncGeneratorFactory:
                     asyncGeneratorFactory.EnsureHasName(displayName, true);
                     break;
             }


### PR DESCRIPTION
## Summary

Completes Phase 2b and 2c of the ExecutionPlan refactoring.

### Phase 2b - Consistent naming pattern:
- `TypedGeneratorFactory` → `GeneratorFunctionCallable`
- `AsyncGeneratorFactory` → `AsyncGeneratorFunctionCallable`
- `AsyncGeneratorInstance` → `AsyncGeneratorIterator`

### Phase 2c - Instance layer cleanup:
- `AsyncFunctionExecutor` → `AsyncFunctionDriver`

## Naming Convention

All types now follow consistent naming:
- `*Callable`: Function objects that can be invoked (the JS function itself)
- `*Iterator`: Iterator instances that drive execution (returned when function is called)
- `*Driver`: Internal drivers that execute to completion (async functions)

## Architecture After Refactoring

```
Factory Layer (callables):
├── GeneratorFunctionBase              (shared infrastructure)
│   ├── GeneratorFunctionCallable      (function*)
│   └── AsyncGeneratorFunctionCallable (async function*)

Instance Layer (drivers/iterators):
├── ExecutionPlanRunner                (shared IR interpreter)
├── AsyncGeneratorIterator             (async iterator protocol)
└── AsyncFunctionDriver                (drives async to Promise)
```

## Test plan

- [x] All 2164 unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)