### PR TITLE
Fix completion value semantics for ECMAScript compliance

### DIFF
--- a/src/Asynkron.JsEngine/Ast/ExpressionStatement.cs
+++ b/src/Asynkron.JsEngine/Ast/ExpressionStatement.cs
@@ -9,4 +9,11 @@ namespace Asynkron.JsEngine.Ast;
 /// <summary>
 ///     Represents an expression statement.
 /// </summary>
-public sealed record ExpressionStatement(SourceReference? Source, ExpressionNode Expression) : StatementNode(Source);
+/// <param name="SuppressCompletionValue">
+///     When true, this statement's result does not contribute to the script completion value.
+///     Used for synthetic/internal assignments (e.g., switch lowering's __done flag).
+/// </param>
+public sealed record ExpressionStatement(
+    SourceReference? Source,
+    ExpressionNode Expression,
+    bool SuppressCompletionValue = false) : StatementNode(Source);

--- a/src/Asynkron.JsEngine/Ast/StatementNodeExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/StatementNodeExtensions.cs
@@ -27,7 +27,10 @@ public static partial class TypedAstEvaluator
             // Hot path - explicit type checks for best inlining
             if (statement is ExpressionStatement expressionStatement)
             {
-                return expressionStatement.Expression.EvaluateExpression(environment, context);
+                var result = expressionStatement.Expression.EvaluateExpression(environment, context);
+                // SuppressCompletionValue is used for synthetic assignments (e.g., switch lowering's __done flag)
+                // Return Unit to indicate no change to completion value
+                return expressionStatement.SuppressCompletionValue ? JsValue.Unit : result;
             }
 
             if (statement is BlockStatement block)

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Completion.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Completion.cs
@@ -113,7 +113,7 @@ public static partial class TypedAstEvaluator
             // (for UpdateEmpty semantics per ES spec)
             var entryCompletionValue = _isScriptMode ? _scriptCompletionValue : JsValue.Unit;
             var frame = new TryFrame(instruction.HandlerIndex, instruction.CatchSlotSymbol, instruction.FinallyIndex,
-                environment, entryCompletionValue);
+                instruction.EndFinallyIndex, environment, entryCompletionValue);
             if (instruction.CatchSlotSymbol is { } slot && !environment.HasBinding(slot))
             {
                 environment.DefineJsValue(slot, JsValue.Undefined);

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Types.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Types.cs
@@ -69,12 +69,19 @@ public static partial class TypedAstEvaluator
             int handlerIndex,
             Symbol? catchSlotSymbol,
             int finallyIndex,
+            int endFinallyIndex,
             JsEnvironment entryEnvironment,
             JsValue entryCompletionValue)
         {
             public int HandlerIndex { get; } = handlerIndex;
             public Symbol? CatchSlotSymbol { get; } = catchSlotSymbol;
             public int FinallyIndex { get; } = finallyIndex;
+
+            /// <summary>
+            /// Index of the EndFinally instruction for this try/finally.
+            /// Used when break/continue inside a finally block needs to jump to EndFinally.
+            /// </summary>
+            public int EndFinallyIndex { get; } = endFinallyIndex;
 
             /// <summary>
             /// The environment that was active when entering the try block.

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -2431,6 +2431,19 @@ public static partial class TypedAstEvaluator
                                 var breakInstruction = Unsafe.As<BreakInstruction>(instruction);
                                 if (HandleAbruptCompletion(AbruptKind.Break, breakInstruction.TargetIndex, environment))
                                 {
+                                    // If inside scheduled finally, HandleAbruptCompletion stored the pending
+                                    // completion but didn't advance _programCounter. We need to jump
+                                    // to EndFinally so it can process the pending break.
+                                    if (_programCounter == _currentInstructionIndex &&
+                                        TryCatchStateRef.TryStack.Count > 0)
+                                    {
+                                        var frame = TryCatchStateRef.TryStack.Peek();
+                                        if (frame.EndFinallyIndex >= 0)
+                                        {
+                                            _programCounter = frame.EndFinallyIndex;
+                                        }
+                                    }
+
                                     continue;
                                 }
 
@@ -2455,6 +2468,19 @@ public static partial class TypedAstEvaluator
                                 if (HandleAbruptCompletion(AbruptKind.Continue, continueInstruction.TargetIndex,
                                         environment))
                                 {
+                                    // If inside scheduled finally, HandleAbruptCompletion stored the pending
+                                    // completion but didn't advance _programCounter. We need to jump
+                                    // to EndFinally so it can process the pending continue.
+                                    if (_programCounter == _currentInstructionIndex &&
+                                        TryCatchStateRef.TryStack.Count > 0)
+                                    {
+                                        var frame = TryCatchStateRef.TryStack.Peek();
+                                        if (frame.EndFinallyIndex >= 0)
+                                        {
+                                            _programCounter = frame.EndFinallyIndex;
+                                        }
+                                    }
+
                                     continue;
                                 }
 
@@ -2669,6 +2695,17 @@ public static partial class TypedAstEvaluator
                                 }
 
                                 _programCounter = iteratorCloseInstruction.Next;
