### PR TITLE
Implement AsyncDisposableStack builtins

### DIFF
--- a/src/Asynkron.JsEngine/JsEngine.cs
+++ b/src/Asynkron.JsEngine/JsEngine.cs
@@ -210,6 +210,9 @@ public sealed class JsEngine : IAsyncDisposable
 
         SetGlobal("WeakRef", WeakRefHelper.CreateWeakRefConstructor(RealmState));
 
+        SetGlobal("DisposableStack", DisposableStackConstructor.CreateConstructor(RealmState));
+        SetGlobal("AsyncDisposableStack", AsyncDisposableStackConstructor.CreateConstructor(RealmState));
+
         // Register Iterator constructor
         SetGlobal("Iterator", IteratorConstructor.CreateConstructor(RealmState));
 

--- a/src/Asynkron.JsEngine/JsTypes/JsAsyncDisposableStack.cs
+++ b/src/Asynkron.JsEngine/JsTypes/JsAsyncDisposableStack.cs
@@ -1,0 +1,8 @@
+namespace Asynkron.JsEngine.JsTypes;
+
+public sealed class JsAsyncDisposableStack : JsDisposableStackBase
+{
+    public JsAsyncDisposableStack() : base()
+    {
+    }
+}

--- a/src/Asynkron.JsEngine/JsTypes/JsDisposableStack.cs
+++ b/src/Asynkron.JsEngine/JsTypes/JsDisposableStack.cs
@@ -1,0 +1,8 @@
+namespace Asynkron.JsEngine.JsTypes;
+
+public sealed class JsDisposableStack : JsDisposableStackBase
+{
+    public JsDisposableStack() : base()
+    {
+    }
+}

--- a/src/Asynkron.JsEngine/JsTypes/JsDisposableStackBase.cs
+++ b/src/Asynkron.JsEngine/JsTypes/JsDisposableStackBase.cs
@@ -1,0 +1,141 @@
+#region
+
+using System;
+using System.Collections.Generic;
+using Asynkron.JsEngine.Ast;
+
+#endregion
+
+namespace Asynkron.JsEngine.JsTypes;
+
+public abstract class JsDisposableStackBase : IJsObjectLike, IPropertyDefinitionHost, IExtensibilityControl,
+    IPrototypeAccessorProvider, IAsJsValue
+{
+    private readonly JsObject _properties = new();
+    private readonly JsValue _cachedJsValue;
+    private readonly List<DisposableStackRecord> _records = [];
+
+    protected JsDisposableStackBase()
+    {
+        _cachedJsValue = new JsValue(JsValueKind.Object, 0.0, this);
+    }
+
+    internal bool IsDisposed { get; private set; }
+
+    public ref readonly JsValue AsJsValue => ref _cachedJsValue;
+
+    public bool IsExtensible => _properties.IsExtensible;
+
+    public void PreventExtensions()
+    {
+        _properties.PreventExtensions();
+    }
+
+    public bool TryGetProperty(string name, JsValue receiver, out JsValue value)
+    {
+        return _properties.TryGetProperty(name, receiver.IsUndefined ? _cachedJsValue : receiver, out value);
+    }
+
+    public bool TryGetProperty(string name, out JsValue value)
+    {
+        return TryGetProperty(name, _cachedJsValue, out value);
+    }
+
+    public void SetProperty(string name, JsValue value, JsValue receiver)
+    {
+        _properties.SetProperty(name, value, receiver.IsUndefined ? _cachedJsValue : receiver);
+    }
+
+    public void SetProperty(string name, JsValue value)
+    {
+        SetProperty(name, value, _cachedJsValue);
+    }
+
+    public JsObject? Prototype => _properties.Prototype;
+
+    public bool IsSealed => _properties.IsSealed;
+    public bool IsFrozen => _properties.IsFrozen;
+
+    public IEnumerable<string> Keys => _properties.Keys;
+
+    public void DefineProperty(string name, PropertyDescriptor descriptor)
+    {
+        _properties.DefineProperty(name, descriptor);
+    }
+
+    public void SetPrototype(IJsPropertyAccessor? candidate)
+    {
+        _properties.SetPrototype(candidate);
+    }
+
+    public void Seal()
+    {
+        _properties.Seal();
+    }
+
+    public bool Delete(string name)
+    {
+        return _properties.DeleteOwnProperty(name);
+    }
+
+    public bool TryDefineProperty(string name, PropertyDescriptor descriptor)
+    {
+        return _properties.TryDefineProperty(name, descriptor);
+    }
+
+    public IJsPropertyAccessor? PrototypeAccessor =>
+        _properties is IPrototypeAccessorProvider provider ? provider.PrototypeAccessor : null;
+
+    internal void AddRecord(IJsCallable disposeMethod, JsValue thisArg, JsValue[] args)
+    {
+        _records.Add(new DisposableStackRecord(disposeMethod, thisArg, args));
+    }
+
+    internal bool TryPopRecord(out DisposableStackRecord record)
+    {
+        if (_records.Count == 0)
+        {
+            record = default;
+            return false;
+        }
+
+        var index = _records.Count - 1;
+        record = _records[index];
+        _records.RemoveAt(index);
+        return true;
+    }
+
+    internal void TransferRecordsTo(JsDisposableStackBase target)
+    {
+        if (_records.Count == 0)
+        {
+            return;
+        }
+
+        target._records.AddRange(_records);
+        _records.Clear();
+    }
+
+    internal void ClearRecords() => _records.Clear();
+
+    internal void MarkDisposed() => IsDisposed = true;
+}
+
+internal readonly struct DisposableStackRecord
+{
+    internal DisposableStackRecord(IJsCallable disposeMethod, JsValue thisArg, JsValue[] args)
+    {
+        DisposeMethod = disposeMethod;
+        ThisArg = thisArg;
+        Args = args;
+    }
+
+    internal IJsCallable DisposeMethod { get; }
+    internal JsValue ThisArg { get; }
+    internal JsValue[] Args { get; }
+
+    internal JsValue Invoke()
+    {
+        return DisposeMethod.Invoke(Args, ThisArg);
+    }
+}

