### PR TITLE
Implement AsyncGenerator.prototype methods (next, return, throw)

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.AsyncGeneratorFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.AsyncGeneratorFunctionInvoker.cs
@@ -73,7 +73,8 @@ public static partial class TypedAstEvaluator
             // %AsyncGeneratorPrototype% (inherits from %AsyncIteratorPrototype%)
             if (RealmState.AsyncGeneratorPrototype is null)
             {
-                var asyncGenProto = new JsObject();
+                // Use the generated prototype factory to get all required properties (Symbol.toStringTag, methods, etc.)
+                var asyncGenProto = (JsObject)AsyncGeneratorPrototype.CreatePrototype(RealmState);
                 asyncGenProto.SetPrototype(RealmState.AsyncIteratorPrototype ?? RealmState.ObjectPrototype);
                 RealmState.AsyncGeneratorPrototype = asyncGenProto;
             }

--- a/src/Asynkron.JsEngine/StdLib/AsyncGenerator/AsyncGeneratorPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/AsyncGenerator/AsyncGeneratorPrototype.cs
@@ -1,8 +1,10 @@
 #region
 
-using System;
+using Asynkron.JsEngine.Ast;
 using Asynkron.JsEngine.JsTypes;
 using Asynkron.JsEngine.Runtime.Prototypes;
+using static Asynkron.JsEngine.StdLib.PromiseHelper;
+using static Asynkron.JsEngine.StdLib.StandardLibrary;
 
 #endregion
 
@@ -14,30 +16,89 @@ namespace Asynkron.JsEngine.StdLib;
 [JsPrototype("AsyncGenerator", ToStringTag = "AsyncGenerator")]
 public sealed partial class AsyncGeneratorPrototype : JsPrototype
 {
-    /* FLAKY */
     [JsHostMethod("next", Length = 1d)]
     public JsValue Next(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement AsyncGenerator.prototype.next
-        // Returns a promise for the next yielded value
-        throw new NotImplementedException("AsyncGenerator.prototype.next is not yet implemented");
+        // Per spec: if this is not an object, return a rejected promise with TypeError
+        if (!thisValue.IsObject)
+        {
+            return CreateRejectedPromiseWithTypeError("AsyncGenerator.prototype.next requires that |this| be an Object");
+        }
+
+        // Check if this is a valid async generator instance.
+        // Valid async generator instances:
+        // 1. Have their own "next" property (set by CreateGeneratorIteratorObject)
+        // 2. Have Symbol.asyncIterator property (distinguishes async from sync generators)
+        if (!thisValue.TryGetObject<JsObject>(out var jsObject) ||
+            !jsObject.ContainsKey("next") ||
+            !jsObject.ContainsKey(SymbolKeys.AsyncIterator) ||
+            !jsObject.TryGetProperty("next", out var nextProp) ||
+            !nextProp.TryGetCallable(out var nextCallable))
+        {
+            return CreateRejectedPromiseWithTypeError("Method AsyncGenerator.prototype.next called on incompatible receiver");
+        }
+
+        // The instance has its own next() implementation - delegate to it
+        return nextCallable.Invoke(args, thisValue);
     }
 
-    /* FLAKY */
     [JsHostMethod("return", Length = 1d)]
     public JsValue Return(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement AsyncGenerator.prototype.return
-        // Finishes the async generator and returns a value
-        throw new NotImplementedException("AsyncGenerator.prototype.return is not yet implemented");
+        // Per spec: if this is not an object, return a rejected promise with TypeError
+        if (!thisValue.IsObject)
+        {
+            return CreateRejectedPromiseWithTypeError("AsyncGenerator.prototype.return requires that |this| be an Object");
+        }
+
+        // Check if this is a valid async generator instance with its own "return" property
+        // and Symbol.asyncIterator (to distinguish from sync generators).
+        if (!thisValue.TryGetObject<JsObject>(out var jsObject) ||
+            !jsObject.ContainsKey("return") ||
+            !jsObject.ContainsKey(SymbolKeys.AsyncIterator) ||
+            !jsObject.TryGetProperty("return", out var returnProp) ||
+            !returnProp.TryGetCallable(out var returnCallable))
+        {
+            return CreateRejectedPromiseWithTypeError("Method AsyncGenerator.prototype.return called on incompatible receiver");
+        }
+
+        // The instance has its own return() implementation - delegate to it
+        return returnCallable.Invoke(args, thisValue);
     }
 
-    /* FLAKY */
     [JsHostMethod("throw", Length = 1d)]
     public JsValue Throw(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement AsyncGenerator.prototype.throw
-        // Throws an error into the async generator
-        throw new NotImplementedException("AsyncGenerator.prototype.throw is not yet implemented");
+        // Per spec: if this is not an object, return a rejected promise with TypeError
+        if (!thisValue.IsObject)
+        {
+            return CreateRejectedPromiseWithTypeError("AsyncGenerator.prototype.throw requires that |this| be an Object");
+        }
+
+        // Check if this is a valid async generator instance with its own "throw" property
+        // and Symbol.asyncIterator (to distinguish from sync generators).
+        if (!thisValue.TryGetObject<JsObject>(out var jsObject) ||
+            !jsObject.ContainsKey("throw") ||
+            !jsObject.ContainsKey(SymbolKeys.AsyncIterator) ||
+            !jsObject.TryGetProperty("throw", out var throwProp) ||
+            !throwProp.TryGetCallable(out var throwCallable))
+        {
+            return CreateRejectedPromiseWithTypeError("Method AsyncGenerator.prototype.throw called on incompatible receiver");
+        }
+
+        // The instance has its own throw() implementation - delegate to it
+        return throwCallable.Invoke(args, thisValue);
+    }
+
+    /// <summary>
+    /// Creates a rejected promise with a TypeError message.
+    /// </summary>
+    private JsValue CreateRejectedPromiseWithTypeError(string message)
+    {
+        var promise = CreatePromise(Realm);
+        var typeError = CreateTypeError(message, realm: Realm);
+        promise.Reject(typeError);
+
+        return (JsValue)promise.JsObject;
     }
 }


### PR DESCRIPTION
- Implement next(), return(), and throw() methods on AsyncGeneratorPrototype
- Each method properly validates the receiver is a valid async generator instance
- Returns rejected promises with TypeError for invalid receivers (per spec)
- Delegates to instance-specific implementation when receiver is valid
- Use generated prototype factory in AsyncGeneratorFunctionInvoker for proper setup
- Removes NotImplementedException stubs that were causing test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)