+                                continue;
+                            }
+
+                            case InstructionKind.SetCompletionValue:
+                            {
+                                var setCompletionInstruction = Unsafe.As<SetCompletionValueInstruction>(instruction);
+                                if (_isScriptMode)
+                                {
+                                    _scriptCompletionValue = JsValue.Undefined;
+                                }
+                                _programCounter = setCompletionInstruction.Next;
                                 continue;
                             }
 

--- a/src/Asynkron.JsEngine/Execution/Emitters/ControlFlowEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/ControlFlowEmitter.cs
@@ -12,9 +12,7 @@ internal static class ControlFlowEmitter
 {
     /// <summary>
     /// Emit IR for an if statement.
-    /// Note: Per ES spec 13.6.7, if/else should have UpdateEmpty(stmtCompletion, undefined).
-    /// This is not yet implemented for if statements - a larger refactor is needed to track
-    /// completion values without interfering with loop scope handling.
+    /// Per ES spec 14.6.2, empty branches and missing else produce undefined completion value.
     /// </summary>
     public static bool TryEmitIf(
         EmitContext ctx,
@@ -34,19 +32,34 @@ internal static class ControlFlowEmitter
         var instructionStart = ctx.InstructionCount;
 
         // Build else branch first (bottom-up building)
-        var elseEntry = nextIndex;
+        int elseEntry;
         if (statement.Else is not null)
         {
-            if (!ctx.TryBuildStatement(statement.Else, nextIndex, out elseEntry, activeLabel))
+            // Check for empty else block - emit SetCompletionValue for UpdateEmpty semantics
+            if (IsEmptyBlock(statement.Else))
+            {
+                elseEntry = ctx.Append(new SetCompletionValueInstruction(nextIndex));
+            }
+            else if (!ctx.TryBuildStatement(statement.Else, nextIndex, out elseEntry, activeLabel))
             {
                 ctx.Rollback(instructionStart);
                 entryIndex = -1;
                 return false;
             }
         }
+        else
+        {
+            // No else branch - per ES spec, if condition is false, completion is undefined
+            elseEntry = ctx.Append(new SetCompletionValueInstruction(nextIndex));
+        }
 
-        // Build then branch
-        if (!ctx.TryBuildStatement(statement.Then, nextIndex, out var thenEntry, activeLabel))
+        // Build then branch - check for empty block
+        int thenEntry;
+        if (IsEmptyBlock(statement.Then))
+        {
+            thenEntry = ctx.Append(new SetCompletionValueInstruction(nextIndex));
+        }
+        else if (!ctx.TryBuildStatement(statement.Then, nextIndex, out thenEntry, activeLabel))
         {
             ctx.Rollback(instructionStart);
             entryIndex = -1;
@@ -56,6 +69,14 @@ internal static class ControlFlowEmitter
         // Emit branch instruction
         entryIndex = ctx.Append(new BranchInstruction(statement.Condition, thenEntry, elseEntry));
         return true;
+    }
+
+    /// <summary>
+    /// Checks if a statement is an empty block (BlockStatement with no statements).
+    /// </summary>
+    private static bool IsEmptyBlock(StatementNode statement)
+    {
+        return statement is BlockStatement { Statements.Length: 0 };
     }
 
     /// <summary>

--- a/src/Asynkron.JsEngine/Execution/Emitters/ExpressionStatementEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/ExpressionStatementEmitter.cs
@@ -71,6 +71,9 @@ internal static class ExpressionStatementEmitter
             return true;
         }
 
+        // Combine context and statement-level suppression flags
+        var suppressCompletion = ctx.SuppressCompletionValue || expressionStatement.SuppressCompletionValue;
+
         // Fast path: simple increment/decrement on identifiers (e.g., i++, --j)
         if (expressionStatement.Expression is UnaryExpression
             {
@@ -84,12 +87,12 @@ internal static class ExpressionStatementEmitter
                 identTarget.Name,
                 isIncrement,
                 unaryExpr.IsPrefix,
-                ctx.SuppressCompletionValue));
+                suppressCompletion));
             return true;
         }
 
         // Use native EvaluateAndDiscardInstruction - evaluates expression and discards result
-        entryIndex = ctx.Append(new EvaluateAndDiscardInstruction(nextIndex, expressionStatement.Expression, ctx.SuppressCompletionValue));
+        entryIndex = ctx.Append(new EvaluateAndDiscardInstruction(nextIndex, expressionStatement.Expression, suppressCompletion));
         return true;
     }
 }

--- a/src/Asynkron.JsEngine/Execution/Emitters/ForOfEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/ForOfEmitter.cs
@@ -169,7 +169,7 @@ internal static class ForOfEmitter
 
         // EnterTry - wraps the loop in a try/finally, points to LoopEnter
         var enterTryIndex =