--- a/src/Asynkron.JsEngine/Runtime/RealmState.cs
+++ b/src/Asynkron.JsEngine/Runtime/RealmState.cs
@@ -74,11 +74,15 @@ public sealed class RealmState
     public JsObject? SetIteratorPrototype { get; set; }
     public JsObject? WeakMapPrototype { get; set; }
     public JsObject? WeakSetPrototype { get; set; }
+    public JsObject? DisposableStackPrototype { get; set; }
+    public JsObject? AsyncDisposableStackPrototype { get; set; }
     public HostFunction? ArrayConstructor { get; set; }
     public HostFunction? MapConstructor { get; set; }
     public HostFunction? SetConstructor { get; set; }
     public HostFunction? WeakMapConstructor { get; set; }
     public HostFunction? WeakSetConstructor { get; set; }
+    public HostFunction? DisposableStackConstructor { get; set; }
+    public HostFunction? AsyncDisposableStackConstructor { get; set; }
     public JsObject? TypedArrayPrototype { get; set; }
     public HostFunction? TypedArrayConstructor { get; set; }
     public JsObject? ArrayBufferPrototype { get; set; }

--- a/src/Asynkron.JsEngine/StdLib/AsyncDisposableStack/AsyncDisposableStackConstructor.cs
+++ b/src/Asynkron.JsEngine/StdLib/AsyncDisposableStack/AsyncDisposableStackConstructor.cs
@@ -5,6 +5,7 @@ using Asynkron.JsEngine.JsTypes;
 using Asynkron.JsEngine.Runtime;
 using Asynkron.JsEngine.Runtime.Prototypes;
 using static Asynkron.JsEngine.StdLib.ReflectHelper;
+using static Asynkron.JsEngine.StdLib.StandardLibrary;
 
 #endregion
 
