### PR TITLE
Add AsyncFunction prototype and constructor wiring

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -170,7 +170,21 @@ public static partial class TypedAstEvaluator
 
             var paramCount = function.Parameters.GetExpectedParameterCount();
             var functionNameValue = _function.Name?.Name ?? string.Empty;
-            if (RealmState.FunctionPrototype is not null)
+            if (IsAsyncLike)
+            {
+                var asyncProto = RealmState.AsyncFunctionPrototype;
+                if (asyncProto is null)
+                {
+                    RealmState.AsyncFunctionConstructor ??= AsyncFunctionConstructor.CreateConstructor(RealmState);
+                    asyncProto = RealmState.AsyncFunctionPrototype;
+                }
+
+                if (asyncProto is not null)
+                {
+                    _properties.SetPrototype(asyncProto);
+                }
+            }
+            else if (RealmState.FunctionPrototype is not null)
             {
                 _properties.SetPrototype(RealmState.FunctionPrototype);
             }

--- a/src/Asynkron.JsEngine/Runtime/RealmState.cs
+++ b/src/Asynkron.JsEngine/Runtime/RealmState.cs
@@ -50,6 +50,7 @@ public sealed class RealmState
 
     public JsObject? ObjectPrototype { get; set; }
     public IJsObjectLike? FunctionPrototype { get; set; }
+    public JsObject? AsyncFunctionPrototype { get; set; }
     public IJsObjectLike? ArrayPrototype { get; set; }
     public JsObject? DatePrototype { get; set; }
     public JsObject? ErrorPrototype { get; set; }
@@ -75,6 +76,7 @@ public sealed class RealmState
     public JsObject? WeakMapPrototype { get; set; }
     public JsObject? WeakSetPrototype { get; set; }
     public HostFunction? ArrayConstructor { get; set; }
+    public HostFunction? AsyncFunctionConstructor { get; set; }
     public HostFunction? MapConstructor { get; set; }
     public HostFunction? SetConstructor { get; set; }
     public HostFunction? WeakMapConstructor { get; set; }

--- a/src/Asynkron.JsEngine/StdLib/AsyncFunction/AsyncFunctionConstructor.cs
+++ b/src/Asynkron.JsEngine/StdLib/AsyncFunction/AsyncFunctionConstructor.cs
@@ -1,10 +1,13 @@
 #region
 
 using System;
+using Asynkron.JsEngine.Ast;
 using Asynkron.JsEngine.JsTypes;
+using Asynkron.JsEngine.Parser;
 using Asynkron.JsEngine.Runtime;
 using Asynkron.JsEngine.Runtime.Prototypes;
 using static Asynkron.JsEngine.StdLib.ReflectHelper;
+using static Asynkron.JsEngine.StdLib.StandardLibrary;
 
 #endregion
 
@@ -13,14 +16,109 @@ namespace Asynkron.JsEngine.StdLib;
 /// <summary>
 /// AsyncFunction constructor for creating async functions dynamically
 /// </summary>
