### PR TITLE
Reuse iteration envs in IR loops

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -1306,6 +1306,17 @@ public static partial class TypedAstEvaluator
                                 }
 
                                 var allowPooling = pushEnvInstruction.AllowPooling;
+                                if (allowPooling &&
+                                    isSubsequentIteration &&
+                                    !pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty)
+                                {
+                                    // Optimization: reuse the existing iteration environment when no closures can
+                                    // capture it. This avoids rent/return churn inside hot loops.
+                                    IteratorStateRef.ResumedWithEnvironment = null;
+                                    _programCounter = pushEnvInstruction.Next;
+                                    continue;
+                                }
+
                                 // Use different description for loop scope (empty bindings) vs per-iteration scope
                                 // This allows the subsequent iteration heuristic to correctly distinguish them
                                 var description = pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty ? "loop-scope" : "scope";

--- a/src/Asynkron.JsEngine/Execution/Emitters/LoopEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/LoopEmitter.cs
@@ -66,7 +66,9 @@ internal static class LoopEmitter
         // environments are SIBLINGS (same parent), not nested.
         var continueTarget = postIterationEntry;
         int createEnvIndex = -1;
-        if (!plan.PerIterationBindings.IsDefaultOrEmpty && plan.Kind == LoopKind.For)
+        if (!plan.PerIterationBindings.IsDefaultOrEmpty &&
+            plan.Kind == LoopKind.For &&
+            !plan.AllowIterationEnvironmentPooling)
         {
             var slotMap = EmitContext.BuildSlotMap(plan.PerIterationBindings, plan.PerIterationSlotIndices);
 


### PR DESCRIPTION
- reuse per-iteration environments in ExecutionPlanRunner when pooling is allowed\n- skip emitting per-iteration PushEnvironment between body and increment for pooled for-loops\n- profiled with ./tools/profile forloop --cpu --calltree-depth 30 --calltree-width 8 --root RunSync