### PR TITLE
Delegate TryGetObject(object?) to JsValue overload

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/StandardLibrary.Helpers.cs
+++ b/src/Asynkron.JsEngine/StdLib/StandardLibrary.Helpers.cs
@@ -27,22 +27,8 @@ public static partial class StandardLibrary
                     accessor = null!;
                     return false;
                 case JsValue jsValue:
-                    // Handle JsValue by extracting the underlying object based on kind
-                    if (jsValue is { Kind: JsValueKind.Object, ObjectValue: { } objVal })
-                    {
-                        candidate = objVal;
-                        continue;
-                    }
-
-                    if (jsValue.IsNullOrUndefined)
-                    {
-                        accessor = null!;
-                        return false;
-                    }
-
-                    // For primitives, use ObjectValue which contains the wrapped value
-                    candidate = jsValue.ObjectValue;
-                    continue;
+                    // Delegate to the JsValue-specific overload which handles all kinds properly
+                    return TryGetObject(jsValue, realm, out accessor);
                 case IJsObjectLike objectLike:
                     accessor = objectLike;
                     return true;


### PR DESCRIPTION
## Summary
- The `TryGetObject(object?, ...)` overload was duplicating JsValue handling logic
- Now delegates to `TryGetObject(JsValue, ...)` when it detects a JsValue
- Eliminates code duplication and ensures consistent behavior

## Before
```csharp
case JsValue jsValue:
    if (jsValue is { Kind: JsValueKind.Object, ObjectValue: { } objVal })
    {
        candidate = objVal;
        continue;
    }
    if (jsValue.IsNullOrUndefined)
    {
        accessor = null!;
        return false;
    }
    candidate = jsValue.ObjectValue;
    continue;
```

## After
```csharp
case JsValue jsValue:
    return TryGetObject(jsValue, realm, out accessor);
```

**Net reduction: 14 lines**

## Test plan
- [x] All 2,770 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)