-[JsConstructor("AsyncFunction", PrototypeType = typeof(FunctionPrototype), Length = 1d, DisplayName = "AsyncFunction")]
+[JsConstructor("AsyncFunction", PrototypeType = typeof(AsyncFunctionPrototype), Length = 1d, DisplayName = "AsyncFunction")]
 public sealed partial class AsyncFunctionConstructor(IJsObjectLike prototype, RealmState realm)
     : JsConstructor(prototype, realm)
 {
+    private HostFunction? _constructor;
+
     protected override JsValue ConstructInstance(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement AsyncFunction constructor
-        // Creates a new async function from string code
-        throw new NotImplementedException("AsyncFunction constructor is not yet implemented");
+        return ConstructAsyncFunctionBody(args, _constructor ?? throw new InvalidOperationException(
+            "AsyncFunction constructor not initialized"));
+    }
+
+    protected override void ConfigureConstructor(HostFunction constructor)
+    {
+        _constructor = constructor;
+        Realm.AsyncFunctionPrototype ??= Prototype as JsObject;
+        Realm.AsyncFunctionConstructor ??= constructor;
+
+        constructor.SetInvokeWithContext((args, _, _, newTarget) =>
+            ConstructAsyncFunctionBody(args,
+                newTarget.TryGetObject<IJsCallable>(out var callable) ? callable : constructor));
+
+        if (Realm.Engine?.GlobalObject.TryGetProperty("Function", out var functionCtorValue) == true &&
+            functionCtorValue.TryGetObject<IJsObjectLike>(out var functionCtor))
+        {
+            constructor.Properties.SetPrototype(functionCtor);
+        }
+
+        if (Prototype is IJsObjectLike protoObj && protoObj.GetOwnPropertyDescriptor("constructor") is null)
+        {
+            protoObj.DefineProperty("constructor",
+                new PropertyDescriptor
+                {
+                    Value = constructor,
+                    Writable = false,
+                    Enumerable = false,
+                    Configurable = true,
+                    HasValue = true,
+                    HasWritable = true,
+                    HasEnumerable = true,
+                    HasConfigurable = true
+                });
+        }
+    }
+
+    private JsValue ConstructAsyncFunctionBody(IReadOnlyList<JsValue> args, IJsCallable newTarget)
+    {
+        var engine = Realm.Engine;
+        if (engine is null)
+        {
+            throw ThrowTypeError("AsyncFunction constructor requires an engine context", realm: Realm);
+        }
+
+        var evalContext = Realm.CreateContext();
+        var argCount = args.Count;
+        var bodyValue = argCount > 0 ? args[argCount - 1] : JsValue.Undefined;
+        var parameterCount = Math.Max(argCount - 1, 0);
+
+        var parameters = new string[parameterCount];
+        for (var i = 0; i < parameterCount; i++)
+        {
+            parameters[i] = FunctionConstructor.ToFunctionArgumentString(args[i], evalContext, Realm);
+        }
+
+        var bodySource = FunctionConstructor.ToFunctionArgumentString(bodyValue, evalContext, Realm);
+        var paramList = string.Join(',', parameters);
+        var hasDanglingClose = FunctionConstructor.ContainsHtmlCloseCommentWithoutLineTerminator(paramList);
+        if (hasDanglingClose)
+        {
+            throw ThrowSyntaxError("Invalid function parameter list", evalContext, Realm);
+        }
+
+        var functionSource = $"(async function anonymous({paramList}\n) {{\n{bodySource}\n}})";
+
+        var scriptGoalOptions = new JsEngineOptions { AllowImportMeta = false };
+
+        ProgramNode program;
+        try
+        {
+            program = engine.ParseProgram(functionSource, options: scriptGoalOptions);
+        }
+        catch (ParseException parseException)
+        {
+            var message = parseException.Message ?? "SyntaxError";
+            throw new ThrowSignal(CreateSyntaxError(message, evalContext, Realm));
+        }
+
+        var created = engine.ExecuteProgram(
+            program,
+            engine.GlobalEnvironment,
+            CancellationToken.None);
+
+        if (created is not IJsObjectLike objectLike)
+        {
+            return JsValue.FromObjectUnsafe(created);
+        }
+
+        var proto = ResolveConstructPrototype(newTarget, _constructor ?? newTarget, Realm);
+        if (proto is not null)
+        {
+            objectLike.SetPrototype(proto);
+        }
+
+        return JsValue.FromObjectUnsafe(created);
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/AsyncFunction/AsyncFunctionPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/AsyncFunction/AsyncFunctionPrototype.cs
@@ -1,0 +1,31 @@
+#region
+
+using Asynkron.JsEngine.JsTypes;
+using Asynkron.JsEngine.Runtime;
+using Asynkron.JsEngine.Runtime.Prototypes;
+
+#endregion
+
+namespace Asynkron.JsEngine.StdLib;
+
+/// <summary>
+/// AsyncFunction prototype object (%AsyncFunction.prototype%).
+/// </summary>
+[JsPrototype("AsyncFunction", ToStringTag = "AsyncFunction")]
+public sealed partial class AsyncFunctionPrototype : JsPrototype
+{
+    protected override void ConfigurePrototype()
+    {
+        if (Prototype is JsObject { RealmState: null } jsObj)
+        {
+            jsObj.RealmState = Realm;
+        }
+
+        if (Realm.FunctionPrototype is { } functionPrototype)
+        {
+            Prototype.SetPrototype(functionPrototype);
+        }
+
+        Realm.AsyncFunctionPrototype ??= Prototype as JsObject;
+    }
+}

--- a/src/Asynkron.JsEngine/StdLib/Function/FunctionConstructor.cs
+++ b/src/Asynkron.JsEngine/StdLib/Function/FunctionConstructor.cs
@@ -96,7 +96,7 @@ public sealed partial class FunctionConstructor(IJsObjectLike prototype, RealmSt
         return JsValue.FromObjectUnsafe(created);
     }
 
-    private static string ToFunctionArgumentString(JsValue value, EvaluationContext evalContext, RealmState realmState)
+    internal static string ToFunctionArgumentString(JsValue value, EvaluationContext evalContext, RealmState realmState)
     {
         return value.Kind switch
         {
@@ -116,7 +116,7 @@ public sealed partial class FunctionConstructor(IJsObjectLike prototype, RealmSt
         };
     }
 
-    private static string NumberToString(double d)
+    internal static string NumberToString(double d)
     {
         if (double.IsNaN(d))
         {
@@ -136,7 +136,7 @@ public sealed partial class FunctionConstructor(IJsObjectLike prototype, RealmSt
         return d.ToString(CultureInfo.InvariantCulture);
     }
 
-    private static string ToFunctionArgumentStringFromObject(JsValue value, EvaluationContext evalContext,
+    internal static string ToFunctionArgumentStringFromObject(JsValue value, EvaluationContext evalContext,
         RealmState realmState)
     {
         var primitive = JsOps.ToPrimitive(value, ToPrimitiveHint.String, evalContext);
@@ -159,7 +159,7 @@ public sealed partial class FunctionConstructor(IJsObjectLike prototype, RealmSt
         };
     }
 
-    private static bool ContainsHtmlCloseCommentWithoutLineTerminator(string text)
+    internal static bool ContainsHtmlCloseCommentWithoutLineTerminator(string text)
     {
         var index = text.IndexOf("-->", StringComparison.Ordinal);
         if (index < 0)

--- a/src/Asynkron.JsEngine/StdLib/Reflect/ReflectHelper.cs
+++ b/src/Asynkron.JsEngine/StdLib/Reflect/ReflectHelper.cs
@@ -537,6 +537,7 @@ public static class ReflectHelper
         {
             "Array" => realmState.ArrayPrototype,
             "ArrayBuffer" => realmState.ArrayBufferPrototype,
+            "AsyncFunction" => realmState.AsyncFunctionPrototype,
             "SharedArrayBuffer" => realmState.SharedArrayBufferPrototype,
             "Boolean" => realmState.BooleanPrototype,
             "Date" => realmState.DatePrototype,


### PR DESCRIPTION
Summary:
- add %AsyncFunction.prototype% object with proper toStringTag and Function.prototype inheritance
- implement AsyncFunction constructor parsing and prototype resolution
- wire async function instances to AsyncFunctionPrototype and map Reflect.construct fallback