### PR TITLE
Use cached index strings and eliminate LINQ allocations

### DIFF
--- a/src/Asynkron.JsEngine/Ast/FunctionExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/FunctionExpressionExtensions.cs
@@ -34,13 +34,19 @@ public static partial class TypedAstEvaluator
                     isStrict);
             }
 
-            var parameterSymbols = function.Parameters
-                .Where(static p => p is { IsRest: false, Pattern: null, DefaultValue: null, Name: not null })
-                .Select(static p => p.Name!)
-                .ToArray();
+            // Collect simple parameter symbols in a single pass (avoids LINQ allocations)
+            var parameterSymbols = new Symbol[function.Parameters.Length];
+            var symbolCount = 0;
+            foreach (var p in function.Parameters)
+            {
+                if (p is { IsRest: false, Pattern: null, DefaultValue: null, Name: not null })
+                {
+                    parameterSymbols[symbolCount++] = p.Name;
+                }
+            }
 
             var seen = new HashSet<Symbol>(ReferenceEqualityComparer<Symbol>.Instance);
-            for (var i = Math.Min(mappedParameters.Length, parameterSymbols.Length) - 1; i >= 0; i--)
+            for (var i = Math.Min(mappedParameters.Length, symbolCount) - 1; i >= 0; i--)
             {
                 var symbol = parameterSymbols[i];
                 if (!seen.Add(symbol))

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.cs
@@ -217,7 +217,7 @@ public static partial class TypedAstEvaluator
                 // Add all numeric indices as seen (already enumerated above)
                 for (var i = 0; i < array.Items.Count; i++)
                 {
-                    seenArrayKeys.Add(i.ToString(CultureInfo.InvariantCulture));
+                    seenArrayKeys.Add(JsValueCache.GetIndexString(i));
                 }
 
                 // Now enumerate non-index properties on the array and its prototype chain
@@ -288,7 +288,7 @@ public static partial class TypedAstEvaluator
             {
                 for (var i = 0; i < s.Length; i++)
                 {
-                    yield return JsValue.FromString(i.ToString(CultureInfo.InvariantCulture));
+                    yield return JsValue.FromString(JsValueCache.GetIndexString(i));
                 }
 
                 yield break;

--- a/src/Asynkron.JsEngine/JsTypes/JsObject.cs
+++ b/src/Asynkron.JsEngine/JsTypes/JsObject.cs
@@ -2225,7 +2225,7 @@ public sealed class JsObject : IDictionary<string, object?>, IJsObjectLike,
         numericKeys.Sort();
         foreach (var index in numericKeys)
         {
-            yield return index.ToString(CultureInfo.InvariantCulture);
+            yield return JsValueCache.GetIndexString((int)index);
         }
 
         foreach (var key in stringKeys)

--- a/src/Asynkron.JsEngine/JsTypes/TypedArrayBase.cs
+++ b/src/Asynkron.JsEngine/JsTypes/TypedArrayBase.cs
@@ -378,7 +378,7 @@ public bool TryGetProperty(string name, JsValue receiver, out JsValue value)
         var length = Length;
         for (var i = 0; i < length; i++)
         {
-            keys.Add(i.ToString(CultureInfo.InvariantCulture));
+            keys.Add(JsValueCache.GetIndexString(i));
         }
 
         keys.AddRange(_properties.GetOwnPropertyNames());
@@ -396,7 +396,7 @@ public bool TryGetProperty(string name, JsValue receiver, out JsValue value)
         var length = ComputeLength();
         for (var i = 0; i < length; i++)
         {
-            keys.Add(i.ToString(CultureInfo.InvariantCulture));
+            keys.Add(JsValueCache.GetIndexString(i));
         }
 
         keys.AddRange(_properties.GetOwnPropertyKeysInOrder(includeSymbols, includeNonEnumerable));
@@ -414,7 +414,7 @@ public bool TryGetProperty(string name, JsValue receiver, out JsValue value)
         var length = ComputeLength();
         for (var i = 0; i < length; i++)
         {
-            keys.Add(i.ToString(CultureInfo.InvariantCulture));
+            keys.Add(JsValueCache.GetIndexString(i));
         }
 
         keys.AddRange(_properties.GetEnumerablePropertyNames());


### PR DESCRIPTION
## Summary

Performance optimizations round 2 - reducing string allocations and LINQ overhead.

### Changes

1. **Cached index strings** - Use `JsValueCache.GetIndexString()` instead of `i.ToString(CultureInfo.InvariantCulture)`:
   - `TypedArrayBase.GetOwnPropertyNames()`
   - `TypedArrayBase.GetOwnPropertyKeysInOrder()`
   - `TypedArrayBase.GetEnumerablePropertyNames()`
   - `JsObject.GetOwnPropertyKeysInOrder()` (for sorted numeric keys)
   - `TypedAstEvaluator` for-in enumeration (array indices, string character indices)

2. **LINQ elimination** - Replace `function.Parameters.Where(...).Select(...).ToArray()` with single-pass foreach loop in `FunctionExpressionExtensions.CreateArgumentsObject()`

### Impact

- Eliminates string allocations for indices 0-9999 (uses pre-cached strings)
- Eliminates LINQ enumerator allocations and intermediate array in arguments object creation

## Test plan

- [x] All existing tests pass (same 25 pre-existing failures as main branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)