### PR TITLE
Fix Array pop length/delete errors

### DIFF
--- a/src/Asynkron.JsEngine/JsTypes/JsArray.cs
+++ b/src/Asynkron.JsEngine/JsTypes/JsArray.cs
@@ -321,6 +321,11 @@ public sealed class JsArray : IJsObjectLike, IPropertyDefinitionHost, IExtensibi
             return false;
         }
 
+        if (IsSealed && TryGetOwnIndex(index, out _))
+        {
+            return false;
+        }
+
         _properties.DeleteOwnProperty(name);
         return DeleteElement((int)index);
     }

--- a/src/Asynkron.JsEngine/JsTypes/JsObject.cs
+++ b/src/Asynkron.JsEngine/JsTypes/JsObject.cs
@@ -1633,6 +1633,13 @@ public sealed class JsObject : IDictionary<string, object?>, IJsObjectLike,
             return true;
         }
 
+        if (_virtualPropertyProvider is not null &&
+            !name.IsPrivateSlotName() &&
+            _virtualPropertyProvider.TryGetOwnProperty(name, out _, out var virtualDescriptor))
+        {
+            return virtualDescriptor?.Configurable != false;
+        }
+
         // Property does not exist; delete is a no-op that succeeds.
         return true;
     }

--- a/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Mutators.cs
+++ b/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Mutators.cs
@@ -81,7 +81,7 @@ public sealed partial class ArrayPrototype
             var length = (long)ToLengthOrZero(lengthValue, evalContext);
             if (length == 0)
             {
-                accessor.SetProperty("length", 0d);
+                SetPropertyOrThrow(accessor, "length", new JsValue(0d), MethodName, Realm);
                 return JsValue.Undefined;
             }
 
@@ -89,7 +89,7 @@ public sealed partial class ArrayPrototype
             var key = ToIndexString(newLength);
             var elementExists = TryGetExistingElement(accessor, key, out var element);
             DeletePropertyOrThrow(objectLike, key, elementExists, MethodName, Realm);
-            accessor.SetProperty("length", (double)newLength);
+            SetPropertyOrThrow(accessor, "length", new JsValue((double)newLength), MethodName, Realm);
             return elementExists ? element : JsValue.Undefined;
         }
         finally

--- a/src/Asynkron.JsEngine/StdLib/Array/StandardLibrary.Array.Helpers.cs
+++ b/src/Asynkron.JsEngine/StdLib/Array/StandardLibrary.Array.Helpers.cs
@@ -437,6 +437,84 @@ public static partial class StandardLibrary
         target.DefineProperty(propertyKey, descriptor);
     }
 
+    internal static void SetPropertyOrThrow(IJsPropertyAccessor accessor, string propertyKey, JsValue value,
+        string methodName, RealmState? realm)
+    {
+        if (accessor is JsProxy)
+        {
+            accessor.SetProperty(propertyKey, value);
+            return;
+        }
+
+        if (accessor is JsArray jsArray && string.Equals(propertyKey, "length", StringComparison.Ordinal))
+        {
+            jsArray.SetLength(value, null);
+            return;
+        }
+
+        if (accessor is IJsObjectLike objectLike)
+        {
+            if (!CanSetProperty(objectLike, propertyKey))
+            {
+                throw ThrowTypeError($"{methodName} could not set property '{propertyKey}'", realm: realm);
+            }
+
+            objectLike.SetProperty(propertyKey, value);
+            return;
+        }
+
+        accessor.SetProperty(propertyKey, value);
+    }
+
+    private static bool CanSetProperty(IJsObjectLike target, string propertyKey)
+    {
+        var ownDescriptor = target.GetOwnPropertyDescriptor(propertyKey);
+        if (ownDescriptor is not null)
+        {
+            if (ownDescriptor.IsAccessorDescriptor)
+            {
+                return ownDescriptor.Set is not null;
+            }
+
+            return ownDescriptor.Writable;
+        }
+
+        var extensible = IsExtensible(target);
+        var prototype = target.Prototype;
+        while (prototype is not null)
+        {
+            var inheritedDescriptor = prototype.GetOwnPropertyDescriptor(propertyKey);
+            if (inheritedDescriptor is not null)
+            {
+                if (inheritedDescriptor.IsAccessorDescriptor)
+                {
+                    return inheritedDescriptor.Set is not null;
+                }
+
+                return inheritedDescriptor.Writable && extensible;
+            }
+
+            prototype = prototype.Prototype;
+        }
+
+        return extensible;
+    }
+
+    private static bool IsExtensible(IJsObjectLike target)
+    {
+        if (target is IExtensibilityControl extensible)
+        {
+            return extensible.IsExtensible;
+        }
+
+        if (target is JsObject jsObject)
+        {
+            return jsObject.IsExtensible;
+        }
+
+        return true;
+    }
+
     internal static bool TryGetExistingElement(IJsPropertyAccessor accessor, long index, out JsValue value)
     {
         return TryGetExistingElement(accessor, ToIndexString(index), out value);


### PR DESCRIPTION
- add SetPropertyOrThrow helper for length updates in Array.prototype.pop\n- prevent deleting array elements from sealed/frozen arrays\n- respect non-configurable virtual string properties during delete