### PR TITLE
Optimize loop environment reuse by skipping rent/return on subsequent iterations

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -1276,9 +1276,6 @@ public static partial class TypedAstEvaluator
                                 // Per-iteration envs are SIBLINGS (same parent), values are COPIED between them.
                                 // This ensures closures capture separate values per iteration.
 
-                                JsEnvironment loopScope;
-                                JsEnvironment? previousIterEnv = null;
-
                                 // Detect if we're in a subsequent iteration:
                                 // 1. If ScopeId is valid, use ScopeId matching
                                 // 2. If ScopeId is -1 (scope analysis not run), check if:
@@ -1292,6 +1289,28 @@ public static partial class TypedAstEvaluator
                                     (pushEnvInstruction.ScopeId < 0 &&
                                      !pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty &&
                                      environment.Description == "scope" && environment.Enclosing != null);
+
+                                // FAST PATH: For subsequent iterations with pooling enabled (no closures),
+                                // reuse the same environment in-place. The increment (i++) already updated
+                                // the binding values, so no copy or rent/return is needed.
+                                // This eliminates all pool overhead for simple loops without closures.
+                                //
+                                // Why this is safe:
+                                // 1. AllowPooling = true means no closures capture iteration variables
+                                // 2. Without closures, we don't need separate environments per iteration
+                                // 3. The loop update (i++) modifies the binding in-place
+                                // 4. The "new" iteration environment would have the same values anyway
+                                if (isSubsequentIteration &&
+                                    pushEnvInstruction.AllowPooling &&
+                                    !pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty)
+                                {
+                                    // Just continue using the same environment - bindings already have correct values
+                                    _programCounter = pushEnvInstruction.Next;
+                                    continue;
+                                }
+
+                                JsEnvironment loopScope;
+                                JsEnvironment? previousIterEnv = null;
 
                                 if (isSubsequentIteration)
                                 {


### PR DESCRIPTION
## Summary

For loops without closures (`AllowPooling=true`), skip the JsEnvironmentPool.Rent/Return cycle on subsequent iterations by reusing the same environment in-place.

## Key Changes

- Added fast path in `PushEnvironmentInstruction` handler that detects subsequent iterations with pooling enabled
- When conditions are met, skip to `instruction.Next` without rent/copy/return
- The loop increment already updates the binding values, so no copy is needed

## Why This is Safe

1. `AllowPooling = true` means no closures capture iteration variables
2. Without closures, we don't need separate environments per iteration  
3. The loop update (i++) modifies the binding in-place
4. The "new" iteration environment would have the same values anyway

## Performance Results

- Baseline: 614ms per iteration
- After: 583ms per iteration (~5% improvement)
- `JsEnvironmentPool.Rent` and `JsEnvironmentPool.Return` no longer appear in profiler hot path

## Test Plan

- [x] All 2920 unit tests pass
- [x] ForLoop-related tests pass (52 tests)
- [x] Profiler verified optimization is working

🤖 Generated with [Claude Code](https://claude.com/claude-code)