### PR TITLE
Fix Array.prototype.toSorted and TypedArray.prototype.toSorted spec compliance

### DIFF
--- a/src/Asynkron.JsEngine/JsTypes/TypedArrayBase.cs
+++ b/src/Asynkron.JsEngine/JsTypes/TypedArrayBase.cs
@@ -825,7 +825,13 @@ public bool TryGetProperty(string name, JsValue receiver, out JsValue value)
 
     internal TypedArrayBase CreateSpeciesDefault(int length)
     {
-        return CreateNewSameType(length);
+        var result = CreateNewSameType(length);
+        // Copy prototype from source to result for spec compliance
+        if (Prototype is not null)
+        {
+            result.SetPrototype(Prototype);
+        }
+        return result;
     }
 
     public TypedArrayBase Slice(int begin, int end)

--- a/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Transformations.cs
+++ b/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Transformations.cs
@@ -472,11 +472,8 @@ public sealed partial class ArrayPrototype
     {
         const string MethodName = "Array.prototype.toSorted";
         var accessor = EnsureArrayLikeReceiver(thisValue, MethodName, Realm);
-        var evalContext = Realm?.CreateContext();
-        var lengthValue = accessor.TryGetProperty("length", out var lenVal) ? lenVal : JsValue.FromDouble(0d);
-        var length = (long)ToLengthOrZero(lengthValue, evalContext);
-        if (evalContext?.IsThrow == true) throw new ThrowSignal(evalContext.FlowValue);
 
+        // Per spec: Step 2 - check compareFn is callable BEFORE reading length (Step 3)
         if (args.Count > 0 && !args[0].IsUndefined && !args[0].TryGetObject<IJsCallable>(out _))
         {
             throw ThrowTypeError($"{MethodName} comparefn must be callable", realm: Realm);
@@ -486,6 +483,18 @@ public sealed partial class ArrayPrototype
         if (args.Count > 0 && args[0].TryGetObject<IJsCallable>(out var callable))
         {
             compareFn = callable;
+        }
+
+        // Per spec: Step 3 - Get length AFTER checking compareFn
+        var evalContext = Realm?.CreateContext();
+        var lengthValue = accessor.TryGetProperty("length", out var lenVal) ? lenVal : JsValue.FromDouble(0d);
+        var length = (long)ToLengthOrZero(lengthValue, evalContext);
+        if (evalContext?.IsThrow == true) throw new ThrowSignal(evalContext.FlowValue);
+
+        // Per spec: ArrayCreate throws RangeError if length > 2^32 - 1
+        if (length > MaxConcreteArrayLength)
+        {
+            throw ThrowRangeError($"{MethodName} array length exceeds maximum (2^32 - 1)", realm: Realm);
         }
 
         // Per spec SortIndexedProperties with skipHoles=true: read all existing elements first.

--- a/src/Asynkron.JsEngine/StdLib/TypedArray/TypedArrayPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/TypedArray/TypedArrayPrototype.cs
@@ -792,7 +792,8 @@ public sealed partial class TypedArrayPrototype
         var typedArray = ValidateReceiver(thisValue, "TypedArray.prototype.toReversed");
 
         var length = typedArray.Length;
-        var result = SpeciesCreate(typedArray, length);
+        // Per spec: TypedArrayCreateSameType - do NOT use species, always create same typed array
+        var result = typedArray.CreateSpeciesDefault(length);
         for (var k = 0; k < length; k++)
         {
             if (typedArray.IsDetachedOrOutOfBounds())
@@ -834,9 +835,25 @@ public sealed partial class TypedArrayPrototype
             values.Add(typedArray.GetValueForIndex(i));
         }
 
-        values.Sort(Comparer);
+        // Wrap sort in try-catch to properly propagate ThrowSignal from compareFn
+        // The .NET Sort may wrap the exception in InvalidOperationException
+        try
+        {
+            values.Sort(Comparer);
+        }
+        catch (InvalidOperationException ex) when (ex.InnerException is ThrowSignal ts)
+        {
+            // Re-throw the original ThrowSignal
+            throw ts;
+        }
+        catch (ThrowSignal)
+        {
+            // Directly propagate ThrowSignal
+            throw;
+        }
 
-        var result = SpeciesCreate(typedArray, length);
+        // Per spec: TypedArrayCreateSameType - do NOT use species, always create same typed array
+        var result = typedArray.CreateSpeciesDefault(length);
         for (var i = 0; i < values.Count; i++)
         {
             result.SetValue(i, values[i]);
@@ -849,7 +866,12 @@ public sealed partial class TypedArrayPrototype
             if (compareFn is not null)
             {
                 var res = compareFn.Invoke([left, right], JsValue.Undefined);
-                var numeric = JsOps.ToNumber(res);
+                var context = Realm?.CreateContext();
+                var numeric = JsOps.ToNumber(res, context);
+                if (context?.IsThrow == true)
+                {
+                    throw new ThrowSignal(context.FlowValue);
+                }
                 return numeric > 0 ? 1 : numeric < 0 ? -1 : 0;
             }
 
@@ -908,7 +930,8 @@ public sealed partial class TypedArrayPrototype
         var insertCount = Math.Max(args.Count - 2, 0);
         var newLength = length - actualDeleteCount + insertCount;
 
-        var result = SpeciesCreate(typedArray, newLength);
+        // Per spec: TypedArrayCreateSameType - do NOT use species, always create same typed array
+        var result = typedArray.CreateSpeciesDefault(newLength);
         var targetIndex = 0;
 
         for (var i = 0; i < actualStart; i++)
@@ -966,7 +989,8 @@ public sealed partial class TypedArrayPrototype
             throw ThrowRangeError("Index out of range", realm: Realm);
         }
 
-        var result = SpeciesCreate(typedArray, length);
+        // Per spec: TypedArrayCreateSameType - do NOT use species, always create same typed array
+        var result = typedArray.CreateSpeciesDefault(length);
         for (var i = 0; i < length; i++)
         {
             if (typedArray.IsDetachedOrOutOfBounds())


### PR DESCRIPTION
## Summary

- Fix `Array.prototype.toSorted` to check if compareFn is callable before reading length (per ECMAScript spec step 2)
- Add RangeError when array length exceeds 2^32 - 1 (per ArrayCreate spec)
- Fix `TypedArray.prototype.toSorted` to properly propagate errors from compareFn and stop sorting
- Update `TypedArray.prototype.toSorted`, `toReversed`, `with`, and `toSpliced` to use TypedArrayCreateSameType instead of species (per spec, these methods should ignore @@species)
- Copy prototype from source to result in `CreateSpeciesDefault` for proper spec compliance

## Test plan

- [x] All 58 `Array.prototype.toSorted` and `TypedArray.prototype.toSorted` Test262 tests pass
- [x] All 2920 internal unit tests pass
- [x] Verified compareFn is checked before length is read
- [x] Verified RangeError is thrown for oversized arrays instead of OutOfMemoryException

🤖 Generated with [Claude Code](https://claude.com/claude-code)