@@ -14,16 +15,49 @@ namespace Asynkron.JsEngine.StdLib;
 public sealed partial class AsyncDisposableStackConstructor(IJsObjectLike prototype, RealmState realm)
     : JsConstructor(prototype, realm)
 {
+    private HostFunction? _constructor;
+
+    private HostFunction ConstructFallback =>
+        _constructor ?? throw new InvalidOperationException("AsyncDisposableStack constructor not initialized");
+
     protected override JsValue ConstructInstance(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement AsyncDisposableStack constructor
-        // Creates a new AsyncDisposableStack for async explicit resource management
-        var obj = PrepareThisObject(JsValue.Undefined, false);
-        if (Prototype is not null && obj.Prototype is null)
+        if (thisValue.IsObject && thisValue.AsObject() is { IsConstructing: true })
         {
-            obj.SetPrototype(Prototype);
+            var target = _constructor ?? ConstructFallback;
+            return JsValue.FromObjectUnsafe(ConstructStack(target, target));
         }
-        obj.RealmState ??= Realm;
-        return new JsValue(obj);
+
+        throw ThrowTypeError("Constructor AsyncDisposableStack requires 'new'", realm: Realm);
+    }
+
+    protected override void ConfigureConstructor(HostFunction constructor)
+    {
+        _constructor = constructor;
+        Realm.AsyncDisposableStackConstructor ??= constructor;
+        Realm.AsyncDisposableStackPrototype ??= Prototype as JsObject;
+
+        constructor.SetInvokeWithContext((_, _, _, newTarget) =>
+        {
+            if (!newTarget.TryGetCallable(out var callable))
+            {
+                throw ThrowTypeError("Constructor AsyncDisposableStack requires 'new'", realm: Realm);
+            }
+
+            var target = _constructor ?? constructor;
+            return JsValue.FromObjectUnsafe(ConstructStack(callable, target));
+        });
+    }
+
+    private object ConstructStack(IJsCallable newTarget, IJsCallable targetCtor)
+    {
+        var proto = ResolveConstructPrototype(newTarget, targetCtor, Realm) ?? Prototype;
+        var instance = new JsAsyncDisposableStack();
+        if (proto is not null)
+        {
+            instance.SetPrototype(proto);
+        }
+
+        return instance;
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/AsyncDisposableStack/AsyncDisposableStackPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/AsyncDisposableStack/AsyncDisposableStackPrototype.cs
@@ -3,65 +3,196 @@
 using System;
 using Asynkron.JsEngine.JsTypes;
 using Asynkron.JsEngine.Runtime.Prototypes;
+using static Asynkron.JsEngine.StdLib.PromiseHelper;
+using static Asynkron.JsEngine.StdLib.StandardLibrary;
 
 #endregion
 
 namespace Asynkron.JsEngine.StdLib;
 
 [JsPrototype("AsyncDisposableStack", ToStringTag = "AsyncDisposableStack")]
+[JsSymbolAlias("asyncDispose", "disposeAsync")]
 public sealed partial class AsyncDisposableStackPrototype : JsPrototype
 {
     /* FLAKY */
     [JsHostMethod("use", Length = 1d)]
     public JsValue Use(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement AsyncDisposableStack.prototype.use
-        // Adds a disposable resource to the async stack
-        throw new NotImplementedException("AsyncDisposableStack.prototype.use is not yet implemented");
+        var stack = RequireStack(thisValue);
+        EnsureNotDisposed(stack);
+
+        var value = args.GetArgument(0);
+        var disposeMethod = DisposableStackHelper.GetDisposeMethod(value, preferAsync: true, Realm);
+        if (disposeMethod is null)
+        {
+            return value;
+        }
+
+        stack.AddRecord(disposeMethod, value, Array.Empty<JsValue>());
+        return value;
     }
 
     /* FLAKY */
     [JsHostMethod("adopt", Length = 2d)]
     public JsValue Adopt(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement AsyncDisposableStack.prototype.adopt
-        // Adopts a value and an async disposal callback
-        throw new NotImplementedException("AsyncDisposableStack.prototype.adopt is not yet implemented");
+        var stack = RequireStack(thisValue);
+        EnsureNotDisposed(stack);
+
+        var value = args.GetArgument(0);
+        var onDispose = args.GetArgument(1);
+        if (!onDispose.TryGetObject<IJsCallable>(out var callable) || callable is null)
+        {
+            throw ThrowTypeError("AsyncDisposableStack.prototype.adopt requires a callable disposer", realm: Realm);
+        }
+
+        stack.AddRecord(callable, JsValue.Undefined, [value]);
+        return value;
     }
 
     /* FLAKY */
     [JsHostMethod("defer", Length = 1d)]
     public JsValue Defer(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement AsyncDisposableStack.prototype.defer
-        // Defers execution of an async callback until disposal
-        throw new NotImplementedException("AsyncDisposableStack.prototype.defer is not yet implemented");
+        var stack = RequireStack(thisValue);
+        EnsureNotDisposed(stack);
+
+        var onDispose = args.GetArgument(0);
+        if (!onDispose.TryGetObject<IJsCallable>(out var callable) || callable is null)
+        {
+            throw ThrowTypeError("AsyncDisposableStack.prototype.defer requires a callable disposer", realm: Realm);
+        }
+
+        stack.AddRecord(callable, JsValue.Undefined, Array.Empty<JsValue>());
+        return JsValue.Undefined;
     }
 
     /* FLAKY */
     [JsHostMethod("move", Length = 0d)]
     public JsValue Move(JsValue thisValue)
     {
-        // TODO: Implement AsyncDisposableStack.prototype.move
-        // Moves the stack to a new AsyncDisposableStack
-        throw new NotImplementedException("AsyncDisposableStack.prototype.move is not yet implemented");
+        var stack = RequireStack(thisValue);
+        EnsureNotDisposed(stack);
+
+        var result = new JsAsyncDisposableStack();
+        if (Realm.AsyncDisposableStackPrototype is not null)
+        {
+            result.SetPrototype(Realm.AsyncDisposableStackPrototype);
+        }
+
+        stack.TransferRecordsTo(result);
+        stack.MarkDisposed();
+        return result.AsJsValue;
     }
 
     /* FLAKY */
     [JsHostMethod("disposeAsync", Length = 0d)]
     public JsValue DisposeAsync(JsValue thisValue)
     {
-        // TODO: Implement AsyncDisposableStack.prototype.disposeAsync
-        // Asynchronously disposes all resources in the stack
-        throw new NotImplementedException("AsyncDisposableStack.prototype.disposeAsync is not yet implemented");
+        var promise = CreatePromise(Realm);
+
+        if (!thisValue.TryGetObject<JsAsyncDisposableStack>(out var stack) || stack is null)
+        {
+            promise.Reject(CreateTypeError("AsyncDisposableStack.prototype.disposeAsync called on incompatible receiver",
+                realm: Realm));
+            return new JsValue(promise.JsObject);
+        }
+
+        if (stack.IsDisposed)
+        {
+            promise.Resolve(JsValue.Undefined);
+            return new JsValue(promise.JsObject);
+        }
+
+        stack.MarkDisposed();
+
+        try
+        {
+            while (stack.TryPopRecord(out var record))
+            {
+                record.Invoke();
+            }
+
+            promise.Resolve(JsValue.Undefined);
+        }
+        catch (ThrowSignal signal)
+        {
+            promise.Reject(signal.ThrownValue);
+        }
+        catch (Exception ex)
+        {
+            promise.Reject(CreateTypeError(ex.Message, realm: Realm));
+        }
+
+        return new JsValue(promise.JsObject);
     }
 
     /* FLAKY */
     [JsHostGetter("disposed")]
     public JsValue Disposed(JsValue thisValue)
     {
-        // TODO: Implement AsyncDisposableStack.prototype.disposed getter
-        // Returns true if the stack has been disposed
-        throw new NotImplementedException("AsyncDisposableStack.prototype.disposed is not yet implemented");
+        var stack = RequireStack(thisValue);
+        return new JsValue(stack.IsDisposed);
+    }
+
+    protected override void ConfigurePrototype()
+    {
+        if (Prototype is JsObject { RealmState: null } jsObj)
+        {
+            jsObj.RealmState = Realm;
+        }
+
+        Realm.AsyncDisposableStackPrototype ??= Prototype as JsObject;
+        EnsureDisposedAccessorMetadata();
+    }
+
+    private JsAsyncDisposableStack RequireStack(JsValue thisValue)
+    {
+        if (!thisValue.TryGetObject<JsAsyncDisposableStack>(out var stack) || stack is null)
+        {
+            throw ThrowTypeError("AsyncDisposableStack method called on incompatible receiver", realm: Realm);
+        }
+
+        return stack;
+    }
+
+    private void EnsureNotDisposed(JsDisposableStackBase stack)
+    {
+        if (stack.IsDisposed)
+        {
+            throw ThrowReferenceError("AsyncDisposableStack has already been disposed", realm: Realm);
+        }
+    }
+
+    private void EnsureDisposedAccessorMetadata()
+    {
+        if (Prototype.GetOwnPropertyDescriptor("disposed") is not { Get: { } getter })
+        {
+            return;
+        }
+
+        if (getter is not IJsObjectLike getterObj)
+        {
+            return;
+        }
+
+        EnsureFunctionMetadata(getterObj, "length", 0d);
+        EnsureFunctionMetadata(getterObj, "name", "get disposed");
+    }
+
+    private static void EnsureFunctionMetadata(IJsObjectLike target, string propertyName, object value)
+    {
+        if (target.GetOwnPropertyDescriptor(propertyName) is not null)
+        {
+            return;
+        }
+
+        target.DefineProperty(propertyName, new PropertyDescriptor
+        {
+            Value = value,
+            Writable = false,
+            Enumerable = false,
+            Configurable = true
+        });
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/DisposableStack/DisposableStackConstructor.cs
+++ b/src/Asynkron.JsEngine/StdLib/DisposableStack/DisposableStackConstructor.cs
@@ -5,6 +5,7 @@ using Asynkron.JsEngine.JsTypes;
 using Asynkron.JsEngine.Runtime;
 using Asynkron.JsEngine.Runtime.Prototypes;
 using static Asynkron.JsEngine.StdLib.ReflectHelper;
+using static Asynkron.JsEngine.StdLib.StandardLibrary;
 
 #endregion
 
@@ -14,16 +15,49 @@ namespace Asynkron.JsEngine.StdLib;
 public sealed partial class DisposableStackConstructor(IJsObjectLike prototype, RealmState realm)
     : JsConstructor(prototype, realm)
 {
+    private HostFunction? _constructor;
+
+    private HostFunction ConstructFallback =>
+        _constructor ?? throw new InvalidOperationException("DisposableStack constructor not initialized");
+
     protected override JsValue ConstructInstance(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement DisposableStack constructor
-        // Creates a new DisposableStack for explicit resource management
-        var obj = PrepareThisObject(JsValue.Undefined, false);
-        if (Prototype is not null && obj.Prototype is null)
+        if (thisValue.IsObject && thisValue.AsObject() is { IsConstructing: true })
         {
-            obj.SetPrototype(Prototype);
+            var target = _constructor ?? ConstructFallback;
+            return JsValue.FromObjectUnsafe(ConstructStack(target, target));
         }
-        obj.RealmState ??= Realm;
-        return new JsValue(obj);
+
+        throw ThrowTypeError("Constructor DisposableStack requires 'new'", realm: Realm);
+    }
+
+    protected override void ConfigureConstructor(HostFunction constructor)
+    {
+        _constructor = constructor;
+        Realm.DisposableStackConstructor ??= constructor;
+        Realm.DisposableStackPrototype ??= Prototype as JsObject;
+
+        constructor.SetInvokeWithContext((_, _, _, newTarget) =>
+        {
+            if (!newTarget.TryGetCallable(out var callable))
+            {
+                throw ThrowTypeError("Constructor DisposableStack requires 'new'", realm: Realm);
+            }
+
+            var target = _constructor ?? constructor;
+            return JsValue.FromObjectUnsafe(ConstructStack(callable, target));
+        });
+    }
+
+    private object ConstructStack(IJsCallable newTarget, IJsCallable targetCtor)
+    {
+        var proto = ResolveConstructPrototype(newTarget, targetCtor, Realm) ?? Prototype;
+        var instance = new JsDisposableStack();
+        if (proto is not null)
+        {
+            instance.SetPrototype(proto);
+        }
+
+        return instance;
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/DisposableStack/DisposableStackHelper.cs
+++ b/src/Asynkron.JsEngine/StdLib/DisposableStack/DisposableStackHelper.cs
@@ -1,0 +1,67 @@
+#region
+
+using Asynkron.JsEngine.Ast;
+using Asynkron.JsEngine.JsTypes;
+using Asynkron.JsEngine.Runtime;
+using static Asynkron.JsEngine.StdLib.StandardLibrary;
+
+#endregion
+
+namespace Asynkron.JsEngine.StdLib;
+
+internal static class DisposableStackHelper
+{
+    internal static IJsCallable? GetDisposeMethod(JsValue value, bool preferAsync, RealmState realm)
+    {
+        if (value.IsNull || value.IsUndefined)
+        {
+            return null;
+        }
+
+        if (!value.TryGetObject<IJsPropertyAccessor>(out var accessor) || accessor is null)
+        {
+            throw ThrowTypeError("DisposableStack value must be an object", realm: realm);
+        }
+
+        if (preferAsync)
+        {
+            if (TryGetCallable(accessor, Symbols.AsyncDispose, realm, out var asyncMethod))
+            {
+                return asyncMethod;
+            }
+
+            if (TryGetCallable(accessor, Symbols.Dispose, realm, out var syncMethod))
+            {
+                return syncMethod;
+            }
+        }
+        else
+        {
+            if (TryGetCallable(accessor, Symbols.Dispose, realm, out var disposeMethod))
+            {
+                return disposeMethod;
+            }
+        }
+
+        throw ThrowTypeError("Object is not disposable", realm: realm);
+    }
+
+    private static bool TryGetCallable(IJsPropertyAccessor accessor, JsSymbol symbol, RealmState realm,
+        out IJsCallable? callable)
+    {
+        var key = JsSymbol.PropertyKey(symbol);
+        if (!accessor.TryGetProperty(key, out var candidate) || candidate.IsUndefined || candidate.IsNull)
+        {
+            callable = null;
+            return false;
+        }
+
+        if (!candidate.TryGetObject<IJsCallable>(out var method) || method is null)
+        {
+            throw ThrowTypeError("Dispose method is not callable", realm: realm);
+        }
+
+        callable = method;
+        return true;
+    }
+}

--- a/src/Asynkron.JsEngine/StdLib/DisposableStack/DisposableStackPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/DisposableStack/DisposableStackPrototype.cs
@@ -3,65 +3,172 @@
 using System;
 using Asynkron.JsEngine.JsTypes;
 using Asynkron.JsEngine.Runtime.Prototypes;
+using static Asynkron.JsEngine.StdLib.StandardLibrary;
 
 #endregion
 
 namespace Asynkron.JsEngine.StdLib;
 
 [JsPrototype("DisposableStack", ToStringTag = "DisposableStack")]
+[JsSymbolAlias("dispose", "dispose")]
 public sealed partial class DisposableStackPrototype : JsPrototype
 {
     /* FLAKY */
     [JsHostMethod("use", Length = 1d)]
     public JsValue Use(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement DisposableStack.prototype.use
-        // Adds a disposable resource to the stack
-        throw new NotImplementedException("DisposableStack.prototype.use is not yet implemented");
+        var stack = RequireStack(thisValue);
+        EnsureNotDisposed(stack);
+
+        var value = args.GetArgument(0);
+        var disposeMethod = DisposableStackHelper.GetDisposeMethod(value, preferAsync: false, Realm);
+        if (disposeMethod is null)
+        {
+            return value;
+        }
+
+        stack.AddRecord(disposeMethod, value, Array.Empty<JsValue>());
+        return value;
     }
 
     /* FLAKY */
     [JsHostMethod("adopt", Length = 2d)]
     public JsValue Adopt(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement DisposableStack.prototype.adopt
-        // Adopts a value and a disposal callback
-        throw new NotImplementedException("DisposableStack.prototype.adopt is not yet implemented");
+        var stack = RequireStack(thisValue);
+        EnsureNotDisposed(stack);
+
+        var value = args.GetArgument(0);
+        var onDispose = args.GetArgument(1);
+        if (!onDispose.TryGetObject<IJsCallable>(out var callable) || callable is null)
+        {
+            throw ThrowTypeError("DisposableStack.prototype.adopt requires a callable disposer", realm: Realm);
+        }
+
+        stack.AddRecord(callable, JsValue.Undefined, [value]);
+        return value;
     }
 
     /* FLAKY */
     [JsHostMethod("defer", Length = 1d)]
     public JsValue Defer(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
-        // TODO: Implement DisposableStack.prototype.defer
-        // Defers execution of a callback until disposal
-        throw new NotImplementedException("DisposableStack.prototype.defer is not yet implemented");
+        var stack = RequireStack(thisValue);
+        EnsureNotDisposed(stack);
+
+        var onDispose = args.GetArgument(0);
+        if (!onDispose.TryGetObject<IJsCallable>(out var callable) || callable is null)
+        {
+            throw ThrowTypeError("DisposableStack.prototype.defer requires a callable disposer", realm: Realm);
+        }
+
+        stack.AddRecord(callable, JsValue.Undefined, Array.Empty<JsValue>());
+        return JsValue.Undefined;
     }
 
     /* FLAKY */
     [JsHostMethod("move", Length = 0d)]
     public JsValue Move(JsValue thisValue)
     {
-        // TODO: Implement DisposableStack.prototype.move
-        // Moves the stack to a new DisposableStack
-        throw new NotImplementedException("DisposableStack.prototype.move is not yet implemented");
+        var stack = RequireStack(thisValue);
+        EnsureNotDisposed(stack);
+
+        var result = new JsDisposableStack();
+        if (Realm.DisposableStackPrototype is not null)
+        {
+            result.SetPrototype(Realm.DisposableStackPrototype);
+        }
+
+        stack.TransferRecordsTo(result);
+        stack.MarkDisposed();
+        return result.AsJsValue;
     }
 
     /* FLAKY */
     [JsHostMethod("dispose", Length = 0d)]
     public JsValue Dispose(JsValue thisValue)
     {
-        // TODO: Implement DisposableStack.prototype.dispose
-        // Disposes all resources in the stack
-        throw new NotImplementedException("DisposableStack.prototype.dispose is not yet implemented");
+        var stack = RequireStack(thisValue);
+        if (stack.IsDisposed)
+        {
+            return JsValue.Undefined;
+        }
+
+        stack.MarkDisposed();
+        while (stack.TryPopRecord(out var record))
+        {
+            record.Invoke();
+        }
+
+        return JsValue.Undefined;
     }
 
     /* FLAKY */
     [JsHostGetter("disposed")]
     public JsValue Disposed(JsValue thisValue)
     {
-        // TODO: Implement DisposableStack.prototype.disposed getter
-        // Returns true if the stack has been disposed
-        throw new NotImplementedException("DisposableStack.prototype.disposed is not yet implemented");
+        var stack = RequireStack(thisValue);
+        return new JsValue(stack.IsDisposed);
+    }
+
+    protected override void ConfigurePrototype()
+    {
+        if (Prototype is JsObject { RealmState: null } jsObj)
+        {
+            jsObj.RealmState = Realm;
+        }
+
+        Realm.DisposableStackPrototype ??= Prototype as JsObject;
+        EnsureDisposedAccessorMetadata();
+    }
+
+    private JsDisposableStack RequireStack(JsValue thisValue)
+    {
+        if (!thisValue.TryGetObject<JsDisposableStack>(out var stack) || stack is null)
+        {
+            throw ThrowTypeError("DisposableStack method called on incompatible receiver", realm: Realm);
+        }
+
+        return stack;
+    }
+
+    private void EnsureNotDisposed(JsDisposableStackBase stack)
+    {
+        if (stack.IsDisposed)
+        {
+            throw ThrowReferenceError("DisposableStack has already been disposed", realm: Realm);
+        }
+    }
+
+    private void EnsureDisposedAccessorMetadata()
+    {
+        if (Prototype.GetOwnPropertyDescriptor("disposed") is not { Get: { } getter })
+        {
+            return;
+        }
+
+        if (getter is not IJsObjectLike getterObj)
+        {
+            return;
+        }
+
+        EnsureFunctionMetadata(getterObj, "length", 0d);
+        EnsureFunctionMetadata(getterObj, "name", "get disposed");
+    }
+
+    private static void EnsureFunctionMetadata(IJsObjectLike target, string propertyName, object value)
+    {
+        if (target.GetOwnPropertyDescriptor(propertyName) is not null)
+        {
+            return;
+        }
+
+        target.DefineProperty(propertyName, new PropertyDescriptor
+        {
+            Value = value,
+            Writable = false,
+            Enumerable = false,
+            Configurable = true
+        });
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/Reflect/ReflectHelper.cs
+++ b/src/Asynkron.JsEngine/StdLib/Reflect/ReflectHelper.cs
@@ -548,6 +548,8 @@ public static class ReflectHelper
             "WeakMap" => realmState.WeakMapPrototype,
             "WeakSet" => realmState.WeakSetPrototype,
             "String" => realmState.StringPrototype,
+            "DisposableStack" => realmState.DisposableStackPrototype,
+            "AsyncDisposableStack" => realmState.AsyncDisposableStackPrototype,
             _ => null
         };
 


### PR DESCRIPTION
Summary:\n- Implement AsyncDisposableStack and DisposableStack constructors/prototypes with internal Js* stack types.\n- Register new globals and realm prototypes, plus Reflect constructor prototype resolution.\n- Ensure disposed getter metadata matches spec (name/length).\n\nTests:\n- dotnet test tests/Asynkron.JsEngine.Tests.Test262 --filter AsyncDisposableStack