### PR TITLE
Add regex caching using IAstCacheable pattern

### DIFF
--- a/src/Asynkron.JsEngine/Ast/RegexCache.cs
+++ b/src/Asynkron.JsEngine/Ast/RegexCache.cs
@@ -1,0 +1,54 @@
+#region
+
+using System.Text.RegularExpressions;
+using Asynkron.JsEngine.JsTypes;
+
+#endregion
+
+namespace Asynkron.JsEngine.Ast;
+
+/// <summary>
+///     Cached regex compilation result for regex literals.
+///     Stores the normalized pattern and compiled .NET Regex to avoid
+///     repeated pattern normalization and regex compilation.
+/// </summary>
+internal sealed class RegexCache
+{
+    public RegexCache(string pattern, string flags)
+    {
+        Pattern = pattern;
+        Flags = flags;
+
+        // Validate flags and determine options
+        JsRegExp.ValidateFlags(flags);
+
+        var hasUnicodeFlag = flags.Contains('u', StringComparison.Ordinal) ||
+                             flags.Contains('v', StringComparison.Ordinal);
+        var ignoreCase = flags.Contains('i', StringComparison.Ordinal);
+        var multiline = flags.Contains('m', StringComparison.Ordinal);
+
+        // Normalize the pattern (expensive operation - done once)
+        NormalizedPattern = JsRegExp.NormalizePattern(pattern, hasUnicodeFlag, ignoreCase);
+
+        // Build RegexOptions
+        var options = RegexOptions.CultureInvariant;
+        if (ignoreCase)
+        {
+            options |= RegexOptions.IgnoreCase;
+        }
+        if (multiline)
+        {
+            options |= RegexOptions.Multiline;
+        }
+        RegexOptions = options;
+
+        // Compile the regex (expensive operation - done once)
+        CompiledRegex = new Regex(NormalizedPattern, options);
+    }
+
+    public string Pattern { get; }
+    public string Flags { get; }
+    public string NormalizedPattern { get; }
+    public RegexOptions RegexOptions { get; }
+    public Regex CompiledRegex { get; }
+}

--- a/src/Asynkron.JsEngine/Ast/RegexLiteralExpression.cs
+++ b/src/Asynkron.JsEngine/Ast/RegexLiteralExpression.cs
@@ -8,6 +8,15 @@ namespace Asynkron.JsEngine.Ast;
 
 /// <summary>
 ///     Represents a regex literal. Kept separate because regex objects require RealmState at runtime.
+///     Implements IAstCacheable to cache the normalized pattern and compiled .NET Regex.
 /// </summary>
 public sealed record RegexLiteralExpression(SourceReference? Source, string Pattern, string Flags)
-    : ExpressionNode(Source);
+    : ExpressionNode(Source), IAstCacheable<RegexCache>
+{
+    private RegexCache? _cachedRegex;
+
+    RegexCache IAstCacheable<RegexCache>.GetOrCreateCache()
+    {
+        return AstCache.GetOrCreate(ref _cachedRegex, this, static self => new RegexCache(self.Pattern, self.Flags));
+    }
+}

--- a/src/Asynkron.JsEngine/Ast/RegexLiteralExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/RegexLiteralExpressionExtensions.cs
@@ -1,7 +1,6 @@
 #region
 
 using Asynkron.JsEngine.JsTypes;
-using static Asynkron.JsEngine.StdLib.RegExpHelper;
 
 #endregion
 
@@ -12,11 +11,22 @@ public static partial class TypedAstEvaluator
     extension(RegexLiteralExpression regex)
     {
         /// <summary>
-        ///     Evaluates a regex literal by creating a RegExp object using the RealmState.
+        ///     Evaluates a regex literal by creating a RegExp object using cached pattern and compiled regex.
+        ///     The cache avoids repeated pattern normalization and regex compilation.
         /// </summary>
         private JsValue EvaluateRegexLiteral(EvaluationContext context)
         {
-            return new JsValue(CreateRegExpLiteral(regex.Pattern, regex.Flags, context.RealmState));
+            var cache = ((IAstCacheable<RegexCache>)regex).GetOrCreateCache();
+            var jsRegExp = new JsRegExp(cache, context.RealmState);
+            var target = jsRegExp.JsObject;
+            target["__regex__"] = jsRegExp;
+
+            if (context.RealmState?.RegExpPrototype is not null)
+            {
+                target.SetPrototype(context.RealmState.RegExpPrototype);
+            }
+
+            return new JsValue(target);
         }
     }
 }

--- a/src/Asynkron.JsEngine/JsTypes/JsRegExp.cs
+++ b/src/Asynkron.JsEngine/JsTypes/JsRegExp.cs
@@ -73,6 +73,28 @@ public class JsRegExp
         }
     }
 
+    /// <summary>
+    ///     Creates a JsRegExp using a pre-compiled RegexCache.
+    ///     This avoids pattern normalization and regex compilation for regex literals.
+    /// </summary>
+    internal JsRegExp(Ast.RegexCache cache, RealmState? realmState = null, JsObject? existingObject = null)
+    {
+        Pattern = cache.Pattern;
+        Flags = cache.Flags;
+        RealmState = realmState;
+        JsObject = existingObject ?? new JsObject();
+
+        _normalizedPattern = cache.NormalizedPattern;
+        _regexOptions = cache.RegexOptions;
+        _compiledRegex = cache.CompiledRegex;
+
+        if (existingObject is null)
+        {
+            JsObject.DefineProperty("lastIndex",
+                new PropertyDescriptor { Value = 0d, Writable = true, Enumerable = false, Configurable = false });
+        }
+    }
+
     public string Pattern { get; }
 
     public string Flags { get; }
@@ -211,7 +233,7 @@ public class JsRegExp
         return EnsureRegex();
     }
 
-    private static void ValidateFlags(string flags)
+    internal static void ValidateFlags(string flags)
     {
         var seen = new HashSet<char>();
         var hasUnicode = false;
@@ -372,7 +394,7 @@ public class JsRegExp
         return groups;
     }
 
-    private static string NormalizePattern(string pattern, bool hasUnicodeFlag, bool ignoreCase)
+    internal static string NormalizePattern(string pattern, bool hasUnicodeFlag, bool ignoreCase)
     {
         if (!hasUnicodeFlag)
         {


### PR DESCRIPTION
## Summary
- Create `RegexCache` class to store normalized pattern, `RegexOptions`, and compiled `Regex`
- Add internal constructor to `JsRegExp` that accepts `RegexCache`
- Update `RegexLiteralExpression` to implement `IAstCacheable<RegexCache>`
- Update evaluator to use cached regex data

This avoids repeated pattern normalization and regex compilation when the same regex literal is evaluated multiple times. The expensive operations (pattern normalization via `NormalizePattern()` and `new Regex()` compilation) now happen once per AST node rather than once per evaluation.

## Test plan
- [x] All 52 regex tests pass
- [x] Full internal test suite passes (3 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)