### PR TITLE
Optimize ScopeId lookup and fix compound assignment fallthrough

### DIFF
--- a/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
@@ -447,8 +447,10 @@ public static partial class TypedAstEvaluator
                                            expression.SlotIndex,
                                            expression.ScopeId);
 
-                if (expression.IsCompoundAssignment &&
-                    TryEvaluateCompoundAssignmentSlotBased(
+                if (expression.IsCompoundAssignment)
+                {
+                    // Try slot-based compound assignment (fastest path)
+                    if (TryEvaluateCompoundAssignmentSlotBased(
                         expression,
                         expression.Value,
                         targetIdentifier,
@@ -456,30 +458,34 @@ public static partial class TypedAstEvaluator
                         context,
                         out var compoundJsValue,
                         out var shouldAssignCompound))
-                {
-                    if (context.ShouldStopEvaluation)
                     {
+                        if (context.ShouldStopEvaluation)
+                        {
+                            return compoundJsValue;
+                        }
+
+                        if (shouldAssignCompound)
+                        {
+                            environment.TryWriteIdentifierWithSlot(targetIdentifier, compoundJsValue, context);
+                        }
+
                         return compoundJsValue;
                     }
-
-                    if (shouldAssignCompound)
+                    // If slot-based compound fails, fall through to other compound handlers below
+                }
+                else
+                {
+                    // Simple slot-based assignment (not compound)
+                    var slotValueJs =
+                        EvaluateAssignmentRhsWithNameHintJsValue(expression, expression.Value, environment, context);
+                    if (context.ShouldStopEvaluation)
                     {
-                        environment.TryWriteIdentifierWithSlot(targetIdentifier, compoundJsValue, context);
+                        return slotValueJs;
                     }
 
-                    return compoundJsValue;
-                }
-
-                // Simple slot-based assignment (not compound)
-                var slotValueJs =
-                    EvaluateAssignmentRhsWithNameHintJsValue(expression, expression.Value, environment, context);
-                if (context.ShouldStopEvaluation)
-                {
+                    environment.TryWriteIdentifierWithSlot(targetIdentifier, slotValueJs, context);
                     return slotValueJs;
                 }
-
-                environment.TryWriteIdentifierWithSlot(targetIdentifier, slotValueJs, context);
-                return slotValueJs;
             }
 
             // Fast path for compound assignments on simple identifiers

--- a/src/Asynkron.JsEngine/JsEnvironment.cs
+++ b/src/Asynkron.JsEngine/JsEnvironment.cs
@@ -1221,7 +1221,9 @@ public sealed class JsEnvironment : IRentable
 
         if (scopeId >= 0 && slotIndex >= 0)
         {
-            var targetEnv = FindByScopeId(scopeId);
+            // Fast path: if current environment matches scopeId, use it directly
+            // This avoids the FindByScopeId loop traversal in the common case
+            var targetEnv = (ScopeId == scopeId) ? this : FindByScopeId(scopeId);
             var slots = targetEnv?._slots;
             if (targetEnv is not null && slots is not null && slotIndex < slots.Length)
             {
@@ -1299,7 +1301,9 @@ public sealed class JsEnvironment : IRentable
 
         if (scopeId >= 0 && slotIndex >= 0)
         {
-            var targetEnv = FindByScopeId(scopeId);
+            // Fast path: if current environment matches scopeId, use it directly
+            // This avoids the FindByScopeId loop traversal in the common case
+            var targetEnv = (ScopeId == scopeId) ? this : FindByScopeId(scopeId);
             var slots = targetEnv?._slots;
             if (targetEnv is not null && slots is not null && slotIndex < slots.Length)
             {
@@ -3362,7 +3366,9 @@ public sealed class JsEnvironment : IRentable
     {
         if (scopeId >= 0 && slotIndex >= 0)
         {
-            targetEnv = FindByScopeId(scopeId);
+            // Fast path: if current environment matches scopeId, use it directly
+            // This avoids the FindByScopeId loop traversal in the common case
+            targetEnv = (ScopeId == scopeId) ? this : FindByScopeId(scopeId);
             if (targetEnv?._slots is not null && slotIndex < targetEnv._slots.Length)
             {
                 return true;


### PR DESCRIPTION
## Summary

- Add fast path for ScopeId matching in `TryReadIdentifierWithSlot`, `TryWriteIdentifierWithSlot`, and `TryResolveSlot`: check if current environment's `ScopeId` matches before walking the scope chain via `FindByScopeId`. This avoids unnecessary loop traversal when the variable is in the current scope.

- Fix bug in `EvaluateAssignment` where compound assignments would incorrectly fall through to the simple assignment handler if `TryEvaluateCompoundAssignmentSlotBased` returned false. Now compound assignments properly continue to other compound handlers.

## Test plan

- [x] All 2920 unit tests pass (17 skipped as expected)
- [x] Profiler verification shows similar performance to baseline (~9.3s for forloop benchmark)
- [x] Build succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)