### PR TITLE
Consolidate duplicate emitter helpers and remove Internal wrappers

### DIFF
--- a/src/Asynkron.JsEngine/Execution/Emitters/DeclarationEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/DeclarationEmitter.cs
@@ -108,18 +108,13 @@ internal static class DeclarationEmitter
             return false;
         }
 
-        if (!IsLowererTemp(targetSymbol))
+        if (!EmitContext.IsLowererTemp(targetSymbol))
         {
             return false;
         }
 
-        return YieldEmitter.TryEmitVariableWithYieldInitializer(
+        return YieldEmitter.TryEmitYieldToSymbol(
             ctx, targetSymbol, yieldInitializer, nextIndex, out entryIndex);
-    }
-
-    private static bool IsLowererTemp(Symbol symbol)
-    {
-        return symbol.Name?.StartsWith("__yield_lower_", StringComparison.Ordinal) == true;
     }
 
     private static bool DeclarationContainsYield(VariableDeclaration declaration)
@@ -127,20 +122,14 @@ internal static class DeclarationEmitter
         return declaration.Declarators.Any(static d =>
             d.Initializer is not null &&
             AstShapeAnalyzer.ContainsYield(d.Initializer) &&
-            !IsLowererTemp(d.Target));
-    }
-
-    private static bool IsLowererTemp(BindingTarget target)
-    {
-        return target is IdentifierBinding { Name.Name: not null } identifier &&
-               identifier.Name.Name.StartsWith("__yield_lower_", StringComparison.Ordinal);
+            !EmitContext.IsLowererTemp(d.Target));
     }
 
     private static bool DeclarationContainsYieldInBindingTargetDefaults(VariableDeclaration declaration)
     {
         return declaration.Declarators.Any(static d =>
             BindingTargetContainsYieldInDefaultValue(d.Target) ||
-            (d.Initializer is not null && ExpressionContainsDestructuringWithYieldAnywhere(d.Initializer)));
+            (d.Initializer is not null && EmitContext.ExpressionContainsDestructuringWithYieldAnywhere(d.Initializer)));
     }
 
     private static bool BindingTargetContainsYieldInDefaultValue(BindingTarget target)
@@ -170,78 +159,6 @@ internal static class DeclarationEmitter
                 }
                 if (objectBinding.RestElement is not null &&
                     BindingTargetContainsYieldInDefaultValue(objectBinding.RestElement))
