### PR TITLE
Fix Array.prototype.splice and toSpliced argument handling per ECMAScript spec

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Mutators.cs
+++ b/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Mutators.cs
@@ -251,30 +251,43 @@ public sealed partial class ArrayPrototype
 
             var insertCount = args.Count > 2 ? args.Count - 2 : 0;
 
-            double deleteCountArg;
-            if (args.Count == 0)
-            {
-                deleteCountArg = length - actualStart;
-            }
-            else
-            {
-                deleteCountArg = ToIntegerOrInfinity(args[1], evalContext);
-            }
+            // Per spec: "If start is not present" means args.Count == 0, not that args[0] is undefined
+            // Step 8: If start is not present, then actualDeleteCount = 0.
+            var startNotPresent = args.Count == 0;
+            // Per spec: "If deleteCount is not present" means args.Count <= 1, not that args[1] is undefined
+            // Step 9: Else if deleteCount is not present, actualDeleteCount = len - actualStart.
+            var deleteCountNotPresent = args.Count <= 1;
 
             long actualDeleteCount;
-            if (double.IsPositiveInfinity(deleteCountArg))
+            if (startNotPresent)
             {
-                actualDeleteCount = length - actualStart;
-            }
-            else if (double.IsNegativeInfinity(deleteCountArg))
-            {
+                // Step 8: start not present → actualDeleteCount = 0
                 actualDeleteCount = 0;
+            }
+            else if (deleteCountNotPresent)
+            {
+                // Step 9: deleteCount not present → actualDeleteCount = len - actualStart
+                actualDeleteCount = length - actualStart;
             }
             else
             {
-                var bounded = Math.Max(deleteCountArg, 0);
-                bounded = Math.Min(bounded, length - actualStart);
-                actualDeleteCount = (long)bounded;
+                // Step 10: deleteCount is present (even if undefined)
+                // ToIntegerOrInfinity(undefined) = 0
+                var deleteCountArg = ToIntegerOrInfinity(args[1], evalContext);
+                if (double.IsPositiveInfinity(deleteCountArg))
+                {
+                    actualDeleteCount = length - actualStart;
+                }
+                else if (double.IsNegativeInfinity(deleteCountArg))
+                {
+                    actualDeleteCount = 0;
+                }
+                else
+                {
+                    var bounded = Math.Max(deleteCountArg, 0);
+                    bounded = Math.Min(bounded, length - actualStart);
+                    actualDeleteCount = (long)bounded;
+                }
             }
 
             var newLength = length - actualDeleteCount + insertCount;

--- a/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Transformations.cs
+++ b/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Transformations.cs
@@ -596,14 +596,28 @@ public sealed partial class ArrayPrototype
         var startIndex = args.Count > 0 ? ToIntegerOrInfinity(args[0], evalContext) : 0;
         var actualStart = ClampRelativeIndex(startIndex, length);
 
-        var deleteCountIsUndefined = args.Count <= 1 || args[1].IsUndefined;
+        // Per spec: "If start is not present" means args.Count == 0, not that args[0] is undefined
+        // Step 8: If start is not present, then actualDeleteCount = 0.
+        var startNotPresent = args.Count == 0;
+        // Per spec: "If deleteCount is not present" means args.Count <= 1, not that args[1] is undefined
+        // Step 9: Else if deleteCount is not present, actualDeleteCount = len - actualStart.
+        var deleteCountNotPresent = args.Count <= 1;
+
         long actualDeleteCount;
-        if (deleteCountIsUndefined)
+        if (startNotPresent)
         {
+            // Step 8: start not present → actualDeleteCount = 0
+            actualDeleteCount = 0;
+        }
+        else if (deleteCountNotPresent)
+        {
+            // Step 9: deleteCount not present → actualDeleteCount = len - actualStart
             actualDeleteCount = length - actualStart;
         }
         else
         {
+            // Step 10: deleteCount is present (even if undefined)
+            // ToIntegerOrInfinity(undefined) = 0
             var deleteCountArg = ToIntegerOrInfinity(args[1], evalContext);
             if (double.IsPositiveInfinity(deleteCountArg))
             {

--- a/tests/Asynkron.JsEngine.Tests/AdditionalArrayMethodsTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/AdditionalArrayMethodsTests.cs
@@ -186,15 +186,24 @@ public class AdditionalArrayMethodsTests(ITestOutputHelper output) : InternalTes
         Assert.Equal(5d + 4d + 99d, result); // original unchanged, spliced is [1,2,99,5]
     }
 
+    /// <summary>
+    /// Per ECMAScript spec, when deleteCount is passed as undefined, it is converted to 0
+    /// via ToIntegerOrInfinity(undefined) = 0. This means no elements are deleted, and
+    /// the new elements are inserted at the start position.
+    /// To delete all elements from start to end, omit deleteCount entirely or use Infinity.
+    /// See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced
+    /// </summary>
     [Fact(Timeout = 2000)]
-    public async Task Array_ToSpliced_TreatsUndefinedDeleteCountAsWholeTail()
+    public async Task Array_ToSpliced_UndefinedDeleteCountConvertedToZero()
     {
         await using var engine = CreateEngine();
+        // With undefined deleteCount: ToIntegerOrInfinity(undefined) = 0, so nothing is deleted
+        // arr.toSpliced(1, undefined, 9) inserts 9 at index 1 with 0 deletions → [1, 9, 2, 3, 4]
         var result = await engine.Evaluate("""
 
                                                        const arr = [1, 2, 3, 4];
                                                        const spliced = arr.toSpliced(1, undefined, 9);
-                                                       return spliced.length === 2 && spliced[0] === 1 && spliced[1] === 9;
+                                                       return spliced.length === 5 && spliced[0] === 1 && spliced[1] === 9 && spliced[2] === 2;
 
                                            """);
         Assert.Equal(true, result);


### PR DESCRIPTION
## Summary

- Fix `Array.prototype.splice()` crash when called with only one argument (IndexOutOfRangeException)
- Fix `Array.prototype.toSpliced()` incorrect behavior when deleteCount is passed as `undefined`

## ECMAScript Specification Compliance

Per ECMAScript specification:
- "start not present" means `args.Count == 0`, not that `start` is `undefined`  
- "deleteCount not present" means `args.Count <= 1`, not that `deleteCount` is `undefined`
- When deleteCount IS present but `undefined`, `ToIntegerOrInfinity(undefined) = 0`

This distinction matters:
- `arr.splice(1)` - deleteCount not present → delete from index 1 to end
- `arr.splice(1, undefined)` - deleteCount is present but undefined → delete 0 elements

## Test Results

| Test Category | Before | After |
|---------------|--------|-------|
| toSpliced Test262 | 50 passing, 10 failing | 58 passing, 2 failing* |
| splice Test262 (called_with_one_argument) | 0 passing, 2 failing | 2 passing, 0 failing |
| Unit tests | 2919 passing, 1 failing | 2920 passing, 0 failing |

*Remaining toSpliced failures are unrelated (length exceeding 2^53-1 limit)

## Test plan

- [x] All 2920 unit tests pass
- [x] toSpliced Test262 tests: `deleteCount-undefined`, `start-and-deleteCount-undefineds`, `start-and-deleteCount-missing`, `frozen-this-value` now pass
- [x] splice Test262 tests: `called_with_one_argument` now passes
- [x] Updated unit test to match ECMAScript spec behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)