### PR TITLE
Fix function name inference for IR execution path

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -1050,6 +1050,16 @@ public static partial class TypedAstEvaluator
                             case InstructionKind.SimpleVariableDeclaration:
                             {
                                 var varDeclInstruction = Unsafe.As<SimpleVariableDeclarationInstruction>(instruction);
+
+                                // Per ES spec 13.3.1.4: If IsAnonymousFunctionDefinition(Initializer) is true,
+                                // then perform SetFunctionName(value, bindingId).
+                                var isAnonymousFunctionDefinition = varDeclInstruction.Initializer is not null &&
+                                    ExpressionNode.IsAnonymousFunctionDefinitionNode(varDeclInstruction.Initializer);
+
+                                using var functionNameHint = isAnonymousFunctionDefinition
+                                    ? context.EnterFunctionNameHint(varDeclInstruction.TargetSymbol)
+                                    : null;
+
                                 // Evaluate initializer if present
                                 var varValue = varDeclInstruction.Initializer?.EvaluateExpression(environment, context) ?? JsValue.Undefined;
 

--- a/tests/Asynkron.JsEngine.Tests/FunctionNameInferenceTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/FunctionNameInferenceTests.cs
@@ -1,0 +1,48 @@
+using Asynkron.JsEngine.JsTypes;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Asynkron.JsEngine.Tests;
+
+/// <summary>
+/// Tests for ES6 function name inference (ES spec 13.3.1.4).
+/// When an anonymous function is assigned to a variable, the function's
+/// name property should be set to the variable name.
+/// </summary>
+public class FunctionNameInferenceTests(ITestOutputHelper output) : InternalTestBase(output)
+{
+    [Fact]
+    public async Task ArrowFunction_NameInference()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("const arrow = () => {}; arrow.name");
+        Assert.Equal("arrow", result?.ToString());
+    }
+
+    [Fact]
+    public async Task FunctionExpression_NameInference()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("const fn = function() {}; fn.name");
+        Output.WriteLine($"fn.name = '{result}'");
+        Assert.Equal("fn", result?.ToString());
+    }
+
+    [Fact]
+    public async Task ClassExpression_NameInference()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("const cls = class {}; cls.name");
+        Output.WriteLine($"cls.name = '{result}'");
+        Assert.Equal("cls", result?.ToString());
+    }
+
+    [Fact]
+    public async Task GeneratorFunction_NameInference()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("const gen = function*() {}; gen.name");
+        Output.WriteLine($"gen.name = '{result}'");
+        Assert.Equal("gen", result?.ToString());
+    }
+}


### PR DESCRIPTION
## Summary
- Fix function name inference for anonymous functions assigned to variables in the IR execution path
- Per ES spec 13.3.1.4, `const fn = () => {}` should result in `fn.name === "fn"`
- The AST evaluator path already had this working, but the IR path was missing the `EnterFunctionNameHint` call

## Changes
- Added `IsAnonymousFunctionDefinitionNode` check in `ExecutionPlanRunner.cs` for `SimpleVariableDeclaration` instructions
- Sets up function name hint context before evaluating initializer expressions
- Added unit tests for arrow functions, function expressions, class expressions, and generators

## Test plan
- [x] All 4 new `FunctionNameInferenceTests` pass
- [x] 402 Test262 `fn-name-arrow` tests pass
- [x] 2852 unit tests pass (3 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)