### PR TITLE
Fix arrow function this binding and return-from-finally bugs

### DIFF
--- a/examples/Demo/Program.cs
+++ b/examples/Demo/Program.cs
@@ -53,3 +53,25 @@ try {
 } catch (Exception ex) {
     Console.WriteLine($"  Exception: {ex.GetType().Name}: {ex.Message}");
 }
+
+// Test 3: Arrow function this binding in strict mode
+Console.WriteLine("\n=== Test 3: Arrow function this in strict mode ===");
+try {
+    var result = await engine.Evaluate(@"
+        'use strict';
+        var context = 'INITIAL';
+        var fnThis = 'NOT SET';
+        var fn = function() {
+          fnThis = this;  // Capture what 'this' is inside fn
+          return () => { context = this; };
+        };
+        fn()();
+        'fnThis=' + (fnThis === undefined ? 'undefined' : typeof fnThis) +
+        ', context=' + (context === undefined ? 'undefined' : typeof context + ': ' + context);
+    ").ConfigureAwait(false);
+    Console.WriteLine($"  Result: {result}");
+    Console.WriteLine($"  Expected: fnThis=undefined, context=undefined");
+    Console.WriteLine(result?.ToString() == "fnThis=undefined, context=undefined" ? "  SUCCESS!" : "  FAILED!");
+} catch (Exception ex) {
+    Console.WriteLine($"  Exception: {ex.GetType().Name}: {ex.Message}");
+}

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Completion.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Completion.cs
@@ -222,11 +222,11 @@ public static partial class TypedAstEvaluator
                         return true;
                     }
 
-                    // Per ES spec: when an abrupt completion occurs inside a finally block,
-                    // the new completion replaces the pending one. For most callers
-                    // (like StoreResumeValueInstruction for generator resumption),
-                    // we update the pending and let them advance PC. For throw/return
-                    // statements that end the finally abruptly, the caller handles it.
+                    // Already inside a finally block. Per ES spec: when an abrupt completion occurs
+                    // inside a finally block, the new completion replaces the pending one.
+                    // The caller decides how to proceed based on the instruction type:
+                    // - StoreResumeValue (generator resumption): continues executing finally
+                    // - Return/Throw statement: should terminate finally immediately
                     frame.PendingCompletion = PendingCompletion.FromAbrupt(kind, value);
                     return true;
                 }
@@ -246,6 +246,17 @@ public static partial class TypedAstEvaluator
             // 1. It preserves the JsValue type information
             // 2. Downstream code can detect "is JsValue" and unbox efficiently
             return HandleAbruptCompletion(kind, value, environment);
+        }
+
+        /// <summary>
+        /// Checks if the current try frame is inside a finally block (FinallyScheduled is true).
+        /// Used by Return/Throw instruction handlers to determine if they should terminate
+        /// the finally block immediately rather than executing code after the statement.
+        /// </summary>
+        private bool IsInsideScheduledFinally()
+        {
+            return TryCatchStateRef.TryStack.Count > 0 &&
+                   TryCatchStateRef.TryStack.Peek().FinallyScheduled;
         }
 
         private JsValue CompleteReturn(JsValue value)

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -2330,8 +2330,20 @@ public static partial class TypedAstEvaluator
                                     returnValue = pendingReturn;
                                 }
 
+                                // Check if we're inside a scheduled finally BEFORE calling HandleAbruptCompletion.
+                                // If so, the return statement should terminate the finally block immediately,
+                                // not execute code after the return (which is unreachable code).
+                                var wasInsideScheduledFinally = IsInsideScheduledFinally();
+
                                 if (HandleAbruptCompletionJsValue(AbruptKind.Return, returnValue, environment))
                                 {
+                                    // If we were inside a scheduled finally, the pending completion was updated.
+                                    // Now complete the function with that value instead of advancing to unreachable code.
+                                    if (wasInsideScheduledFinally)
+                                    {
+                                        return CompleteReturn(returnValue);
+                                    }
+
                                     if (_programCounter == _currentInstructionIndex)
                                     {
                                         _programCounter = returnInstruction.Next;
@@ -2340,11 +2352,7 @@ public static partial class TypedAstEvaluator
                                     continue;
                                 }
 
-                                _programCounter = -1;
-                                _state = GeneratorState.Completed;
-                                _done = true;
-                                TryCatchStateRef.TryStack.Clear();
-                                return CreateIteratorResult(returnValue, true);
+                                return CompleteReturn(returnValue);
                             }
 
                             case InstructionKind.EnterWith:

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -991,7 +991,11 @@ public static partial class TypedAstEvaluator
                 }
 
                 functionEnvironment.SetThisInitializationStatus(initialThisInitialized);
-                functionEnvironment.DefineJsValue(Symbol.This, JsValue.FromObjectUnsafe(initialThisValue));
+                // In strict mode, `this` can be undefined - handle Symbol.Undefined marker correctly
+                var thisJsValue = ReferenceEquals(initialThisValue, Symbol.Undefined)
+                    ? JsValue.Undefined
+                    : JsValue.FromObjectUnsafe(initialThisValue);
+                functionEnvironment.DefineJsValue(Symbol.This, thisJsValue);
 
                 if (IsClassConstructor && initialThisValue is JsObject ctorThis)
                 {

--- a/src/Asynkron.JsEngine/JsEnvironment.cs
+++ b/src/Asynkron.JsEngine/JsEnvironment.cs
@@ -2051,6 +2051,14 @@ public sealed class JsEnvironment : IRentable
 
         while (current is not null && hops++ < maxLookupDepth)
         {
+            // Fast path for 'this' stored via _hasThisValue (used by InvokeSimpleFast)
+            if (ReferenceEquals(name, Symbol.This) && current._hasThisValue)
+            {
+                environment = current;
+                value = current._thisValue;
+                return true;
+            }
+
             if (current._values is not null && current._values.TryGetValue(name, out var binding))
             {
                 if (binding.IsUninitialized && !allowUninitialized)


### PR DESCRIPTION
## Summary

- **Fix arrow function `this` binding in strict mode**: Added fast-path check for `_hasThisValue` in `TryFindBindingJsValue()` so arrow functions correctly capture `this=undefined` when called without a receiver in strict mode.

- **Fix return statement in finally block**: Added `IsInsideScheduledFinally()` helper and modified Return instruction handler to call `CompleteReturn()` immediately when inside a finally, preventing execution of unreachable code after the return statement.

- **Handle `Symbol.Undefined` marker correctly** in SyncFunctionInvoker when `this` is undefined in strict mode.

## Test262 Tests Fixed

- ✅ `language/expressions/tagged-template/call-expression-context-strict.js`
- ✅ `language/statements/for-of/return-from-finally.js`

## Test Plan

- [x] All 2770 internal unit tests pass
- [x] All 301 generator tests pass
- [x] Demo program tests pass
- [x] Fixed Test262 tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)