### PR TITLE
Fix for-loop per-iteration lexical binding scoping per ES spec

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -1263,9 +1263,12 @@ public static partial class TypedAstEvaluator
                                 }
 
                                 var allowPooling = pushEnvInstruction.AllowPooling;
+                                // Use different description for loop scope (empty bindings) vs per-iteration scope
+                                // This allows the subsequent iteration heuristic to correctly distinguish them
+                                var description = pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty ? "loop-scope" : "scope";
                                 var newIterationEnv = allowPooling
-                                    ? JsEnvironmentPool.Rent(loopScope, false, false, null, "scope", logger: _realmState.Logger)
-                                    : new JsEnvironment(loopScope, false, false, null, "scope");
+                                    ? JsEnvironmentPool.Rent(loopScope, false, false, null, description, logger: _realmState.Logger)
+                                    : new JsEnvironment(loopScope, false, false, null, description);
 
                                 // Initialize slots for O(1) identifier lookups
                                 if (pushEnvInstruction is { SlotCount: > 0, ScopeId: >= 0 })
@@ -1348,9 +1351,15 @@ public static partial class TypedAstEvaluator
                                 // Pop the iteration environment when exiting a loop.
                                 // If current env matches ScopeId, pop (set to Enclosing).
                                 // If not (loop ran 0 times), this is a no-op.
-                                // CRITICAL: Only pop if ScopeId is valid (>= 0). When ScopeAnalyzer
-                                // hasn't run, both ScopeIds are -1, and we'd incorrectly pop.
-                                if (popEnvInstruction.ScopeId >= 0 && environment.ScopeId == popEnvInstruction.ScopeId)
+                                //
+                                // When ScopeId is -1 (scope analysis not run), use heuristic:
+                                // Pop if current env has Description="scope" or "loop-scope" and has Enclosing.
+                                // This matches environments created by PushEnvironment for loops.
+                                var shouldPop = popEnvInstruction.ScopeId >= 0
+                                    ? environment.ScopeId == popEnvInstruction.ScopeId
+                                    : (environment.Description is "scope" or "loop-scope") && environment.Enclosing != null;
+
+                                if (shouldPop)
                                 {
                                     var envToPop = environment;
                                     environment = environment.Enclosing!;

--- a/src/Asynkron.JsEngine/Execution/Emitters/LoopEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/LoopEmitter.cs
@@ -83,15 +83,30 @@ internal static class LoopEmitter
             continueTarget = createEnvIndex;
         }
 
-        // Create Pop instruction for loop exit BEFORE building body
-        // This ensures breaks also go through the pop, then through BreakableExitInstruction
+        // Create Pop instructions for loop exit BEFORE building body
+        // This ensures breaks also go through the pops, then through BreakableExitInstruction
         var loopExitTarget = loopExitIndex;
         if (!plan.PerIterationBindings.IsDefaultOrEmpty)
         {
+            // Pop loop scope (parent of per-iteration scopes) at loop exit
+            // Use IterationParentScopeId if available, otherwise synthesize from IterationScopeId
+            var loopScopeId = plan.IterationParentScopeId >= 0
+                ? plan.IterationParentScopeId
+                : (plan.IterationScopeId >= 0 ? plan.IterationScopeId + 1000 : -1);
+
+            if (plan.Kind == LoopKind.For)
+            {
+                loopExitTarget = ctx.Append(new PopEnvironmentInstruction(
+                    loopScopeId,
+                    plan.AllowIterationEnvironmentPooling,
+                    loopExitIndex));
+            }
+
+            // Pop per-iteration scope
             loopExitTarget = ctx.Append(new PopEnvironmentInstruction(
                 plan.IterationScopeId,
                 plan.AllowIterationEnvironmentPooling,
-                loopExitIndex));
+                loopExitTarget));
         }
 
         // TargetScopeId is the scope to pop TO when break/continue
@@ -146,6 +161,25 @@ internal static class LoopEmitter
 
         var loopEntry = plan.ConditionAfterBody ? iterationBodyEntry : conditionJumpIndex;
 
