### PR TITLE
Cache slot targets for assignment resolution

### DIFF
--- a/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
@@ -256,6 +256,119 @@ public static partial class TypedAstEvaluator
     }
 
     /// <summary>
+    /// Slot-based compound assignment evaluation using cached slot targets.
+    /// Avoids resolving the identifier on every iteration.
+    /// </summary>
+    private static bool TryEvaluateCompoundAssignmentCachedSlot(
+        AssignmentExpression assignment,
+        ExpressionNode candidate,
+        EvaluationContext.CachedSlotTarget cached,
+        JsEnvironment environment,
+        EvaluationContext context,
+        out JsValue value,
+        out bool shouldAssign)
+    {
+        if (candidate is not BinaryExpression binary)
+        {
+            value = JsValue.Undefined;
+            shouldAssign = false;
+            return false;
+        }
+
+        if (!cached.Environment.TryReadSlotValue(cached.Name, cached.SlotIndex, context, out var leftJs))
+        {
+            value = JsValue.Undefined;
+            shouldAssign = false;
+            return false;
+        }
+
+        if (context.ShouldStopEvaluation)
+        {
+            value = leftJs;
+            shouldAssign = false;
+            return true;
+        }
+
+        switch (binary.Operator)
+        {
+            case BinaryOperator.LogicalAnd:
+                if (!leftJs.IsTruthy)
+                {
+                    value = leftJs;
+                    shouldAssign = false;
+                    return true;
+                }
+
+                value = EvaluateAssignmentRhsWithNameHintJsValue(assignment, binary.Right, environment, context);
+                shouldAssign = !context.ShouldStopEvaluation;
+                return true;
+            case BinaryOperator.LogicalOr:
+                if (leftJs.IsTruthy)
+                {
+                    value = leftJs;
+                    shouldAssign = false;
+                    return true;
+                }
+
+                value = EvaluateAssignmentRhsWithNameHintJsValue(assignment, binary.Right, environment, context);
+                shouldAssign = !context.ShouldStopEvaluation;
+                return true;
+            case BinaryOperator.NullishCoalescing:
+                if (!leftJs.IsNullish)
+                {
+                    value = leftJs;
+                    shouldAssign = false;
+                    return true;
+                }
+
+                value = EvaluateAssignmentRhsWithNameHintJsValue(assignment, binary.Right, environment, context);
+                shouldAssign = !context.ShouldStopEvaluation;
+                return true;
+        }
+
+        var rightJs = EvaluateAssignmentRhsWithNameHintJsValue(assignment, binary.Right, environment, context);
+        if (context.ShouldStopEvaluation)
+        {
+            value = JsValue.Undefined;
+            shouldAssign = false;
+            return true;
+        }
+
+        value = binary.Operator switch
+        {
+            BinaryOperator.Add => AddValue(leftJs, rightJs, context),
+            BinaryOperator.Subtract => SubtractValue(leftJs, rightJs, context),
+            BinaryOperator.Multiply => MultiplyValue(leftJs, rightJs, context),
+            BinaryOperator.Divide => DivideValue(leftJs, rightJs, context),
+            BinaryOperator.Modulo => ModuloValue(leftJs, rightJs, context),
+            BinaryOperator.Power => PowerValue(leftJs, rightJs, context),
+            BinaryOperator.Equal => LooseEqualsValue(leftJs, rightJs, context) ? JsValue.True : JsValue.False,
+            BinaryOperator.NotEqual => !LooseEqualsValue(leftJs, rightJs, context) ? JsValue.True : JsValue.False,
+            BinaryOperator.StrictEqual => StrictEqualsValue(leftJs, rightJs) ? JsValue.True : JsValue.False,
+            BinaryOperator.StrictNotEqual => !StrictEqualsValue(leftJs, rightJs) ? JsValue.True : JsValue.False,
+            BinaryOperator.LessThan => LessThanValue(leftJs, rightJs, context),
+            BinaryOperator.LessThanOrEqual => LessThanOrEqualValue(leftJs, rightJs, context),
+            BinaryOperator.GreaterThan => GreaterThanValue(leftJs, rightJs, context),
+            BinaryOperator.GreaterThanOrEqual => GreaterThanOrEqualValue(leftJs, rightJs, context),
+            BinaryOperator.BitwiseAnd => BitwiseAndValue(leftJs, rightJs, context),
+            BinaryOperator.BitwiseOr => BitwiseOrValue(leftJs, rightJs, context),
+            BinaryOperator.BitwiseXor => BitwiseXorValue(leftJs, rightJs, context),
+            BinaryOperator.LeftShift => LeftShiftValue(leftJs, rightJs, context),
+            BinaryOperator.RightShift => RightShiftValue(leftJs, rightJs, context),
+            BinaryOperator.UnsignedRightShift => UnsignedRightShiftValue(leftJs, rightJs, context),
+            BinaryOperator.In => InOperatorJsValue(leftJs, rightJs, context) ? JsValue.True : JsValue.False,
+            BinaryOperator.InstanceOf => InstanceofOperatorJsValue(leftJs, rightJs, context)
+                ? JsValue.True
+                : JsValue.False,
+            _ => throw new NotSupportedException(
+                $"Compound assignment operator '{binary.Operator}' is not supported yet.")
+        };
+        shouldAssign = true;
+
+        return true;
+    }
+
+    /// <summary>
     /// JsValue version of compound assignment evaluation that avoids boxing for numeric operations.
     /// </summary>
     private static bool TryEvaluateCompoundAssignmentJsValue(
@@ -605,6 +718,48 @@ public static partial class TypedAstEvaluator
                     environment.SetSlot(runtimeSlotIndex, rhsValue);
                     return rhsValue;
                 }
