### PR TITLE
Align iterator prototypes with IteratorPrototype

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/ArrayIterator/ArrayIteratorPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/ArrayIterator/ArrayIteratorPrototype.cs
@@ -36,6 +36,11 @@ public sealed partial class ArrayIteratorPrototype : JsPrototype
             jsObj.RealmState = Realm;
         }
 
+        var iteratorPrototype = Realm.IteratorPrototype ??
+                                (JsObject)IteratorPrototype.CreatePrototype(Realm);
+        Realm.IteratorPrototype = iteratorPrototype;
+        Prototype.SetPrototype(iteratorPrototype);
+
         Realm.ArrayIteratorPrototype ??= Prototype as JsObject;
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/Iterator/IteratorConstructor.cs
+++ b/src/Asynkron.JsEngine/StdLib/Iterator/IteratorConstructor.cs
@@ -42,7 +42,21 @@ public sealed partial class IteratorConstructor(IJsObjectLike prototype, RealmSt
     protected override void ConfigureConstructor(HostFunction constructor)
     {
         // Store the iterator prototype in the realm for static method access
-        Realm.IteratorPrototype ??= Prototype as JsObject;
+        var constructorPrototype = Prototype as JsObject;
+        if (constructorPrototype is null)
+        {
+            return;
+        }
+
+        if (!ReferenceEquals(Realm.IteratorPrototype, constructorPrototype))
+        {
+            Realm.IteratorPrototype = constructorPrototype;
+        }
+
+        var iteratorPrototype = constructorPrototype;
+        Realm.ArrayIteratorPrototype?.SetPrototype(iteratorPrototype);
+        Realm.MapIteratorPrototype?.SetPrototype(iteratorPrototype);
+        Realm.SetIteratorPrototype?.SetPrototype(iteratorPrototype);
     }
 
     /// <summary>

--- a/src/Asynkron.JsEngine/StdLib/MapSet/MapIteratorPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/MapSet/MapIteratorPrototype.cs
@@ -33,6 +33,11 @@ public sealed partial class MapIteratorPrototype : JsPrototype
             jsObj.RealmState = Realm;
         }
 
+        var iteratorPrototype = Realm.IteratorPrototype ??
+                                (JsObject)IteratorPrototype.CreatePrototype(Realm);
+        Realm.IteratorPrototype = iteratorPrototype;
+        Prototype.SetPrototype(iteratorPrototype);
+
         Realm.MapIteratorPrototype ??= Prototype as JsObject;
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/MapSet/SetIteratorPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/MapSet/SetIteratorPrototype.cs
@@ -33,6 +33,11 @@ public sealed partial class SetIteratorPrototype : JsPrototype
             jsObj.RealmState = Realm;
         }
 
+        var iteratorPrototype = Realm.IteratorPrototype ??
+                                (JsObject)IteratorPrototype.CreatePrototype(Realm);
+        Realm.IteratorPrototype = iteratorPrototype;
+        Prototype.SetPrototype(iteratorPrototype);
+
         Realm.SetIteratorPrototype ??= Prototype as JsObject;
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/TypedArray/TypedArrayPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/TypedArray/TypedArrayPrototype.cs
@@ -243,31 +243,21 @@ public sealed partial class TypedArrayPrototype
     private JsValue Values(JsValue thisValue, IReadOnlyList<JsValue> _)
     {
         var typedArray = ValidateReceiver(thisValue, "%TypedArray%.prototype.values");
-        return JsValue.FromObjectUnsafe(CreateArrayIteratorObject(typedArray,
-            idx => typedArray.GetValueForIndex((int)idx), Realm));
+        return JsValue.FromObjectUnsafe(CreateArrayIteratorObject(typedArray, ArrayIteratorKind.Values, Realm));
     }
 
     [JsHostMethod("keys", Length = 0d)]
     private JsValue Keys(JsValue thisValue, IReadOnlyList<JsValue> _)
     {
         var typedArray = ValidateReceiver(thisValue, "%TypedArray%.prototype.keys");
-        return JsValue.FromObjectUnsafe(CreateArrayIteratorObject(typedArray, idx => new JsValue((double)idx), Realm));
+        return JsValue.FromObjectUnsafe(CreateArrayIteratorObject(typedArray, ArrayIteratorKind.Keys, Realm));
     }
 
     [JsHostMethod("entries", Length = 0d)]
     private JsValue Entries(JsValue thisValue, IReadOnlyList<JsValue> _)
     {
         var typedArray = ValidateReceiver(thisValue, "%TypedArray%.prototype.entries");
-        return JsValue.FromObjectUnsafe(CreateArrayIteratorObject(
-            typedArray,
-            idx =>
-            {
-                var pair = new JsArray(Realm);
-                pair.Push((double)idx);
-                pair.Push(typedArray.GetValueForIndex((int)idx));
-                return JsValue.FromJsArray(pair);
-            },
-            Realm));
+        return JsValue.FromObjectUnsafe(CreateArrayIteratorObject(typedArray, ArrayIteratorKind.Entries, Realm));
     }
 
     [JsHostMethod("join", Length = 1d)]


### PR DESCRIPTION
- Ensure Array/Map/Set iterator prototypes inherit from IteratorPrototype and rebind to the constructor prototype when available.
- Route TypedArray values/keys/entries through ArrayIteratorKind so typed array iterators use the shared ArrayIteratorPrototype.