### PR TITLE
Cache slot variables for assignments

### DIFF
--- a/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
@@ -607,6 +607,93 @@ public static partial class TypedAstEvaluator
                 }
             }
 
+            // Cached slot resolution: resolve once, then reuse slot location for repeated assignments.
+            // This avoids ResolveIdentifierDirect in hot loops when identifier caching is allowed.
+            var isStrictRestrictedName = context.CurrentScope.IsStrict &&
+                                         (ReferenceEquals(expression.Target, Symbol.Eval) ||
+                                          ReferenceEquals(expression.Target, Symbol.Arguments));
+            if (!isStrictRestrictedName &&
+                context.AllowIdentifierCache &&
+                environment.TryGetCachedSlotVariable(expression.Target, context, out var cachedSlot))
+            {
+                if (expression.IsCompoundAssignment && expression.Value is BinaryExpression cachedBinary)
+                {
+                    if (environment.TryReadCachedSlotValue(expression.Target, cachedSlot, context,
+                            out var currentValue))
+                    {
+                        switch (cachedBinary.Operator)
+                        {
+                            case BinaryOperator.LogicalAnd:
+                                if (!currentValue.IsTruthy)
+                                {
+                                    return currentValue;
+                                }
+                                break;
+                            case BinaryOperator.LogicalOr:
+                                if (currentValue.IsTruthy)
+                                {
+                                    return currentValue;
+                                }
+                                break;
+                            case BinaryOperator.NullishCoalescing:
+                                if (!currentValue.IsNullish)
+                                {
+                                    return currentValue;
+                                }
+                                break;
+                        }
+
+                        var rhsValue = EvaluateAssignmentRhsWithNameHintJsValue(expression,
+                            cachedBinary.Right, environment, context);
+                        if (context.ShouldStopEvaluation)
+                        {
+                            return rhsValue;
+                        }
+
+                        var compoundResult = cachedBinary.Operator switch
+                        {
+                            BinaryOperator.Add => AddValue(currentValue, rhsValue, context),
+                            BinaryOperator.Subtract => SubtractValue(currentValue, rhsValue, context),
+                            BinaryOperator.Multiply => MultiplyValue(currentValue, rhsValue, context),
+                            BinaryOperator.Divide => DivideValue(currentValue, rhsValue, context),
+                            BinaryOperator.Modulo => ModuloValue(currentValue, rhsValue, context),
+                            BinaryOperator.Power => PowerValue(currentValue, rhsValue, context),
+                            BinaryOperator.BitwiseAnd => BitwiseAndValue(currentValue, rhsValue, context),
+                            BinaryOperator.BitwiseOr => BitwiseOrValue(currentValue, rhsValue, context),
+                            BinaryOperator.BitwiseXor => BitwiseXorValue(currentValue, rhsValue, context),
+                            BinaryOperator.LeftShift => LeftShiftValue(currentValue, rhsValue, context),
+                            BinaryOperator.RightShift => RightShiftValue(currentValue, rhsValue, context),
+                            BinaryOperator.UnsignedRightShift => UnsignedRightShiftValue(currentValue, rhsValue, context),
+                            BinaryOperator.LogicalAnd or BinaryOperator.LogicalOr or BinaryOperator.NullishCoalescing => rhsValue,
+                            _ => throw new NotSupportedException(
+                                $"Compound assignment operator '{cachedBinary.Operator}' is not supported.")
+                        };
+
+                        if (!environment.TryWriteCachedSlotValue(expression.Target, cachedSlot, compoundResult, context))
+                        {
+                            environment.SetIdentifierJsValue(expression.Target, compoundResult, context);
+                        }
+
+                        return compoundResult;
+                    }
+                }
+                else if (!expression.IsCompoundAssignment)
+                {
+                    var rhsValue = EvaluateAssignmentRhsWithNameHintJsValue(expression, expression.Value, environment, context);
+                    if (context.ShouldStopEvaluation)
+                    {
+                        return rhsValue;
+                    }
+
+                    if (!environment.TryWriteCachedSlotValue(expression.Target, cachedSlot, rhsValue, context))
+                    {
+                        environment.SetIdentifierJsValue(expression.Target, rhsValue, context);
+                    }
+
+                    return rhsValue;
+                }
+            }
+
             // Fallback to the AssignmentReference path for other cases
             var reference = AssignmentReferenceResolver.ResolveIdentifierDirect(
                 expression.Target, environment, context);

--- a/src/Asynkron.JsEngine/Ast/AssignmentReferenceResolver.cs
+++ b/src/Asynkron.JsEngine/Ast/AssignmentReferenceResolver.cs
@@ -23,7 +23,7 @@ internal static class AssignmentReferenceResolver
         var isStrictTarget = context.CurrentScope.IsStrict &&
                              (ReferenceEquals(name, Symbol.Eval) || ReferenceEquals(name, Symbol.Arguments));
 
