### PR TITLE
Implement Array iterator prototype

### DIFF
--- a/src/Asynkron.JsEngine/JsTypes/JsArrayIterator.cs
+++ b/src/Asynkron.JsEngine/JsTypes/JsArrayIterator.cs
@@ -1,0 +1,155 @@
+#region
+
+using Asynkron.JsEngine.Runtime;
+using Asynkron.JsEngine.StdLib;
+using Microsoft.Extensions.Logging;
+
+#endregion
+
+namespace Asynkron.JsEngine.JsTypes;
+
+internal sealed class JsArrayIterator : IJsObjectLike, IAsJsValue, IPrototypeAccessorProvider
+{
+    private readonly IJsPropertyAccessor _accessor;
+    private readonly ArrayIteratorKind _kind;
+    private readonly RealmState? _realm;
+    private readonly Func<uint, JsValue>? _projector;
+    private readonly JsObject _properties = new();
+    private readonly TypedArrayBase? _typedAccessor;
+    private JsValue _cachedJsValue;
+    private uint _index;
+    private bool _exhausted;
+
+    internal JsArrayIterator(IJsPropertyAccessor accessor, ArrayIteratorKind kind, RealmState? realm, JsObject? prototype)
+    {
+        _accessor = accessor;
+        _kind = kind;
+        _realm = realm;
+        _typedAccessor = accessor as TypedArrayBase;
+        _properties.RealmState = realm;
+        if (prototype is not null)
+        {
+            _properties.SetPrototype(prototype);
+        }
+
+        _cachedJsValue = new JsValue(JsValueKind.Object, 0.0, this);
+    }
+
+    internal JsArrayIterator(IJsPropertyAccessor accessor, Func<uint, JsValue> projector, RealmState? realm,
+        JsObject? prototype)
+        : this(accessor, ArrayIteratorKind.Values, realm, prototype)
+    {
+        _projector = projector ?? throw new ArgumentNullException(nameof(projector));
+    }
+
+    public ref readonly JsValue AsJsValue => ref _cachedJsValue;
+
+    internal JsValue Next()
+    {
+        _realm?.Logger?.LogInformation("ArrayIterator.next index={Index}", _index);
+        if (_exhausted)
+        {
+            return IteratorResultObject.DoneUndefined.AsJsValue;
+        }
+
+        if (_typedAccessor?.IsDetachedOrOutOfBounds() == true)
+        {
+            throw _typedAccessor.CreateOutOfBoundsTypeError();
+        }
+
+        if (!_accessor.TryGetProperty("length", out var lenVal))
+        {
+            lenVal = JsValue.Zero;
+        }
+
+        var length = ReadLength(lenVal);
+        if (_index < length)
+        {
+            var valueJs = _projector is null ? ProjectIteratorValue(_kind, _index) : _projector(_index);
+            _index++;
+            return IteratorResultObject.Create(valueJs, false);
+        }
+
+        _exhausted = true;
+        return IteratorResultObject.DoneUndefined.AsJsValue;
+    }
+
+    private uint ReadLength(JsValue lengthValue)
+    {
+        if (_realm is null)
+        {
+            var length = StandardLibrary.ToLengthOrZero(lengthValue);
+            return (uint)Math.Min(Math.Max(length, 0), uint.MaxValue);
+        }
+
+        var evalContext = _realm.CreateContext();
+        var lengthNumeric = StandardLibrary.ToLengthOrZero(lengthValue, evalContext);
+        if (evalContext.IsThrow)
+        {
+            throw new ThrowSignal(evalContext.FlowValue);
+        }
+
+        return (uint)Math.Min(Math.Max(lengthNumeric, 0), uint.MaxValue);
+    }
+
+    private JsValue ProjectIteratorValue(ArrayIteratorKind kind, uint index)
+    {
+        return kind switch
+        {
+            ArrayIteratorKind.Keys => new JsValue((double)index),
+            ArrayIteratorKind.Values => StandardLibrary.GetElementOrUndefinedJsValue(_accessor, index),
+            ArrayIteratorKind.Entries => CreateIteratorEntryPair(index),
+            _ => JsValue.Undefined
+        };
+    }
+
+    private JsValue CreateIteratorEntryPair(uint index)
+    {
+        var pair = new JsArray(_realm);
+        pair.Push((double)index);
+        pair.Push(StandardLibrary.GetElementOrUndefinedJsValue(_accessor, index));
+        return JsValue.FromJsArray(pair);
+    }
+
+    public JsObject? Prototype => _properties.Prototype;
+    public bool IsSealed => _properties.IsSealed;
+    public bool IsFrozen => _properties.IsFrozen;
+    IEnumerable<string> IJsObjectLike.Keys => _properties.Keys;
+
+    public IJsPropertyAccessor? PrototypeAccessor =>
+        _properties is IPrototypeAccessorProvider provider ? provider.PrototypeAccessor : null;
+
+    public bool TryGetProperty(string name, out JsValue value) =>
+        _properties.TryGetProperty(name, _cachedJsValue, out value);
+
+    public bool TryGetProperty(string name, JsValue receiver, out JsValue value) =>
+        _properties.TryGetProperty(name, receiver, out value);
+
+    public void SetProperty(string name, JsValue value) =>
+        _properties.SetProperty(name, value, _cachedJsValue);
+
+    public void SetProperty(string name, JsValue value, JsValue receiver) =>
+        _properties.SetProperty(name, value, receiver);
+
+    public PropertyDescriptor? GetOwnPropertyDescriptor(string name) =>
+        _properties.GetOwnPropertyDescriptor(name);
+
+    public IEnumerable<string> GetOwnPropertyNames() =>
+        _properties.GetOwnPropertyNames();
+
+    public IEnumerable<string> GetEnumerablePropertyNames() =>
+        _properties.GetEnumerablePropertyNames();
+
+    public IEnumerable<string> GetOwnPropertyKeysInOrder(bool includeSymbols = true, bool includeNonEnumerable = true) =>
+        _properties.GetOwnPropertyKeysInOrder(includeSymbols, includeNonEnumerable);
+
+    public void DefineProperty(string name, PropertyDescriptor descriptor) =>
+        _properties.DefineProperty(name, descriptor);
+
+    public void SetPrototype(IJsPropertyAccessor? candidate) =>
+        _properties.SetPrototype(candidate);
+
+    public void Seal() => _properties.Seal();
+
+    public bool Delete(string name) => _properties.DeleteOwnProperty(name);
+}

