### PR TITLE
Fix duplicate execution on yield/await resume in blocks with let/const

### DIFF
--- a/src/Asynkron.JsEngine/Ast/ScopeDynamicnessAnalyzer.cs
+++ b/src/Asynkron.JsEngine/Ast/ScopeDynamicnessAnalyzer.cs
@@ -60,7 +60,7 @@ public static partial class TypedAstEvaluator
         return false;
     }
 
-    private static bool ContainsWithOrDirectEval(BlockStatement block)
+    internal static bool ContainsWithOrDirectEval(BlockStatement block)
     {
         if (block.TryGetContainsDynamicScope(out var cached))
         {

--- a/src/Asynkron.JsEngine/Execution/ExecutionPlanBuilder.cs
+++ b/src/Asynkron.JsEngine/Execution/ExecutionPlanBuilder.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using Asynkron.JsEngine.Ast;
 using Asynkron.JsEngine.Ast.ShapeAnalyzer;
 using Asynkron.JsEngine.JsTypes;
+using static Asynkron.JsEngine.Ast.TypedAstEvaluator;
 
 #endregion
 
@@ -191,11 +192,20 @@ internal sealed class ExecutionPlanBuilder
             {
                 case BlockStatement block:
                     // If the block needs its own scope (has let/const declarations),
-                    // use StatementInstruction to let the AST evaluator handle scope creation.
-                    // This ensures proper block scoping when exceptions are thrown.
+                    // we need to create an environment for it.
                     var hoistPlan = ((IAstCacheable<HoistPlan>)block).GetOrCreateCache();
                     if (hoistPlan.NeedsEnvironment)
                     {
+                        // If the block contains yield or await, we must NOT use StatementInstruction
+                        // because that causes duplicate execution on resume. Instead, emit
+                        // PushEnvironment + individual statements + PopEnvironment.
+                        if (AstShapeAnalyzer.StatementContainsYield(block) ||
+                            AstShapeAnalyzer.StatementContainsAwait(block))
+                        {
+                            return TryBuildBlockWithEnvironment(block, hoistPlan, nextIndex, out entryIndex);
+                        }
+
+                        // For blocks without yield/await, StatementInstruction is fine
                         entryIndex = Append(new StatementInstruction(nextIndex, block));
                         return true;
                     }
@@ -600,6 +610,54 @@ internal sealed class ExecutionPlanBuilder
                 entryIndex = instructionIndex;
             }
         }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Builds a block that needs its own environment AND contains yield/await.
+    /// Instead of using StatementInstruction (which causes duplicate execution on resume),
+    /// we emit PushEnvironment + individual statements + PopEnvironment.
+    /// </summary>
+    private bool TryBuildBlockWithEnvironment(BlockStatement block, HoistPlan hoistPlan, int nextIndex, out int entryIndex)
+    {
+        var instructionStart = _instructions.Count;
+
+        // Check if we can pool the environment (no closures or dynamic scope)
+        var allowPooling = !ContainsWithOrDirectEval(block) && !ContainsInnerFunctionExpression(block);
+
+        // Get scope info from the block (stamped by scope analysis)
+        var scopeId = block.ScopeId >= 0 ? block.ScopeId : -1;
+        var slotCount = block.SlotCount >= 0 ? block.SlotCount : 0;
+        var slotMap = block.SlotMap.IsEmpty
+            ? ImmutableDictionary<Symbol, int>.Empty.WithComparers(ReferenceEqualityComparer<Symbol>.Instance)
+            : block.SlotMap;
+
+        // Build instructions bottom-up (reverse order):
+        // 1. PopEnvironmentInstruction pointing to nextIndex
+        // 2. Body statements pointing to PopEnvironment
+        // 3. PushEnvironmentInstruction pointing to body entry
+
+        // 1. Pop environment (exit the block scope)
+        var popEnvIndex = Append(new PopEnvironmentInstruction(scopeId, allowPooling, nextIndex));
+
+        // 2. Build the body statements, they flow to PopEnvironment
+        if (!TryBuildStatementList(block.Statements, popEnvIndex, out var bodyEntry))
+        {
+            _instructions.RemoveRange(instructionStart, _instructions.Count - instructionStart);
+            entryIndex = -1;
+            return false;
+        }
+
+        // 3. Push environment (enter the block scope)
+        // For blocks, PerIterationBindings is empty (no loop iteration semantics)
+        entryIndex = Append(new PushEnvironmentInstruction(
+            bodyEntry,
+            hoistPlan.LexicalTemplate,
+            scopeId,
+            slotCount,
+            slotMap,
+            allowPooling));
 
         return true;
     }


### PR DESCRIPTION
## Summary
- Fix duplicate execution bug when yield/await happens inside blocks with let/const declarations
- Replace StatementInstruction with proper IR (PushEnvironment + statements + PopEnvironment) for suspendable blocks

## Problem
When a block statement needs an environment (has `let`/`const` declarations) AND contains `yield` or `await`, the `ExecutionPlanBuilder` was using `StatementInstruction` to wrap the block. This caused duplicate execution because:
1. `_programCounter` wasn't updated when yield/await happened inside `StatementInstruction`
2. On resume, the entire block re-executed from the beginning
3. Code before the yield/await ran again

## Solution
For blocks that need an environment AND contain yield/await, emit proper IR:
- `PushEnvironmentInstruction` (enter block scope)
- Individual statement instructions (suspendable at IR level)
- `PopEnvironmentInstruction` (exit block scope)

## Test plan
- [x] All 217 generator tests pass
- [x] Full test suite: 2156 passed, 4 failures (all pre-existing on main)
- [x] Build succeeds with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)