-                    return true;
-                return false;
-
-            case AssignmentTargetBinding assignmentTarget:
-                return AstShapeAnalyzer.ContainsYield(assignmentTarget.Expression);
-
-            default:
-                return false;
-        }
-    }
-
-    private static bool ExpressionContainsDestructuringWithYieldAnywhere(ExpressionNode expression)
-    {
-        while (true)
-        {
-            switch (expression)
-            {
-                case DestructuringAssignmentExpression destructuringExpr:
-                    if (BindingTargetContainsYieldAnywhere(destructuringExpr.Target))
-                        return true;
-                    expression = destructuringExpr.Value;
-                    continue;
-                case AssignmentExpression assignmentExpr:
-                    expression = assignmentExpr.Value;
-                    continue;
-                case PropertyAssignmentExpression propAssignExpr:
-                    expression = propAssignExpr.Value;
-                    continue;
-                case IndexAssignmentExpression indexAssignExpr:
-                    expression = indexAssignExpr.Value;
-                    continue;
-                case ConditionalExpression conditionalExpr:
-                    return ExpressionContainsDestructuringWithYieldAnywhere(conditionalExpr.Consequent) ||
-                           ExpressionContainsDestructuringWithYieldAnywhere(conditionalExpr.Alternate);
-                case SequenceExpression seqExpr:
-                    return ExpressionContainsDestructuringWithYieldAnywhere(seqExpr.Left) ||
-                           ExpressionContainsDestructuringWithYieldAnywhere(seqExpr.Right);
-                default:
-                    return false;
-            }
-        }
-    }
-
-    private static bool BindingTargetContainsYieldAnywhere(BindingTarget target)
-    {
-        switch (target)
-        {
-            case ArrayBinding arrayBinding:
-                foreach (var element in arrayBinding.Elements)
-                {
-                    if (element.DefaultValue is not null && AstShapeAnalyzer.ContainsYield(element.DefaultValue))
-                        return true;
-                    if (element.Target is not null && BindingTargetContainsYieldAnywhere(element.Target))
-                        return true;
-                }
-                if (arrayBinding.RestElement is not null &&
-                    BindingTargetContainsYieldAnywhere(arrayBinding.RestElement))
-                    return true;
-                return false;
-
-            case ObjectBinding objectBinding:
-                foreach (var prop in objectBinding.Properties)
-                {
-                    if (prop.DefaultValue is not null && AstShapeAnalyzer.ContainsYield(prop.DefaultValue))
-                        return true;
-                    if (prop.NameExpression is not null && AstShapeAnalyzer.ContainsYield(prop.NameExpression))
-                        return true;
-                    if (BindingTargetContainsYieldAnywhere(prop.Target))
-                        return true;
-                }
-                if (objectBinding.RestElement is not null &&
-                    BindingTargetContainsYieldAnywhere(objectBinding.RestElement))
                     return true;
                 return false;
 
@@ -363,10 +280,16 @@ internal static class DeclarationEmitter
     // Helper Methods
     // ─────────────────────────────────────────────────────────────────────────
 
-    private static bool ClassDefinitionContainsYield(ClassDefinition definition)
+    private static bool ClassDefinitionContainsYield(ClassDefinition definition) =>
+        ClassDefinitionContains(definition, static e => AstShapeAnalyzer.ContainsYield(e));
+
+    private static bool ClassDefinitionContainsAwait(ClassDefinition definition) =>
+        ClassDefinitionContains(definition, static e => AstShapeAnalyzer.ContainsAwait(e));
+
+    private static bool ClassDefinitionContains(ClassDefinition definition, Func<ExpressionNode, bool> predicate)
     {
         // Check extends clause
-        if (definition.Extends is not null && AstShapeAnalyzer.ContainsYield(definition.Extends))
+        if (definition.Extends is not null && predicate(definition.Extends))
         {
             return true;
         }
@@ -375,7 +298,7 @@ internal static class DeclarationEmitter
         foreach (var member in definition.Members)
         {
             if (member is { IsComputed: true, ComputedName: not null } &&
-                AstShapeAnalyzer.ContainsYield(member.ComputedName))
+                predicate(member.ComputedName))
             {
                 return true;
             }
@@ -385,38 +308,7 @@ internal static class DeclarationEmitter
         foreach (var field in definition.Fields)
         {
             if (field is { IsComputed: true, ComputedName: not null } &&
-                AstShapeAnalyzer.ContainsYield(field.ComputedName))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static bool ClassDefinitionContainsAwait(ClassDefinition definition)
-    {
-        // Check extends clause
-        if (definition.Extends is not null && AstShapeAnalyzer.ContainsAwait(definition.Extends))
-        {
-            return true;
-        }
-
-        // Check computed property names in members (methods, getters, setters)
-        foreach (var member in definition.Members)
-        {
-            if (member is { IsComputed: true, ComputedName: not null } &&
-                AstShapeAnalyzer.ContainsAwait(member.ComputedName))
-            {
-                return true;
-            }
-        }
-
-        // Check computed property names in fields
-        foreach (var field in definition.Fields)
-        {
-            if (field is { IsComputed: true, ComputedName: not null } &&
-                AstShapeAnalyzer.ContainsAwait(field.ComputedName))
+                predicate(field.ComputedName))
             {
                 return true;
             }

--- a/src/Asynkron.JsEngine/Execution/Emitters/EmitContext.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/EmitContext.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using Asynkron.JsEngine.Ast;
+using Asynkron.JsEngine.Ast.ShapeAnalyzer;
 using Asynkron.JsEngine.Execution.Instructions;
 
 namespace Asynkron.JsEngine.Execution.Emitters;
@@ -112,7 +113,7 @@ internal sealed class EmitContext(
     /// </summary>
     public bool TryBuildStatementList(ImmutableArray<StatementNode> statements, int nextIndex, out int entryIndex)
     {
-        return builder.TryBuildStatementListInternal(statements, nextIndex, out entryIndex);
+        return builder.TryBuildStatementList(statements, nextIndex, out entryIndex);
     }
 
     /// <summary>
@@ -128,7 +129,7 @@ internal sealed class EmitContext(
     /// </summary>
     public void SetFailureReason(string reason)
     {
-        builder.SetFailureReasonInternal(reason);
+        builder.SetFailureReason(reason);
     }
 
     /// <summary>
@@ -136,7 +137,7 @@ internal sealed class EmitContext(
     /// </summary>
     public Symbol CreateCatchSlotSymbol()
     {
-        return builder.CreateCatchSlotSymbolInternal();
+        return builder.CreateCatchSlotSymbol();
     }
 
     /// <summary>
@@ -144,7 +145,7 @@ internal sealed class EmitContext(
     /// </summary>
     public BlockStatement BuildCatchBlock(CatchClause catchClause, Symbol catchSlotSymbol)
     {
-        return ExecutionPlanBuilder.BuildCatchBlockInternal(catchClause, catchSlotSymbol);
+        return ExecutionPlanBuilder.BuildCatchBlock(catchClause, catchSlotSymbol);
     }
 
     /// <summary>
@@ -152,20 +153,20 @@ internal sealed class EmitContext(
     /// </summary>
     public int AllocateSlot(Symbol symbol)
     {
-        return builder.AllocateSlotInternal(symbol);
+        return builder.AllocateSlot(symbol);
     }
 
     /// <summary>
     /// Get the instruction list (for IteratorInstructionTemplate).
     /// </summary>
-    public List<ExecutionInstruction> Instructions => builder.InstructionsInternal;
+    public List<ExecutionInstruction> Instructions => builder.Instructions;
 
     /// <summary>
     /// Create iterator binding statement.
     /// </summary>
     public static StatementNode CreateIteratorBindingStatement(IteratorDriverPlan plan, Symbol valueSymbol, int valueSlotIndex)
     {
-        return ExecutionPlanBuilder.CreateIteratorBindingStatementInternal(plan, valueSymbol, valueSlotIndex);
+        return ExecutionPlanBuilder.CreateIteratorBindingStatement(plan, valueSymbol, valueSlotIndex);
     }
 
     /// <summary>
@@ -173,7 +174,7 @@ internal sealed class EmitContext(
     /// </summary>
     public static bool IsStrictBlock(StatementNode statement)
     {
-        return ExecutionPlanBuilder.IsStrictBlockInternal(statement);
+        return ExecutionPlanBuilder.IsStrictBlock(statement);
     }
 
     /// <summary>
@@ -181,7 +182,7 @@ internal sealed class EmitContext(
     /// </summary>
     public static bool ContainsUnlabeledAbruptInFinally(StatementNode statement)
     {
-        return ExecutionPlanBuilder.ContainsUnlabeledAbruptInFinallyInternal(statement);
+        return ExecutionPlanBuilder.ContainsUnlabeledAbruptInFinally(statement);
     }
 
     /// <summary>
@@ -189,7 +190,7 @@ internal sealed class EmitContext(
     /// </summary>
     public Symbol CreateWithScopeSlotSymbol()
     {
-        return builder.CreateWithScopeSlotSymbolInternal();
+        return builder.CreateWithScopeSlotSymbol();
     }
 
     /// <summary>
@@ -197,7 +198,7 @@ internal sealed class EmitContext(
     /// </summary>
     public Symbol CreateResumeSlotSymbol()
     {
-        return builder.CreateResumeSlotSymbolInternal();
+        return builder.CreateResumeSlotSymbol();
     }
 
     /// <summary>
@@ -205,7 +206,7 @@ internal sealed class EmitContext(
     /// </summary>
     public int AppendYieldSequence(ExpressionNode? expression, int continuationIndex, Symbol? resumeSlot)
     {
-        return builder.AppendYieldSequenceInternal(expression, continuationIndex, resumeSlot);
+        return builder.AppendYieldSequence(expression, continuationIndex, resumeSlot);
     }
 
     /// <summary>
@@ -213,7 +214,7 @@ internal sealed class EmitContext(
     /// </summary>
     public int AppendYieldStarSequence(YieldExpression expression, int continuationIndex, Symbol? resultSlot)
     {
-        return builder.AppendYieldStarSequenceInternal(expression, continuationIndex, resultSlot);
+        return builder.AppendYieldStarSequence(expression, continuationIndex, resultSlot);
     }
 
     /// <summary>
@@ -236,5 +237,128 @@ internal sealed class EmitContext(
         }
 
         return slotMapBuilder.ToImmutable();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Shared Yield Detection Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Check if a symbol is a lowerer-generated temporary variable.
+    /// </summary>
+    public static bool IsLowererTemp(Symbol symbol)
+    {
+        return symbol.Name?.StartsWith("__yield_lower_", StringComparison.Ordinal) == true;
+    }
+
+    /// <summary>
+    /// Check if a binding target is a lowerer-generated temporary variable.
+    /// </summary>
+    public static bool IsLowererTemp(BindingTarget target)
+    {
+        return target is IdentifierBinding { Name.Name: not null } identifier &&
+               identifier.Name.Name.StartsWith("__yield_lower_", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Checks if a binding target contains yields anywhere - either in default values
+    /// or in assignment target expressions (like [ {}[ yield ] ]).
+    /// </summary>
+    public static bool BindingTargetContainsYieldAnywhere(BindingTarget target)
+    {
+        switch (target)
+        {
+            case ArrayBinding arrayBinding:
+                foreach (var element in arrayBinding.Elements)
+                {
+                    if (element.DefaultValue is not null && AstShapeAnalyzer.ContainsYield(element.DefaultValue))
+                    {
+                        return true;
+                    }
+                    if (element.Target is not null && BindingTargetContainsYieldAnywhere(element.Target))
+                    {
+                        return true;
+                    }
+                }
+                if (arrayBinding.RestElement is not null &&
+                    BindingTargetContainsYieldAnywhere(arrayBinding.RestElement))
+                {
+                    return true;
+                }
+                return false;
+
+            case ObjectBinding objectBinding:
+                foreach (var prop in objectBinding.Properties)
+                {
+                    if (prop.DefaultValue is not null && AstShapeAnalyzer.ContainsYield(prop.DefaultValue))
+                    {
+                        return true;
+                    }
+                    if (prop.NameExpression is not null && AstShapeAnalyzer.ContainsYield(prop.NameExpression))
+                    {
+                        return true;
+                    }
+                    if (BindingTargetContainsYieldAnywhere(prop.Target))
+                    {
+                        return true;
+                    }
+                }
+                if (objectBinding.RestElement is not null &&
+                    BindingTargetContainsYieldAnywhere(objectBinding.RestElement))
+                {
+                    return true;
+                }
+                return false;
+
+            case AssignmentTargetBinding assignmentTarget:
+                return AstShapeAnalyzer.ContainsYield(assignmentTarget.Expression);
+
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Checks if an expression contains a destructuring assignment with yields anywhere in
+    /// the binding target - either in default values or in assignment target expressions.
+    /// </summary>
+    public static bool ExpressionContainsDestructuringWithYieldAnywhere(ExpressionNode expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case DestructuringAssignmentExpression destructuringExpr:
+                    if (BindingTargetContainsYieldAnywhere(destructuringExpr.Target))
+                    {
+                        return true;
+                    }
+                    expression = destructuringExpr.Value;
+                    continue;
+
+                case AssignmentExpression assignmentExpr:
+                    expression = assignmentExpr.Value;
+                    continue;
+
+                case PropertyAssignmentExpression propAssignExpr:
+                    expression = propAssignExpr.Value;
+                    continue;
+
+                case IndexAssignmentExpression indexAssignExpr:
+                    expression = indexAssignExpr.Value;
+                    continue;
+
+                case ConditionalExpression conditionalExpr:
+                    return ExpressionContainsDestructuringWithYieldAnywhere(conditionalExpr.Consequent) ||
+                           ExpressionContainsDestructuringWithYieldAnywhere(conditionalExpr.Alternate);
+
+                case SequenceExpression seqExpr:
+                    return ExpressionContainsDestructuringWithYieldAnywhere(seqExpr.Left) ||
+                           ExpressionContainsDestructuringWithYieldAnywhere(seqExpr.Right);
+
+                default:
+                    return false;
+            }
+        }
     }
 }

--- a/src/Asynkron.JsEngine/Execution/Emitters/ExpressionStatementEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/ExpressionStatementEmitter.cs
@@ -25,9 +25,9 @@ internal static class ExpressionStatementEmitter
             {
                 Target: { } targetSymbol, Value: YieldExpression yieldAssignment
             } &&
-            IsLowererTemp(targetSymbol))
+            EmitContext.IsLowererTemp(targetSymbol))
         {
-            if (YieldEmitter.TryEmitYieldAssignment(
+            if (YieldEmitter.TryEmitYieldToSymbol(
                 ctx, targetSymbol, yieldAssignment, nextIndex, out entryIndex))
             {
                 return true;
@@ -39,7 +39,7 @@ internal static class ExpressionStatementEmitter
         // - Yields in default values (only evaluated when element is undefined)
         // - Yields in assignment target expressions (e.g., [ {}[ yield ] ] = x)
         // Wrap them as StatementInstruction to use AST evaluation's state-saving.
-        if (ExpressionContainsDestructuringWithYieldAnywhere(expressionStatement.Expression))
+        if (EmitContext.ExpressionContainsDestructuringWithYieldAnywhere(expressionStatement.Expression))
         {
             entryIndex = ctx.Append(new StatementInstruction(nextIndex, expressionStatement));
             return true;
@@ -90,108 +90,5 @@ internal static class ExpressionStatementEmitter
         // Use native EvaluateAndDiscardInstruction - evaluates expression and discards result
         entryIndex = ctx.Append(new EvaluateAndDiscardInstruction(nextIndex, expressionStatement.Expression));
         return true;
-    }
-
-    private static bool IsLowererTemp(Symbol symbol)
-    {
-        return symbol.Name?.StartsWith("__yield_lower_", StringComparison.Ordinal) == true;
-    }
-
-    /// <summary>
-    /// Checks if an expression contains a destructuring assignment with yields anywhere in
-    /// the binding target - either in default values or in assignment target expressions.
-    /// </summary>
-    private static bool ExpressionContainsDestructuringWithYieldAnywhere(ExpressionNode expression)
-    {
-        while (true)
-        {
-            switch (expression)
-            {
-                case DestructuringAssignmentExpression destructuringExpr:
-                    if (BindingTargetContainsYieldAnywhere(destructuringExpr.Target))
-                    {
-                        return true;
-                    }
-                    expression = destructuringExpr.Value;
-                    continue;
-
-                case AssignmentExpression assignmentExpr:
-                    expression = assignmentExpr.Value;
-                    continue;
-
-                case PropertyAssignmentExpression propAssignExpr:
-                    expression = propAssignExpr.Value;
-                    continue;
-
-                case IndexAssignmentExpression indexAssignExpr:
-                    expression = indexAssignExpr.Value;
-                    continue;
-
-                case ConditionalExpression conditionalExpr:
-                    return ExpressionContainsDestructuringWithYieldAnywhere(conditionalExpr.Consequent) ||
-                           ExpressionContainsDestructuringWithYieldAnywhere(conditionalExpr.Alternate);
-
-                case SequenceExpression seqExpr:
-                    return ExpressionContainsDestructuringWithYieldAnywhere(seqExpr.Left) ||
-                           ExpressionContainsDestructuringWithYieldAnywhere(seqExpr.Right);
-
-                default:
-                    return false;
-            }
-        }
-    }
-
-    private static bool BindingTargetContainsYieldAnywhere(BindingTarget target)
-    {
-        switch (target)
-        {
-            case ArrayBinding arrayBinding:
-                foreach (var element in arrayBinding.Elements)
-                {
-                    if (element.DefaultValue is not null && AstShapeAnalyzer.ContainsYield(element.DefaultValue))
-                    {
-                        return true;
-                    }
-                    if (element.Target is not null && BindingTargetContainsYieldAnywhere(element.Target))
-                    {
-                        return true;
-                    }
-                }
-                if (arrayBinding.RestElement is not null &&
-                    BindingTargetContainsYieldAnywhere(arrayBinding.RestElement))
-                {
-                    return true;
-                }
-                return false;
-
-            case ObjectBinding objectBinding:
-                foreach (var prop in objectBinding.Properties)
-                {
-                    if (prop.DefaultValue is not null && AstShapeAnalyzer.ContainsYield(prop.DefaultValue))
-                    {
-                        return true;
-                    }
-                    if (prop.NameExpression is not null && AstShapeAnalyzer.ContainsYield(prop.NameExpression))
-                    {
-                        return true;
-                    }
-                    if (BindingTargetContainsYieldAnywhere(prop.Target))
-                    {
-                        return true;
-                    }
-                }
-                if (objectBinding.RestElement is not null &&
-                    BindingTargetContainsYieldAnywhere(objectBinding.RestElement))
-                {
-                    return true;
-                }
-                return false;
-
-            case AssignmentTargetBinding assignmentTarget:
-                return AstShapeAnalyzer.ContainsYield(assignmentTarget.Expression);
-
-            default:
-                return false;
-        }
     }
 }

--- a/src/Asynkron.JsEngine/Execution/Emitters/ForOfEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/ForOfEmitter.cs
@@ -13,35 +13,9 @@ namespace Asynkron.JsEngine.Execution.Emitters;
 internal static class ForOfEmitter
 {
     /// <summary>
-    /// Emit IR for a for-of statement.
+    /// Emit IR for a for-of or for-await-of statement.
     /// </summary>
-    public static bool TryEmitForOf(
-        EmitContext ctx,
-        ForEachStatement statement,
-        int nextIndex,
-        Symbol? label,
-        out int entryIndex)
-    {
-        return TryEmitIteratorPlan(ctx, statement, nextIndex, label, out entryIndex);
-    }
-
-    /// <summary>
-    /// Emit IR for a for-await-of statement.
-    /// </summary>
-    public static bool TryEmitForAwaitOf(
-        EmitContext ctx,
-        ForEachStatement statement,
-        int nextIndex,
-        Symbol? label,
-        out int entryIndex)
-    {
-        return TryEmitIteratorPlan(ctx, statement, nextIndex, label, out entryIndex);
-    }
-
-    /// <summary>
-    /// Emit IR for an iterator-based loop (for-of or for-await-of).
-    /// </summary>
-    private static bool TryEmitIteratorPlan(
+    public static bool TryEmit(
         EmitContext ctx,
         ForEachStatement statement,
         int nextIndex,

--- a/src/Asynkron.JsEngine/Execution/Emitters/StatementEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/StatementEmitter.cs
@@ -70,13 +70,9 @@ internal static class StatementEmitter
                     entryIndex = ctx.Append(new StatementInstruction(nextIndex, forInStatement));
                     return true;
 
-                case ForEachStatement { Kind: ForEachKind.Of } forEachStatement
+                case ForEachStatement { Kind: ForEachKind.Of or ForEachKind.AwaitOf } forEachStatement
                     when IsSimpleForOfBinding(forEachStatement):
-                    return TryEmitForOf(ctx, forEachStatement, nextIndex, activeLabel, out entryIndex);
-
-                case ForEachStatement { Kind: ForEachKind.AwaitOf } forEachStatement
-                    when IsSimpleForOfBinding(forEachStatement):
-                    return TryEmitForAwaitOf(ctx, forEachStatement, nextIndex, activeLabel, out entryIndex);
+                    return TryEmitForEach(ctx, forEachStatement, nextIndex, activeLabel, out entryIndex);
 
                 case ReturnStatement returnStatement:
                     // First check for yield return
@@ -142,7 +138,7 @@ internal static class StatementEmitter
             return false;
         }
 
-        var whileStrict = IsStrictBlock(whileStatement.Body);
+        var whileStrict = EmitContext.IsStrictBlock(whileStatement.Body);
         if (!LoopNormalizer.TryNormalize(whileStatement, whileStrict, out var whilePlan, out var whileFailure))
         {
             ctx.SetFailureReason(whileFailure ?? "Failed to normalize while loop.");
@@ -167,7 +163,7 @@ internal static class StatementEmitter
             return false;
         }
 
-        var doStrict = IsStrictBlock(doWhileStatement.Body);
+        var doStrict = EmitContext.IsStrictBlock(doWhileStatement.Body);
         if (!LoopNormalizer.TryNormalize(doWhileStatement, doStrict, out var doWhilePlan, out var doFailure))
         {
             ctx.SetFailureReason(doFailure ?? "Failed to normalize do/while loop.");
@@ -199,7 +195,7 @@ internal static class StatementEmitter
             return false;
         }
 
-        var forStrict = IsStrictBlock(forStatement.Body);
+        var forStrict = EmitContext.IsStrictBlock(forStatement.Body);
         if (!LoopNormalizer.TryNormalize(forStatement, forStrict, out var forPlan, out var forFailure))
         {
             ctx.SetFailureReason(forFailure ?? "Failed to normalize for loop.");
@@ -214,7 +210,7 @@ internal static class StatementEmitter
     // For-Of/For-Await-Of Helpers
     // ─────────────────────────────────────────────────────────────────────────
 
-    private static bool TryEmitForOf(
+    private static bool TryEmitForEach(
         EmitContext ctx,
         ForEachStatement forEachStatement,
         int nextIndex,
@@ -224,7 +220,7 @@ internal static class StatementEmitter
         // If binding target has yields anywhere (defaults or assignment target expressions),
         // wrap as StatementInstruction. The AST evaluator handles yield state-saving correctly.
         // This handles patterns like: for ([ {}[ yield ] ] of iterable) { }
-        if (BindingTargetContainsYieldAnywhere(forEachStatement.Target) &&
+        if (EmitContext.BindingTargetContainsYieldAnywhere(forEachStatement.Target) &&
             !AstShapeAnalyzer.StatementContainsYield(forEachStatement.Body) &&
             !AstShapeAnalyzer.ContainsYield(forEachStatement.Iterable))
         {
@@ -232,27 +228,7 @@ internal static class StatementEmitter
             return true;
         }
 
-        return ForOfEmitter.TryEmitForOf(ctx, forEachStatement, nextIndex, activeLabel, out entryIndex);
-    }
-
-    private static bool TryEmitForAwaitOf(
-        EmitContext ctx,
-        ForEachStatement forEachStatement,
-        int nextIndex,
-        Symbol? activeLabel,
-        out int entryIndex)
-    {
-        // If binding target has yields anywhere (defaults or assignment target expressions),
-        // wrap as StatementInstruction. Same reasoning as for regular for-of loops above.
-        if (BindingTargetContainsYieldAnywhere(forEachStatement.Target) &&
-            !AstShapeAnalyzer.StatementContainsYield(forEachStatement.Body) &&
-            !AstShapeAnalyzer.ContainsYield(forEachStatement.Iterable))
-        {
-            entryIndex = ctx.Append(new StatementInstruction(nextIndex, forEachStatement));
-            return true;
-        }
-
-        return ForOfEmitter.TryEmitForAwaitOf(ctx, forEachStatement, nextIndex, activeLabel, out entryIndex);
+        return ForOfEmitter.TryEmit(ctx, forEachStatement, nextIndex, activeLabel, out entryIndex);
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -289,87 +265,9 @@ internal static class StatementEmitter
     // Helper Methods
     // ─────────────────────────────────────────────────────────────────────────
 
-    private static bool IsStrictBlock(StatementNode statement)
-    {
-        return statement is BlockStatement { IsStrict: true };
-    }
-
     private static bool IsSimpleForOfBinding(ForEachStatement statement)
     {
         // We now allow identifier or destructuring targets for all declaration kinds.
         return statement.Target is not null;
-    }
-
-    /// <summary>
-    /// Checks if a binding target contains yields anywhere - either in default values
-    /// or in assignment target expressions (like [ {}[ yield ] ]).
-    /// This is used to determine when to wrap declarations in StatementInstruction.
-    /// </summary>
-    private static bool BindingTargetContainsYieldAnywhere(BindingTarget target)
-    {
-        switch (target)
-        {
-            case ArrayBinding arrayBinding:
-                foreach (var element in arrayBinding.Elements)
-                {
-                    // Check for yields in default values
-                    if (element.DefaultValue is not null && AstShapeAnalyzer.ContainsYield(element.DefaultValue))
-                    {
-                        return true;
-                    }
-
-                    // Recursively check nested bindings
-                    if (element.Target is not null && BindingTargetContainsYieldAnywhere(element.Target))
-                    {
-                        return true;
-                    }
-                }
-
-                if (arrayBinding.RestElement is not null &&
-                    BindingTargetContainsYieldAnywhere(arrayBinding.RestElement))
-                {
-                    return true;
-                }
-
-                return false;
-
-            case ObjectBinding objectBinding:
-                foreach (var prop in objectBinding.Properties)
-                {
-                    // Check for yields in default values
-                    if (prop.DefaultValue is not null && AstShapeAnalyzer.ContainsYield(prop.DefaultValue))
-                    {
-                        return true;
-                    }
-
-                    // Check for yields in computed property names
-                    if (prop.NameExpression is not null && AstShapeAnalyzer.ContainsYield(prop.NameExpression))
-                    {
-                        return true;
-                    }
-
-                    // Recursively check nested bindings
-                    if (BindingTargetContainsYieldAnywhere(prop.Target))
-                    {
-                        return true;
-                    }
-                }
-
-                if (objectBinding.RestElement is not null &&
-                    BindingTargetContainsYieldAnywhere(objectBinding.RestElement))
-                {
-                    return true;
-                }
-
-                return false;
-
-            case AssignmentTargetBinding assignmentTarget:
-                // Check if the assignment target expression contains a yield
-                return AstShapeAnalyzer.ContainsYield(assignmentTarget.Expression);
-
-            default:
-                // IdentifierBinding doesn't have expressions or default values
-                return false;
-        }
     }
 }

--- a/src/Asynkron.JsEngine/Execution/Emitters/YieldEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/YieldEmitter.cs
@@ -76,46 +76,25 @@ internal static class YieldEmitter
     }
 
     /// <summary>
-    /// Try to emit IR for a yield assignment expression (lowerer temp assignment).
+    /// Try to emit IR for a yield assignment/initializer expression (lowerer temp).
+    /// Used for both assignment expressions and variable declarations.
     /// </summary>
-    public static bool TryEmitYieldAssignment(
+    public static bool TryEmitYieldToSymbol(
         EmitContext ctx,
         Symbol targetSymbol,
-        YieldExpression yieldAssignment,
+        YieldExpression yieldExpression,
         int nextIndex,
         out int entryIndex)
     {
-        if (AstShapeAnalyzer.ContainsYield(yieldAssignment.Expression))
+        if (AstShapeAnalyzer.ContainsYield(yieldExpression.Expression))
         {
             entryIndex = -1;
             return false;
         }
 
-        entryIndex = yieldAssignment.IsDelegated
-            ? ctx.AppendYieldStarSequence(yieldAssignment, nextIndex, targetSymbol)
-            : ctx.AppendYieldSequence(yieldAssignment.Expression, nextIndex, targetSymbol);
-        return true;
-    }
-
-    /// <summary>
-    /// Try to emit IR for a variable declaration with yield initializer (lowerer temp).
-    /// </summary>
-    public static bool TryEmitVariableWithYieldInitializer(
-        EmitContext ctx,
-        Symbol targetSymbol,
-        YieldExpression yieldInitializer,
-        int nextIndex,
-        out int entryIndex)
-    {
-        if (AstShapeAnalyzer.ContainsYield(yieldInitializer.Expression))
-        {
-            entryIndex = -1;
-            return false;
-        }
-
-        entryIndex = yieldInitializer.IsDelegated
-            ? ctx.AppendYieldStarSequence(yieldInitializer, nextIndex, targetSymbol)
-            : ctx.AppendYieldSequence(yieldInitializer.Expression, nextIndex, targetSymbol);
+        entryIndex = yieldExpression.IsDelegated
+            ? ctx.AppendYieldStarSequence(yieldExpression, nextIndex, targetSymbol)
+            : ctx.AppendYieldSequence(yieldExpression.Expression, nextIndex, targetSymbol);
         return true;
     }
 }

--- a/src/Asynkron.JsEngine/Execution/ExecutionPlanBuilder.Emitters.cs
+++ b/src/Asynkron.JsEngine/Execution/ExecutionPlanBuilder.Emitters.cs
@@ -1,13 +1,11 @@
-using System.Collections.Immutable;
 using Asynkron.JsEngine.Ast;
 using Asynkron.JsEngine.Execution.Emitters;
 using Asynkron.JsEngine.Execution.Instructions;
-using Asynkron.JsEngine.JsTypes;
 
 namespace Asynkron.JsEngine.Execution;
 
 /// <summary>
-/// Partial class exposing internal methods for emitters.
+/// Partial class exposing internal members for emitters.
 /// </summary>
 internal sealed partial class ExecutionPlanBuilder
 {
@@ -23,112 +21,20 @@ internal sealed partial class ExecutionPlanBuilder
     }
 
     /// <summary>
-    /// Internal method for EmitContext to build a statement list.
+    /// Sets the failure reason if not already set.
     /// </summary>
-    internal bool TryBuildStatementListInternal(ImmutableArray<StatementNode> statements, int nextIndex, out int entryIndex)
-    {
-        return TryBuildStatementList(statements, nextIndex, out entryIndex);
-    }
-
-    /// <summary>
-    /// Internal method for EmitContext to set failure reason.
-    /// </summary>
-    internal void SetFailureReasonInternal(string reason)
+    internal void SetFailureReason(string reason)
     {
         _failureReason ??= reason;
     }
 
     /// <summary>
-    /// Internal method for EmitContext to create catch slot symbol.
+    /// Access to the instruction list for emitters.
     /// </summary>
-    internal Symbol CreateCatchSlotSymbolInternal()
-    {
-        return CreateCatchSlotSymbol();
-    }
-
-    /// <summary>
-    /// Internal static method for EmitContext to build catch block.
-    /// </summary>
-    internal static BlockStatement BuildCatchBlockInternal(CatchClause catchClause, Symbol catchSlotSymbol)
-    {
-        return BuildCatchBlock(catchClause, catchSlotSymbol);
-    }
-
-    /// <summary>
-    /// Internal method for EmitContext to allocate a slot index.
-    /// </summary>
-    internal int AllocateSlotInternal(Symbol symbol)
-    {
-        return AllocateSlot(symbol);
-    }
-
-    /// <summary>
-    /// Internal property for EmitContext to access the instruction list.
-    /// </summary>
-    internal List<ExecutionInstruction> InstructionsInternal => _instructions;
-
-    /// <summary>
-    /// Internal static method to create iterator binding statement.
-    /// </summary>
-    internal static StatementNode CreateIteratorBindingStatementInternal(
-        IteratorDriverPlan plan,
-        Symbol valueSymbol,
-        int valueSlotIndex)
-    {
-        return CreateIteratorBindingStatement(plan, valueSymbol, valueSlotIndex);
-    }
-
-    /// <summary>
-    /// Internal static method to check if a statement is a strict block.
-    /// </summary>
-    internal static bool IsStrictBlockInternal(StatementNode statement)
-    {
-        return IsStrictBlock(statement);
-    }
-
-    /// <summary>
-    /// Internal static method to check for unlabeled break/continue in finally blocks.
-    /// </summary>
-    internal static bool ContainsUnlabeledAbruptInFinallyInternal(StatementNode statement)
-    {
-        return ContainsUnlabeledAbruptInFinally(statement);
-    }
-
-    /// <summary>
-    /// Internal method for EmitContext to create with scope slot symbol.
-    /// </summary>
-    internal Symbol CreateWithScopeSlotSymbolInternal()
-    {
-        return CreateWithScopeSlotSymbol();
-    }
-
-    /// <summary>
-    /// Internal method for EmitContext to create resume slot symbol.
-    /// </summary>
-    internal Symbol CreateResumeSlotSymbolInternal()
-    {
-        return CreateResumeSlotSymbol();
-    }
-
-    /// <summary>
-    /// Internal method for EmitContext to append a yield sequence.
-    /// </summary>
-    internal int AppendYieldSequenceInternal(ExpressionNode? expression, int continuationIndex, Symbol? resumeSlot)
-    {
-        return AppendYieldSequence(expression, continuationIndex, resumeSlot);
-    }
-
-    /// <summary>
-    /// Internal method for EmitContext to append a yield* sequence.
-    /// </summary>
-    internal int AppendYieldStarSequenceInternal(YieldExpression expression, int continuationIndex, Symbol? resultSlot)
-    {
-        return AppendYieldStarSequence(expression, continuationIndex, resultSlot);
-    }
+    internal List<ExecutionInstruction> Instructions => _instructions;
 
     /// <summary>
     /// Loop scope structure for break/continue resolution.
-    /// Made internal so EmitContext can access it.
     /// </summary>
     internal readonly record struct LoopScope(Symbol? Label, int ContinueTarget, int BreakTarget, int TargetScopeId);
 }

--- a/src/Asynkron.JsEngine/Execution/ExecutionPlanBuilder.cs
+++ b/src/Asynkron.JsEngine/Execution/ExecutionPlanBuilder.cs
@@ -41,7 +41,7 @@ internal sealed partial class ExecutionPlanBuilder
     /// <summary>
     /// Allocates a new slot index for a generator-internal symbol.
     /// </summary>
-    private int AllocateSlot(Symbol symbol)
+    internal int AllocateSlot(Symbol symbol)
     {
         var index = _slotSymbols.Count;
         _slotSymbols.Add(symbol);
@@ -139,7 +139,7 @@ internal sealed partial class ExecutionPlanBuilder
         }
     }
 
-    private bool TryBuildStatementList(ImmutableArray<StatementNode> statements, int nextIndex, out int entryIndex)
+    internal bool TryBuildStatementList(ImmutableArray<StatementNode> statements, int nextIndex, out int entryIndex)
     {
         var ctx = GetEmitContext();
         var currentNext = nextIndex;
@@ -157,13 +157,13 @@ internal sealed partial class ExecutionPlanBuilder
         return true;
     }
 
-    private Symbol CreateResumeSlotSymbol()
+    internal Symbol CreateResumeSlotSymbol()
     {
         var symbolName = $"{ResumeSlotPrefix}{_resumeSlotCounter++}";
         return Symbol.Intern(symbolName);
     }
 
-    private static StatementNode CreateIteratorBindingStatement(IteratorDriverPlan plan, Symbol valueSymbol,
+    internal static StatementNode CreateIteratorBindingStatement(IteratorDriverPlan plan, Symbol valueSymbol,
         int valueSlotIndex)
     {
         // Stamp the identifier expression with slot info for O(1) access
@@ -217,7 +217,7 @@ internal sealed partial class ExecutionPlanBuilder
         }
     }
 
-    private Symbol CreateCatchSlotSymbol()
+    internal Symbol CreateCatchSlotSymbol()
     {
         var symbolName = $"{CatchSlotPrefix}{_catchSlotCounter++}";
         return Symbol.Intern(symbolName);
@@ -229,24 +229,24 @@ internal sealed partial class ExecutionPlanBuilder
         return Symbol.Intern(symbolName);
     }
 
-    private Symbol CreateWithScopeSlotSymbol()
+    internal Symbol CreateWithScopeSlotSymbol()
     {
         var symbolName = $"{WithScopeSlotPrefix}{_withScopeSlotCounter++}";
         return Symbol.Intern(symbolName);
     }
 
-    private static bool IsStrictBlock(StatementNode statement)
+    internal static bool IsStrictBlock(StatementNode statement)
     {
         return statement is BlockStatement { IsStrict: true };
     }
 
-    private int AppendYieldSequence(ExpressionNode? expression, int continuationIndex, Symbol? resumeSlot)
+    internal int AppendYieldSequence(ExpressionNode? expression, int continuationIndex, Symbol? resumeSlot)
     {
         var storeIndex = Append(new StoreResumeValueInstruction(continuationIndex, resumeSlot));
         return Append(new YieldInstruction(storeIndex, expression));
     }
 
-    private int AppendYieldStarSequence(YieldExpression expression, int continuationIndex, Symbol? resultSlot)
+    internal int AppendYieldStarSequence(YieldExpression expression, int continuationIndex, Symbol? resultSlot)
     {
         if (expression.Expression is null)
         {
@@ -257,7 +257,7 @@ internal sealed partial class ExecutionPlanBuilder
         return Append(new YieldStarInstruction(continuationIndex, expression.Expression, stateSymbol, resultSlot));
     }
 
-    private static BlockStatement BuildCatchBlock(CatchClause clause, Symbol catchSlotSymbol)
+    internal static BlockStatement BuildCatchBlock(CatchClause clause, Symbol catchSlotSymbol)
     {
         var builder = ImmutableArray.CreateBuilder<StatementNode>();
 
@@ -298,7 +298,7 @@ internal sealed partial class ExecutionPlanBuilder
     /// This is used to reject such cases in switch statements since the lowered
     /// code transforms switch into if statements, making the break target invalid.
     /// </summary>
-    private static bool ContainsUnlabeledAbruptInFinally(StatementNode statement)
+    internal static bool ContainsUnlabeledAbruptInFinally(StatementNode statement)
     {
         return ContainsUnlabeledAbruptInFinallyImpl(statement, false);
     }


### PR DESCRIPTION
## Summary
- Remove 11 `*Internal` wrapper methods from `ExecutionPlanBuilder.Emitters.cs` by making the underlying methods internal
- Consolidate `BindingTargetContainsYieldAnywhere` (3 duplicates → 1 in `EmitContext`)
- Consolidate `ExpressionContainsDestructuringWithYieldAnywhere` (2 duplicates → 1)
- Consolidate `IsLowererTemp` (2 duplicates → 1 with both overloads)
- Remove duplicate `IsStrictBlock` from `StatementEmitter`
- Merge `ClassDefinitionContainsYield`/`ClassDefinitionContainsAwait` using predicate parameter
- Merge `TryEmitForOf`/`TryEmitForAwaitOf` into single `TryEmit` method
- Merge `TryEmitYieldAssignment`/`TryEmitVariableWithYieldInitializer` into `TryEmitYieldToSymbol`

**Net reduction: ~330 lines of code**

## Test plan
- [x] All 2770 unit tests pass
- [x] Build succeeds with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)