### PR TITLE
Reduce closure allocations in array iterators

### DIFF
--- a/src/Asynkron.JsEngine/Ast/AssignmentReferenceResolver.cs
+++ b/src/Asynkron.JsEngine/Ast/AssignmentReferenceResolver.cs
@@ -196,7 +196,7 @@ internal static class AssignmentReferenceResolver
         var target = evaluateExpression(member.Target, environment, context);
         if (context.ShouldStopEvaluation)
         {
-            return AssignmentReference.ForDelegate(() => JsValue.Undefined, _ => { });
+            return AssignmentReference.ForDelegate(static () => JsValue.Undefined, static _ => { });
         }
 
         // For non-computed member access (like obj.prop or obj.#privateField),
@@ -220,7 +220,7 @@ internal static class AssignmentReferenceResolver
 
         if (context.ShouldStopEvaluation)
         {
-            return AssignmentReference.ForDelegate(() => JsValue.Undefined, _ => { });
+            return AssignmentReference.ForDelegate(static () => JsValue.Undefined, static _ => { });
         }
 
         if (target.IsNullish)

--- a/src/Asynkron.JsEngine/Ast/ObjectBindingExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ObjectBindingExtensions.cs
@@ -43,7 +43,7 @@ public static partial class TypedAstEvaluator
                         assignmentTarget.Expression,
                         environment,
                         context,
-                        (e, env, ctx) => e.EvaluateExpression(env, ctx));
+                        static (e, env, ctx) => e.EvaluateExpression(env, ctx));
                     if (context.ShouldStopEvaluation)
                     {
                         return;

--- a/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Iterators.cs
+++ b/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Iterators.cs
@@ -14,26 +14,20 @@ public sealed partial class ArrayPrototype
     public JsValue Entries(JsValue thisValue)
     {
         return JsValue.FromObjectUnsafe(CreateArrayIterator(thisValue, "Array.prototype.entries", Realm,
-            (accessor, _) => idx =>
-            {
-                var pair = new JsArray(Realm);
-                pair.Push((double)idx);
-                pair.Push(GetElementOrUndefinedJsValue(accessor, idx));
-                return JsValue.FromJsArray(pair);
-            }));
+            ArrayIteratorKind.Entries));
     }
 
     [JsHostMethod("keys", Length = 0d)]
     public JsValue Keys(JsValue thisValue)
     {
         return JsValue.FromObjectUnsafe(CreateArrayIterator(thisValue, "Array.prototype.keys", Realm,
-            (_, _) => idx => new JsValue((double)idx)));
+            ArrayIteratorKind.Keys));
     }
 
     [JsHostMethod("values", Length = 0d)]
     public JsValue Values(JsValue thisValue)
     {
         return JsValue.FromObjectUnsafe(CreateArrayIterator(thisValue, "Array.prototype.values", Realm,
-            (accessor, _) => idx => GetElementOrUndefinedJsValue(accessor, idx)));
+            ArrayIteratorKind.Values));
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/Array/StandardLibrary.Array.Iterators.cs
+++ b/src/Asynkron.JsEngine/StdLib/Array/StandardLibrary.Array.Iterators.cs
@@ -9,14 +9,96 @@ using Microsoft.Extensions.Logging;
 
 namespace Asynkron.JsEngine.StdLib;
 