--- a/src/Asynkron.JsEngine/Runtime/RealmState.cs
+++ b/src/Asynkron.JsEngine/Runtime/RealmState.cs
@@ -36,6 +36,7 @@ public sealed class RealmState
     public JsObject? ObjectPrototype { get; set; }
     public IJsObjectLike? FunctionPrototype { get; set; }
     public IJsObjectLike? ArrayPrototype { get; set; }
+    public JsObject? ArrayIteratorPrototype { get; set; }
     public JsObject? DatePrototype { get; set; }
     public JsObject? ErrorPrototype { get; set; }
     public JsObject? TypeErrorPrototype { get; set; }

--- a/src/Asynkron.JsEngine/StdLib/Array/StandardLibrary.Array.Iterators.cs
+++ b/src/Asynkron.JsEngine/StdLib/Array/StandardLibrary.Array.Iterators.cs
@@ -50,109 +50,27 @@ public static partial class StandardLibrary
     internal static object CreateArrayIteratorObject(IJsPropertyAccessor accessor, ArrayIteratorKind kind,
         RealmState? realm)
     {
-        var iterator = new JsObject(realm?.ObjectPrototype);
-        var iteratorKey = SymbolKeys.Iterator;
-
-        uint index = 0;
-        var exhausted = false;
-        var typedAccessor = accessor as TypedArrayBase;
-
-        iterator.SetHostedProperty("next", Next, realm);
-        iterator.SetHostedProperty(iteratorKey, ReturnIterator, realm);
-        return iterator;
-
-        JsValue Next(JsValue _, IReadOnlyList<JsValue> __, RealmState? ___)
+        if (realm is null)
         {
-            realm?.Logger?.LogInformation("ArrayIterator.next index={Index}", index);
-            if (exhausted)
-            {
-                return IteratorResultObject.DoneUndefined.AsJsValue;
-            }
-
-            if (typedAccessor?.IsDetachedOrOutOfBounds() == true)
-            {
-                throw typedAccessor.CreateOutOfBoundsTypeError();
-            }
-
-            // Get length as JsValue, avoiding boxing from ternary expression
-            if (!accessor.TryGetProperty("length", out var lenVal))
-            {
-                lenVal = JsValue.Zero;
-            }
-
-            var evalContext = realm?.CreateContext();
-            var length = (uint)Math.Min(Math.Max(ToLengthOrZero(lenVal, evalContext), 0), uint.MaxValue);
-            if (evalContext?.IsThrow == true) throw new ThrowSignal(evalContext.FlowValue);
-            if (index < length)
-            {
-                // Project value based on kind - no closure allocation
-                var valueJs = ProjectIteratorValue(kind, index, accessor, realm);
-                index++;
-                return new IteratorResultObject(valueJs, false).AsJsValue;
-            }
-
-            exhausted = true;
-            return IteratorResultObject.DoneUndefined.AsJsValue;
+            return CreateArrayIteratorFallback(accessor, kind, realm);
         }
 
-        JsValue ReturnIterator(JsValue _, IReadOnlyList<JsValue> __, RealmState? ___)
-        {
-            return new JsValue(iterator);
-        }
+        var iteratorPrototype = realm.ArrayIteratorPrototype ??
+                                (realm.ArrayIteratorPrototype = (JsObject)ArrayIteratorPrototype.CreatePrototype(realm));
+        return new JsArrayIterator(accessor, kind, realm, iteratorPrototype);
     }
 
     internal static object CreateArrayIteratorObject(IJsPropertyAccessor accessor, Func<uint, JsValue> projector,
         RealmState? realm)
     {
-        var iterator = new JsObject(realm?.ObjectPrototype);
-        var iteratorKey = SymbolKeys.Iterator;
-
-        uint index = 0;
-        var exhausted = false;
-        var typedAccessor = accessor as TypedArrayBase;
-
-        iterator.SetHostedProperty("next", Next, realm);
-        iterator.SetHostedProperty(iteratorKey, ReturnIterator, realm);
-        return iterator;
-
-        JsValue Next(JsValue _, IReadOnlyList<JsValue> __, RealmState? ___)
+        if (realm is null)
         {
-            realm?.Logger?.LogInformation("ArrayIterator.next index={Index}", index);
-            if (exhausted)
-            {
-                return IteratorResultObject.DoneUndefined.AsJsValue;
-            }
-
-            if (typedAccessor?.IsDetachedOrOutOfBounds() == true)
-            {
-                throw typedAccessor.CreateOutOfBoundsTypeError();
-            }
-
-            // Get length as JsValue, avoiding boxing from ternary expression
-            if (!accessor.TryGetProperty("length", out var lenVal))
-            {
-                lenVal = JsValue.Zero;
-            }
-
-            var evalContext = realm?.CreateContext();
-            var length = (uint)Math.Min(Math.Max(ToLengthOrZero(lenVal, evalContext), 0), uint.MaxValue);
-            if (evalContext?.IsThrow == true) throw new ThrowSignal(evalContext.FlowValue);
-            if (index < length)
-            {
-                // Projector now returns JsValue directly - no boxing
-                var valueJs = projector(index);
-                index++;
-                return new IteratorResultObject(valueJs, false).AsJsValue;
-            }
-
-            exhausted = true;
-            return IteratorResultObject.DoneUndefined.AsJsValue;
+            return CreateArrayIteratorFallback(accessor, projector, realm);
         }
 
-        JsValue ReturnIterator(JsValue _, IReadOnlyList<JsValue> __, RealmState? ___)
-        {
-            return new JsValue(iterator);
-        }
+        var iteratorPrototype = realm.ArrayIteratorPrototype ??
+                                (realm.ArrayIteratorPrototype = (JsObject)ArrayIteratorPrototype.CreatePrototype(realm));
+        return new JsArrayIterator(accessor, projector, realm, iteratorPrototype);
     }
 
     /// <summary>
