### PR TITLE
Optimize loop iteration by reusing environment for loops without closures

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -1275,6 +1275,10 @@ public static partial class TypedAstEvaluator
                                 //
                                 // Per-iteration envs are SIBLINGS (same parent), values are COPIED between them.
                                 // This ensures closures capture separate values per iteration.
+                                //
+                                // OPTIMIZATION: When AllowPooling is true (no closures capture the environment),
+                                // we REUSE the same environment across all iterations instead of rent/return
+                                // per iteration. This dramatically reduces overhead for hot loops.
 
                                 JsEnvironment loopScope;
                                 JsEnvironment? previousIterEnv = null;
@@ -1293,6 +1297,21 @@ public static partial class TypedAstEvaluator
                                      !pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty &&
                                      environment.Description == "scope" && environment.Enclosing != null);
 
+                                var allowPooling = pushEnvInstruction.AllowPooling;
+
+                                // FAST PATH: For loops without closures (AllowPooling=true), we can reuse
+                                // the same environment for ALL iterations. The slot values persist across
+                                // iterations and are updated by the loop body/increment as needed.
+                                // This eliminates the rent/copy/return overhead per iteration.
+                                if (isSubsequentIteration && allowPooling && !pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty)
+                                {
+                                    // Subsequent iteration with pooling enabled: just continue using the same env.
+                                    // No rent, no copy, no return needed. Values are already in slots.
+                                    IteratorStateRef.ResumedWithEnvironment = null;
+                                    _programCounter = pushEnvInstruction.Next;
+                                    continue;
+                                }
+
                                 if (isSubsequentIteration)
                                 {
                                     // In a previous iteration - parent is Enclosing, current is previous iter
@@ -1305,7 +1324,6 @@ public static partial class TypedAstEvaluator
                                     loopScope = environment;
                                 }
 
-                                var allowPooling = pushEnvInstruction.AllowPooling;
                                 // Use different description for loop scope (empty bindings) vs per-iteration scope
                                 // This allows the subsequent iteration heuristic to correctly distinguish them
                                 var description = pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty ? "loop-scope" : "scope";


### PR DESCRIPTION
## Summary

- Optimized loop iteration performance by reusing the same JsEnvironment across all iterations when `AllowPooling` is true (no closures capture the iteration environment)
- Added fast path in `PushEnvironmentInstruction` handler that skips rent/copy/return when subsequent iterations with pooling enabled
- Performance improvement: **~33% faster** for hot loops (16.5s → 11s for 1M iteration `for (let i...)` loop)

## Details

For loops without closures (`AllowPooling=true`), the optimization works by:

1. First iteration: Rent one environment from the pool (normal path)
2. Subsequent iterations: **REUSE** the same environment (skip rent/return entirely)
3. Loop exit: Return the environment to pool (only once at the end)

This eliminates ~1M rent/return cycles for a 1M iteration loop. The slot values persist across iterations and are updated by the loop body/increment as needed.

## Test plan

- [x] All 2920 unit tests pass
- [x] CPU profiler shows ~33% performance improvement
- [x] `JsEnvironmentPool.Rent` and `JsEnvironmentPool.Return` no longer appear in profiler hot path

🤖 Generated with [Claude Code](https://claude.com/claude-code)