+            }
+
+            if (context.TryResolveAssignmentSlot(expression, environment, out var cachedSlot))
+            {
+                if (expression.IsCompoundAssignment &&
+                    TryEvaluateCompoundAssignmentCachedSlot(expression, expression.Value, cachedSlot, environment, context,
+                        out var cachedCompoundValue,
+                        out var cachedShouldAssign))
+                {
+                    if (context.ShouldStopEvaluation)
+                    {
+                        return cachedCompoundValue;
+                    }
+
+                    if (cachedShouldAssign)
+                    {
+                        if (!cachedSlot.Environment.TryWriteSlotValue(
+                                cachedSlot.Name,
+                                cachedSlot.SlotIndex,
+                                cachedCompoundValue,
+                                context))
+                        {
+                            environment.SetIdentifierJsValue(cachedSlot.Name, cachedCompoundValue, context);
+                        }
+                    }
+
+                    return cachedCompoundValue;
+                }
+
+                var cachedValue =
+                    EvaluateAssignmentRhsWithNameHintJsValue(expression, expression.Value, environment, context);
+                if (context.ShouldStopEvaluation)
+                {
+                    return cachedValue;
+                }
+
+                if (!cachedSlot.Environment.TryWriteSlotValue(cachedSlot.Name, cachedSlot.SlotIndex, cachedValue, context))
+                {
+                    environment.SetIdentifierJsValue(cachedSlot.Name, cachedValue, context);
+                }
+
+                return cachedValue;
             }
 
             // Fallback to the AssignmentReference path for other cases