+        // Per ES spec 13.7.4.9 ForBodyEvaluation step 3:
+        // CreatePerIterationEnvironment is called BEFORE the first condition test.
+        // This ensures closures created in the initializer capture the loop scope,
+        // while closures in condition/body capture the per-iteration scope.
+        if (!plan.PerIterationBindings.IsDefaultOrEmpty && plan.Kind == LoopKind.For)
+        {
+            var slotMap = EmitContext.BuildSlotMap(plan.PerIterationBindings, plan.PerIterationSlotIndices);
+
+            // Initial PushEnv flows to loopEntry (condition)
+            // This is the FIRST per-iteration environment, created before the first test
+            loopEntry = ctx.Append(new PushEnvironmentInstruction(
+                loopEntry,
+                plan.PerIterationBindings,
+                plan.IterationScopeId,
+                plan.IterationSlotCount,
+                slotMap,
+                plan.AllowIterationEnvironmentPooling));
+        }
+
         if (!plan.LeadingStatements.IsDefaultOrEmpty)
         {
             // Per ES spec 13.7.4.7 (ForLoopEvaluation), the initializer expression/declaration
@@ -160,6 +194,31 @@ internal static class LoopEmitter
                 entryIndex = -1;
                 return false;
             }
+        }
+
+        // Per ES spec 13.7.4.7 ForLoopEvaluation steps 3-7:
+        // Create a LOOP SCOPE environment that wraps the initializer.
+        // This is the parent of per-iteration scopes and holds the let/const bindings.
+        // The initializer (LeadingStatements) runs in this loop scope, creating bindings there.
+        // Then per-iteration scopes copy values from this loop scope (or previous iteration).
+        if (!plan.PerIterationBindings.IsDefaultOrEmpty && plan.Kind == LoopKind.For)
+        {
+            var slotMap = EmitContext.BuildSlotMap(plan.PerIterationBindings, plan.PerIterationSlotIndices);
+
+            // Use IterationParentScopeId if available, otherwise synthesize from IterationScopeId
+            var loopScopeId = plan.IterationParentScopeId >= 0
+                ? plan.IterationParentScopeId
+                : (plan.IterationScopeId >= 0 ? plan.IterationScopeId + 1000 : -1);
+
+            // Loop scope PushEnv - NO PerIterationBindings (this is not a per-iteration scope,
+            // it's the parent scope where bindings are created by the initializer)
+            loopEntry = ctx.Append(new PushEnvironmentInstruction(
+                loopEntry,
+                ImmutableArray<Symbol>.Empty,  // Not per-iteration, so no bindings to copy
+                loopScopeId,
+                plan.IterationSlotCount,
+                slotMap,
+                plan.AllowIterationEnvironmentPooling));
         }
 
         // Wrap entry with BreakableEnterInstruction to push context at runtime.


### PR DESCRIPTION
## Summary

- Fix for loops with `let`/`const` declarations to properly create bindings in loop scope per ES spec
- Add loop scope environment that wraps the initializer (spec 13.7.4.7 ForLoopEvaluation)
- Add initial per-iteration scope before first condition test (spec 13.7.4.9 ForBodyEvaluation step 3)
- Fix PushEnv/PopEnv heuristics when ScopeId=-1 (scope analysis not run)

## Problem

Before this fix:
```javascript
let x = 'outside';
for (let x = 'inside'; run;) { run = false; }
x;  // Returns 'inside' ❌
```

The inner `let x = 'inside'` was modifying the outer `x` binding because:
1. Loop scope wasn't being created around the initializer
2. PopEnvironment didn't work when ScopeId=-1

## Solution

Per ECMAScript spec 13.7.4.7 (ForLoopEvaluation):
1. Create **loop scope** as child of outer scope
2. Create bindings in loop scope (let x = 'inside')
3. Create **per-iteration scope** with copied values
4. Execute body in per-iteration scope
5. Pop both scopes at loop exit

Now correctly returns `'outside'` ✅

## Test plan

- [x] All 2889 internal tests pass
- [x] All 16 Test262 for statement tests pass
- [x] `ForLoop_LexicalBindings_AreFreshPerIteration_ScopeBodyLexOpen` passes
- [x] `scope-head-lex-close.js` semantics verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)