### PR TITLE
Skip with-binding check in ResolveIdentifierDirect for identifier caching optimization

### DIFF
--- a/src/Asynkron.JsEngine/Ast/AssignmentReferenceResolver.cs
+++ b/src/Asynkron.JsEngine/Ast/AssignmentReferenceResolver.cs
@@ -23,7 +23,8 @@ internal static class AssignmentReferenceResolver
         var isStrictTarget = context.CurrentScope.IsStrict &&
                              (ReferenceEquals(name, Symbol.Eval) || ReferenceEquals(name, Symbol.Arguments));
 
-        if (environment.TryResolveWithBinding(name, context, out var withBinding))
+        // Fast path: skip with-binding check when AllowIdentifierCache is true (no with/eval in scope)
+        if (!context.AllowIdentifierCache && environment.TryResolveWithBinding(name, context, out var withBinding))
         {
             return AssignmentReference.ForWithBinding(
                 withBinding,


### PR DESCRIPTION
## Summary

- Added `AllowIdentifierCache` check to `AssignmentReferenceResolver.ResolveIdentifierDirect` to skip the expensive `TryResolveWithBinding` call when there are no `with` statements or direct `eval` in scope
- This aligns with the existing optimization in `JsEnvironment.TryGetIdentifierJsValue` which already has this fast path check

## Performance Impact

Forloop benchmark improvement:
- `ResolveIdentifierDirect`: 607ms → 285ms (**53% reduction**)
- `TryResolveWithBinding`: 273ms → ~0ms (**completely eliminated from hot path**)

## Test plan

- [x] All 2920 unit tests pass
- [x] CPU profiler verifies TryResolveWithBinding is no longer in hot path
- [x] Manual verification with forloop benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)