@@ -179,5 +97,109 @@ public static partial class StandardLibrary
         pair.Push((double)index);
         pair.Push(GetElementOrUndefinedJsValue(accessor, index));
         return JsValue.FromJsArray(pair);
+    }
+
+    private static object CreateArrayIteratorFallback(IJsPropertyAccessor accessor, ArrayIteratorKind kind,
+        RealmState? realm)
+    {
+        var iterator = new JsObject(realm?.ObjectPrototype);
+        var iteratorKey = SymbolKeys.Iterator;
+
+        uint index = 0;
+        var exhausted = false;
+        var typedAccessor = accessor as TypedArrayBase;
+
+        iterator.SetHostedProperty("next", Next, realm);
+        iterator.SetHostedProperty(iteratorKey, ReturnIterator, realm);
+        return iterator;
+
+        JsValue Next(JsValue _, IReadOnlyList<JsValue> __, RealmState? ___)
+        {
+            realm?.Logger?.LogInformation("ArrayIterator.next index={Index}", index);
+            if (exhausted)
+            {
+                return IteratorResultObject.DoneUndefined.AsJsValue;
+            }
+
+            if (typedAccessor?.IsDetachedOrOutOfBounds() == true)
+            {
+                throw typedAccessor.CreateOutOfBoundsTypeError();
+            }
+
+            if (!accessor.TryGetProperty("length", out var lenVal))
+            {
+                lenVal = JsValue.Zero;
+            }
+
+            var evalContext = realm?.CreateContext();
+            var length = (uint)Math.Min(Math.Max(ToLengthOrZero(lenVal, evalContext), 0), uint.MaxValue);
+            if (evalContext?.IsThrow == true) throw new ThrowSignal(evalContext.FlowValue);
+            if (index < length)
+            {
+                var valueJs = ProjectIteratorValue(kind, index, accessor, realm);
+                index++;
+                return new IteratorResultObject(valueJs, false).AsJsValue;
+            }
+
+            exhausted = true;
+            return IteratorResultObject.DoneUndefined.AsJsValue;
+        }
+
+        JsValue ReturnIterator(JsValue _, IReadOnlyList<JsValue> __, RealmState? ___)
+        {
+            return new JsValue(iterator);
+        }
+    }
+
+    private static object CreateArrayIteratorFallback(IJsPropertyAccessor accessor, Func<uint, JsValue> projector,
+        RealmState? realm)
+    {
+        var iterator = new JsObject(realm?.ObjectPrototype);
+        var iteratorKey = SymbolKeys.Iterator;
+
+        uint index = 0;
+        var exhausted = false;
+        var typedAccessor = accessor as TypedArrayBase;
+
+        iterator.SetHostedProperty("next", Next, realm);
+        iterator.SetHostedProperty(iteratorKey, ReturnIterator, realm);
+        return iterator;
+
+        JsValue Next(JsValue _, IReadOnlyList<JsValue> __, RealmState? ___)
+        {
+            realm?.Logger?.LogInformation("ArrayIterator.next index={Index}", index);
+            if (exhausted)
+            {
+                return IteratorResultObject.DoneUndefined.AsJsValue;
+            }
+
+            if (typedAccessor?.IsDetachedOrOutOfBounds() == true)
+            {
+                throw typedAccessor.CreateOutOfBoundsTypeError();
+            }
+
+            if (!accessor.TryGetProperty("length", out var lenVal))
+            {
+                lenVal = JsValue.Zero;
+            }
+
+            var evalContext = realm?.CreateContext();
+            var length = (uint)Math.Min(Math.Max(ToLengthOrZero(lenVal, evalContext), 0), uint.MaxValue);
+            if (evalContext?.IsThrow == true) throw new ThrowSignal(evalContext.FlowValue);
+            if (index < length)
+            {
+                var valueJs = projector(index);
+                index++;
+                return new IteratorResultObject(valueJs, false).AsJsValue;
+            }
+
+            exhausted = true;
+            return IteratorResultObject.DoneUndefined.AsJsValue;
+        }
+
+        JsValue ReturnIterator(JsValue _, IReadOnlyList<JsValue> __, RealmState? ___)
+        {
+            return new JsValue(iterator);
+        }
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/ArrayIterator/ArrayIteratorPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/ArrayIterator/ArrayIteratorPrototype.cs
@@ -1,8 +1,8 @@
 #region
 
-using System;
 using Asynkron.JsEngine.JsTypes;
 using Asynkron.JsEngine.Runtime.Prototypes;
+using static Asynkron.JsEngine.StdLib.StandardLibrary;
 
 #endregion
 
@@ -12,14 +12,31 @@ namespace Asynkron.JsEngine.StdLib;
 /// ArrayIterator prototype for array iterators
 /// </summary>
 [JsPrototype("Array Iterator", ToStringTag = "Array Iterator")]
+[JsSymbolAlias("iterator", "__selfIterator")]
 public sealed partial class ArrayIteratorPrototype : JsPrototype
 {
     /* FLAKY */
     [JsHostMethod("next", Length = 0d)]
     public JsValue Next(JsValue thisValue)
     {
-        // TODO: Implement ArrayIterator.prototype.next
-        // Returns the next item in the array iteration
-        throw new NotImplementedException("ArrayIterator.prototype.next is not yet implemented");
+        if (!thisValue.TryGetObject<JsArrayIterator>(out var iterator) || iterator is null)
+        {
+            throw ThrowTypeError("Array Iterator.prototype.next requires an Array Iterator instance", realm: Realm);
+        }
+
+        return iterator.Next();
+    }
+
+    [JsHostMethod("__selfIterator", Length = 0d)]
+    public static JsValue SelfIterator(JsValue thisValue) => thisValue;
+
+    protected override void ConfigurePrototype()
+    {
+        if (Prototype is JsObject { RealmState: null } jsObj)
+        {
+            jsObj.RealmState = Realm;
+        }
+
+        Realm.ArrayIteratorPrototype ??= Prototype as JsObject;
     }
 }


### PR DESCRIPTION
Summary:
- Implement JsArrayIterator and ArrayIteratorPrototype.next
- Wire ArrayIteratorPrototype into array iterator creation
- Add RealmState.ArrayIteratorPrototype

Tests:
- dotnet test tests/Asynkron.JsEngine.Tests.Test262 --filter "ArrayIteratorPrototype_next"