+/// <summary>
+/// Specifies the kind of array iterator to create.
+/// Using an enum avoids closure allocations compared to passing Func delegates.
+/// </summary>
+internal enum ArrayIteratorKind
+{
+    /// <summary>Iterator yields [index, value] pairs.</summary>
+    Entries,
+    /// <summary>Iterator yields index values only.</summary>
+    Keys,
+    /// <summary>Iterator yields element values only.</summary>
+    Values
+}
+
 public static partial class StandardLibrary
 {
+    /// <summary>
+    /// Creates an array iterator without closure allocations.
+    /// </summary>
+    internal static object CreateArrayIterator(JsValue thisValue, string methodName, RealmState? realm,
+        ArrayIteratorKind kind)
+    {
+        var accessor = EnsureArrayLikeReceiver(thisValue, methodName, realm);
+        return CreateArrayIteratorObject(accessor, kind, realm);
+    }
+
+    /// <summary>
+    /// Legacy overload for backwards compatibility - still allocates closures.
+    /// Prefer the ArrayIteratorKind overload for new code.
+    /// </summary>
     internal static object CreateArrayIterator(JsValue thisValue, string methodName, RealmState? realm,
         Func<IJsPropertyAccessor, JsValue, Func<uint, JsValue>> projectorFactory)
     {
         var accessor = EnsureArrayLikeReceiver(thisValue, methodName, realm);
         var projector = projectorFactory(accessor, thisValue);
         return CreateArrayIteratorObject(accessor, projector, realm);
+    }
+
+    internal static object CreateArrayIteratorObject(IJsPropertyAccessor accessor, ArrayIteratorKind kind,
+        RealmState? realm)
+    {
+        var iterator = new JsObject(realm?.ObjectPrototype);
+        var iteratorKey = SymbolKeys.Iterator;
+
+        uint index = 0;
+        var exhausted = false;
+        var typedAccessor = accessor as TypedArrayBase;
+
+        iterator.SetHostedProperty("next", Next, realm);
+        iterator.SetHostedProperty(iteratorKey, ReturnIterator, realm);
+        return iterator;
+
+        JsValue Next(JsValue _, IReadOnlyList<JsValue> __, RealmState? ___)
+        {
+            realm?.Logger?.LogInformation("ArrayIterator.next index={Index}", index);
+            if (exhausted)
+            {
+                return IteratorResultObject.DoneUndefined.AsJsValue;
+            }
+
+            if (typedAccessor?.IsDetachedOrOutOfBounds() == true)
+            {
+                throw typedAccessor.CreateOutOfBoundsTypeError();
+            }
+
+            // Get length as JsValue, avoiding boxing from ternary expression
+            if (!accessor.TryGetProperty("length", out var lenVal))
+            {
+                lenVal = JsValue.Zero;
+            }
+
+            var evalContext = realm?.CreateContext();
+            var length = (uint)Math.Min(Math.Max(ToLengthOrZero(lenVal, evalContext), 0), uint.MaxValue);
+            if (evalContext?.IsThrow == true) throw new ThrowSignal(evalContext.FlowValue);
+            if (index < length)
+            {
+                // Project value based on kind - no closure allocation
+                var valueJs = ProjectIteratorValue(kind, index, accessor, realm);
+                index++;
+                return new IteratorResultObject(valueJs, false).AsJsValue;
+            }
+
+            exhausted = true;
+            return IteratorResultObject.DoneUndefined.AsJsValue;
+        }
+
+        JsValue ReturnIterator(JsValue _, IReadOnlyList<JsValue> __, RealmState? ___)
+        {
+            return new JsValue(iterator);
+        }
     }
 
     internal static object CreateArrayIteratorObject(IJsPropertyAccessor accessor, Func<uint, JsValue> projector,
@@ -71,5 +153,31 @@ public static partial class StandardLibrary
         {
             return new JsValue(iterator);
         }
+    }
+
+    /// <summary>
+    /// Projects the iterator value based on kind. Inlined to avoid delegate allocation.
+    /// </summary>
+    private static JsValue ProjectIteratorValue(ArrayIteratorKind kind, uint index, IJsPropertyAccessor accessor,
+        RealmState? realm)
+    {
+        return kind switch
+        {
+            ArrayIteratorKind.Keys => new JsValue((double)index),
+            ArrayIteratorKind.Values => GetElementOrUndefinedJsValue(accessor, index),
+            ArrayIteratorKind.Entries => CreateIteratorEntryPair(index, accessor, realm),
+            _ => JsValue.Undefined
+        };
+    }
+
+    /// <summary>
+    /// Creates an [index, value] pair for entries iterator.
+    /// </summary>
+    private static JsValue CreateIteratorEntryPair(uint index, IJsPropertyAccessor accessor, RealmState? realm)
+    {
+        var pair = new JsArray(realm);
+        pair.Push((double)index);
+        pair.Push(GetElementOrUndefinedJsValue(accessor, index));
+        return JsValue.FromJsArray(pair);
     }
 }


### PR DESCRIPTION
## Summary

- Replace lambda-based array iterator creation with enum-based approach (`ArrayIteratorKind.Entries/Keys/Values`) to avoid closure allocations on every call to `entries()`/`keys()`/`values()`
- Add `static` keyword to lambdas in `AssignmentReferenceResolver` that don't capture any variables
- Add `static` keyword to lambda in `ObjectBindingExtensions`

## Changes

1. **ArrayPrototype.Iterators.cs** - Now passes `ArrayIteratorKind` enum instead of `Func<IJsPropertyAccessor, JsValue, Func<uint, JsValue>>` factory
2. **StandardLibrary.Array.Iterators.cs** - Added enum-based overload that projects values via switch expression instead of delegate invocation
3. **AssignmentReferenceResolver.cs** - Added `static` to two lambdas that return `JsValue.Undefined` (lines 199, 223)
4. **ObjectBindingExtensions.cs** - Added `static` to evaluate expression lambda

## Test plan

- [x] All existing tests pass (same 25 pre-existing failures as main branch)
- [ ] Profile to measure allocation reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)