--- a/src/Asynkron.JsEngine/EvaluationContext.cs
+++ b/src/Asynkron.JsEngine/EvaluationContext.cs
@@ -39,6 +39,7 @@ public sealed class EvaluationContext(
 
     private readonly Stack<ScopeFrame> _scopeStack = new();
     private int _classFieldInitializerDepth;
+    private Dictionary<AssignmentExpression, CachedSlotTarget>? _assignmentSlotCache;
 
     // Fast path for returns - avoids allocating ReturnCompletionSignal
     private JsValue _returnValue;
@@ -221,6 +222,46 @@ public sealed class EvaluationContext(
         return AllowIdentifierCache
             ? environment.GetIdentifierJsValueDirect(name, this)
             : environment.GetIdentifierJsValueWithScope(name, this);
+    }
+
+    internal bool TryResolveAssignmentSlot(AssignmentExpression expression, JsEnvironment environment,
+        out CachedSlotTarget cached)
+    {
+        if (_assignmentSlotCache is not null && _assignmentSlotCache.TryGetValue(expression, out cached))
+        {
+            return true;
+        }
+
+        cached = default;
+
+        if (!AllowIdentifierCache)
+        {
+            return false;
+        }
+
+        var name = expression.Target;
+        if (CurrentScope.IsStrict &&
+            (ReferenceEquals(name, Symbol.Eval) || ReferenceEquals(name, Symbol.Arguments)))
+        {
+            return false;
+        }
+
+        if (!environment.TryFindBindingJsValue(name, allowUninitialized: true, out var bindingEnvironment, out _))
+        {
+            return false;
+        }
+
+        if (!bindingEnvironment.HasSlots || !bindingEnvironment.TryGetSlotIndex(name, out var slotIndex))
+        {
+            return false;
+        }
+
+        cached = new CachedSlotTarget(new JsVariable(bindingEnvironment, slotIndex), name);
+
+        _assignmentSlotCache ??= new Dictionary<AssignmentExpression, CachedSlotTarget>(
+            ReferenceEqualityComparer<AssignmentExpression>.Instance);
+        _assignmentSlotCache[expression] = cached;
+        return true;
     }
 
     public ImmutableArray<PrivateNameScope> CapturePrivateNameScopes()
@@ -478,6 +519,7 @@ public sealed class EvaluationContext(
         _scopeStack.Clear();
         _pendingClassFieldInitializers.Clear();
         _functionNameHints.Clear();
+        _assignmentSlotCache?.Clear();
         _classFieldInitializerDepth = 0;
         AllowIdentifierCache = false;
         IsStrictSource = false;
@@ -515,6 +557,20 @@ public sealed class EvaluationContext(
         {
             _pendingClassFieldInitializers.Pop();
         }
+    }
+
+    internal readonly struct CachedSlotTarget
+    {
+        public CachedSlotTarget(JsVariable variable, Symbol name)
+        {
+            Variable = variable;
+            Name = name;
+        }
+
+        public JsVariable Variable { get; }
+        public Symbol Name { get; }
+        public JsEnvironment Environment => Variable.Environment;
+        public int SlotIndex => Variable.SlotIndex;
     }
 
     /// <summary>

--- a/src/Asynkron.JsEngine/JsEnvironment.cs
+++ b/src/Asynkron.JsEngine/JsEnvironment.cs
@@ -1376,6 +1376,64 @@ public sealed class JsEnvironment : IRentable
         return TryWriteIdentifierWithSlot(identifier.Name, identifier.ScopeId, identifier.SlotIndex, value, context);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryReadSlotValue(Symbol name, int slotIndex, EvaluationContext context, out JsValue value)
+    {
+        var slots = _slots;
+        if (slots is null || (uint)slotIndex >= (uint)slots.Length)
+        {
+            value = default;
+            return false;
+        }
+
+        var slotValue = slots[slotIndex];
+        if (slotValue.IsUninitialized)
+        {
+            var errorValue = StandardLibrary.CreateReferenceError(
+                $"Cannot access '{name.Name}' before initialization",
+                context,
+                context.RealmState);
+            value = errorValue;
+            context.SetThrow(value);
+            return true;
+        }
+
+        value = slotValue;
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryWriteSlotValue(Symbol name, int slotIndex, JsValue value, EvaluationContext context)
+    {
+        var slots = _slots;
+        if (slots is null || (uint)slotIndex >= (uint)slots.Length)
+        {
+            return false;
+        }
+
+        if (_values is not null)
+        {
+            ref var binding = ref _values.GetValueRefOrNullRef(name);
+            if (!Unsafe.IsNullRef(ref binding))
+            {
+                WriteResolvedBindingJsValue(this, ref binding, name, value, context.CurrentScope.IsStrict);
+                slots[slotIndex] = value;
+                return true;
+            }
+        }
+
+        if (slots[slotIndex].IsUninitialized)
+        {
+            throw new ThrowSignal(StandardLibrary.CreateReferenceError(
+                $"Cannot access '{name.Name}' before initialization",
+                context,
+                context.RealmState));
+        }
+
+        slots[slotIndex] = value;
+        return true;
+    }
+
     /// <summary>
     /// Direct identifier assignment that avoids creating AssignmentReference structs.
     /// This is the fast path for simple identifier assignments in loops.


### PR DESCRIPTION
## Summary
- cache assignment slot targets per evaluation context using JsVariable
- add slot read/write helpers for cached slot access with TDZ handling
- use cached slot path in AssignmentExpression before ResolveIdentifierDirect

## Testing
- dotnet test tests/Asynkron.JsEngine.Tests