-        if (environment.TryResolveWithBinding(name, context, out var withBinding))
+        if (!context.AllowIdentifierCache && environment.TryResolveWithBinding(name, context, out var withBinding))
         {
             return AssignmentReference.ForWithBinding(
                 withBinding,

--- a/src/Asynkron.JsEngine/JsEnvironment.cs
+++ b/src/Asynkron.JsEngine/JsEnvironment.cs
@@ -34,6 +34,7 @@ public sealed class JsEnvironment : IRentable
     private string? _description;
     internal bool _hasThisValue;
     private Dictionary<Symbol, ResolvedIdentifierBinding>? _identifierBindingCache;
+    private Dictionary<Symbol, JsVariable>? _identifierSlotCache;
     private bool _inheritStrictness;
     private bool _isStrictEffective;
 
@@ -208,6 +209,7 @@ public sealed class JsEnvironment : IRentable
         _description = description;
         _values?.Clear();
         _identifierBindingCache?.Clear();
+        _identifierSlotCache?.Clear();
         _bindingObservers?.Clear();
         _bodyLexicalNames?.Clear();
         _simpleCatchParameters?.Clear();
@@ -1459,6 +1461,97 @@ public sealed class JsEnvironment : IRentable
         _identifierBindingCache ??=
             new Dictionary<Symbol, ResolvedIdentifierBinding>(ReferenceEqualityComparer<Symbol>.Instance);
         _identifierBindingCache[name] = binding;
+    }
+
+    /// <summary>
+    /// Tries to resolve a symbol to a cached slot-based variable for fast repeated writes.
+    /// Only used when AllowIdentifierCache is true (no with/eval in scope).
+    /// </summary>
+    internal bool TryGetCachedSlotVariable(Symbol name, EvaluationContext context, out JsVariable variable)
+    {
+        if (!context.AllowIdentifierCache)
+        {
+            variable = default;
+            return false;
+        }
+
+        if (_identifierSlotCache is not null && _identifierSlotCache.TryGetValue(name, out variable))
+        {
+            return variable.IsValid;
+        }
+
+        if (!TryLocateBinding(name, out var bindingEnvironment, out _))
+        {
+            variable = default;
+            return false;
+        }
+
+        if (!bindingEnvironment.HasSlots ||
+            !bindingEnvironment.TryGetSlotIndex(name, out var slotIndex))
+        {
+            variable = default;
+            return false;
+        }
+
+        variable = new JsVariable(bindingEnvironment, slotIndex);
+        _identifierSlotCache ??=
+            new Dictionary<Symbol, JsVariable>(ReferenceEqualityComparer<Symbol>.Instance);
+        _identifierSlotCache[name] = variable;
+        return true;
+    }
+
+    /// <summary>
+    /// Reads a cached slot-based identifier value using the resolved slot environment.
+    /// </summary>
+    internal bool TryReadCachedSlotValue(Symbol name, JsVariable slotVariable, EvaluationContext context,
+        out JsValue value)
+    {
+        var targetEnv = slotVariable.Environment;
+        if (targetEnv._values is null)
+        {
+            value = default;
+            return false;
+        }
+
+        ref var binding = ref targetEnv._values.GetValueRefOrNullRef(name);
+        if (Unsafe.IsNullRef(ref binding))
+        {
+            value = default;
+            return false;
+        }
+
+        value = ReadResolvedBindingJsValue(targetEnv, ref binding, name, context);
+        return true;
+    }
+
+    /// <summary>
+    /// Writes a cached slot-based identifier value using the resolved slot environment.
+    /// </summary>
+    internal bool TryWriteCachedSlotValue(Symbol name, JsVariable slotVariable, JsValue value, EvaluationContext context)
+    {
+        var targetEnv = slotVariable.Environment;
+        if (targetEnv._values is null)
+        {
+            return false;
+        }
+
+        ref var binding = ref targetEnv._values.GetValueRefOrNullRef(name);
+        if (Unsafe.IsNullRef(ref binding))
+        {
+            return false;
+        }
+
+        targetEnv.WriteResolvedBindingJsValue(targetEnv, ref binding, name, value, context.CurrentScope.IsStrict);
+
+        var slots = targetEnv._slots;
+        if (slots is not null &&
+            slotVariable.SlotIndex >= 0 &&
+            slotVariable.SlotIndex < slots.Length)
+        {
+            slots[slotVariable.SlotIndex] = value;
+        }
+
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
Summary:\n- add cached slot-variable resolution in JsEnvironment and use it in assignment evaluation to avoid repeated identifier resolution in hot loops\n- skip with-binding lookup in ResolveIdentifierDirect when identifier caching is enabled\n- tests: dotnet test tests/Asynkron.JsEngine.Tests