-            ctx.Append(new EnterTryInstruction(loopEnterIndex, -1, null, iteratorCloseIndex));
+            ctx.Append(new EnterTryInstruction(loopEnterIndex, -1, null, iteratorCloseIndex, endFinallyIndex));
 
         // Wire IteratorInit to point to EnterTry
         ctx.Patch(iteratorInstructions.InitIndex,

--- a/src/Asynkron.JsEngine/Execution/Emitters/SwitchEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/SwitchEmitter.cs
@@ -174,9 +174,11 @@ internal static class SwitchEmitter
 
             if (breakIndex != -1)
             {
+                // Mark as SuppressCompletionValue because __done is a synthetic variable -
+                // its assignment should never affect the script's completion value.
                 var setDoneAssignment = new AssignmentExpression(statement.Source, doneSymbol,
                     new LiteralExpression(statement.Source, true));
-                execBuilder.Add(new ExpressionStatement(statement.Source, setDoneAssignment));
+                execBuilder.Add(new ExpressionStatement(statement.Source, setDoneAssignment, SuppressCompletionValue: true));
             }
 
             var execBlock = new BlockStatement(body.Source, execBuilder.ToImmutable(), body.IsStrict);

--- a/src/Asynkron.JsEngine/Execution/Emitters/TryEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/TryEmitter.cs
@@ -33,9 +33,10 @@ internal static class TryEmitter
 
         // Build finally block first (bottom-up)
         var finallyEntry = -1;
+        var endFinallyIndex = -1;
         if (hasFinally && statement.Finally is not null)
         {
-            var endFinallyIndex = ctx.Append(new EndFinallyInstruction(nextIndex));
+            endFinallyIndex = ctx.Append(new EndFinallyInstruction(nextIndex));
             if (!ctx.TryBuildStatement(statement.Finally, endFinallyIndex, out finallyEntry, activeLabel))
             {
                 ctx.Rollback(instructionStart);
@@ -69,7 +70,7 @@ internal static class TryEmitter
 
         // Emit EnterTry instruction as the entry point
         // Note: CatchSlotSymbol is null because we use EnterCatchInstruction now
-        entryIndex = ctx.Append(new EnterTryInstruction(tryEntry, catchEntry, null, finallyEntry));
+        entryIndex = ctx.Append(new EnterTryInstruction(tryEntry, catchEntry, null, finallyEntry, endFinallyIndex));
         return true;
     }
 

--- a/src/Asynkron.JsEngine/Execution/Instructions/InstructionKind.cs
+++ b/src/Asynkron.JsEngine/Execution/Instructions/InstructionKind.cs
@@ -37,4 +37,5 @@ internal enum InstructionKind : byte
     EnterWith,
     LeaveWith,
     Expression,
+    SetCompletionValue,
 }

--- a/src/Asynkron.JsEngine/Execution/Instructions/Instructions.cs
+++ b/src/Asynkron.JsEngine/Execution/Instructions/Instructions.cs
@@ -165,7 +165,12 @@ internal sealed record StoreResumeValueInstruction(int Next, Symbol? TargetSymbo
 /// <summary>
 ///     Marks the beginning of a <c>try</c> region.
 /// </summary>
-internal sealed record EnterTryInstruction(int Next, int HandlerIndex, Symbol? CatchSlotSymbol, int FinallyIndex)
+/// <param name="Next">Next instruction index (try body entry).</param>
+/// <param name="HandlerIndex">Index of catch handler, or -1 if no catch.</param>
+/// <param name="CatchSlotSymbol">Symbol for catch parameter binding (legacy).</param>
+/// <param name="FinallyIndex">Index of finally block entry, or -1 if no finally.</param>
+/// <param name="EndFinallyIndex">Index of EndFinally instruction, or -1 if no finally.</param>
+internal sealed record EnterTryInstruction(int Next, int HandlerIndex, Symbol? CatchSlotSymbol, int FinallyIndex, int EndFinallyIndex = -1)
     : ExecutionInstruction(InstructionKind.EnterTry, Next);
 
 /// <summary>
@@ -329,3 +334,10 @@ internal sealed record LeaveWithInstruction(Symbol WithScopeSlot, int Next)
 /// </summary>
 internal sealed record ExpressionInstruction(int Next, ExpressionNode Expression)
     : ExecutionInstruction(InstructionKind.Expression, Next);
+
+/// <summary>
+///     Sets the script completion value to undefined.
+///     Used for empty blocks/branches per ES spec UpdateEmpty semantics.
+/// </summary>
+internal sealed record SetCompletionValueInstruction(int Next)
+    : ExecutionInstruction(InstructionKind.SetCompletionValue, Next);


### PR DESCRIPTION
## Summary
- Fix break/continue from finally block causing infinite loop
- Fix empty if/else branches not producing undefined completion value
- Fix switch statement break producing internal __done flag value instead of undefined

## Changes
- Added `SetCompletionValueInstruction` for explicit completion value reset
- Added `EndFinallyIndex` to `EnterTryInstruction` and `TryFrame` for proper jump targets
- Added `SuppressCompletionValue` flag to `ExpressionStatement` for synthetic assignments
- Updated both IR and AST evaluation paths to respect the new flag

## Test Results
- All 27 CatchBlockTestBomb tests pass (previously 2 failed)
- Full test suite: 2840 passed, 3 failed (down from 8 pre-existing failures)
- Remaining failures are unrelated for-loop scoping issues (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)