### PR TITLE
Cache slot variables for fast assignment

### DIFF
--- a/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
@@ -607,6 +607,145 @@ public static partial class TypedAstEvaluator
                 }
             }
 
+            if (context.AllowIdentifierCache &&
+                environment.TryResolveSlotVariable(expression.Target, out var cachedVariable))
+            {
+                if (expression.IsCompoundAssignment && expression.Value is BinaryExpression cachedBinary &&
+                    cachedVariable.Environment.TryReadSlotValue(expression.Target, cachedVariable.SlotIndex, context,
+                        out var leftJs))
+                {
+                    if (context.ShouldStopEvaluation)
+                    {
+                        return leftJs;
+                    }
+
+                    switch (cachedBinary.Operator)
+                    {
+                        case BinaryOperator.LogicalAnd:
+                            if (!leftJs.IsTruthy)
+                            {
+                                return leftJs;
+                            }
+
+                            {
+                                var rhsValue = EvaluateAssignmentRhsWithNameHintJsValue(
+                                    expression,
+                                    cachedBinary.Right,
+                                    environment,
+                                    context);
+                                if (context.ShouldStopEvaluation)
+                                {
+                                    return rhsValue;
+                                }
+
+                                cachedVariable.Environment.WriteSlotValue(expression.Target, cachedVariable.SlotIndex,
+                                    rhsValue, context);
+                                return rhsValue;
+                            }
+                        case BinaryOperator.LogicalOr:
+                            if (leftJs.IsTruthy)
+                            {
+                                return leftJs;
+                            }
+
+                            {
+                                var rhsValue = EvaluateAssignmentRhsWithNameHintJsValue(
+                                    expression,
+                                    cachedBinary.Right,
+                                    environment,
+                                    context);
+                                if (context.ShouldStopEvaluation)
+                                {
+                                    return rhsValue;
+                                }
+
+                                cachedVariable.Environment.WriteSlotValue(expression.Target, cachedVariable.SlotIndex,
+                                    rhsValue, context);
+                                return rhsValue;
+                            }
+                        case BinaryOperator.NullishCoalescing:
+                            if (!leftJs.IsNullish)
+                            {
+                                return leftJs;
+                            }
+
+                            {
+                                var rhsValue = EvaluateAssignmentRhsWithNameHintJsValue(
+                                    expression,
+                                    cachedBinary.Right,
+                                    environment,
+                                    context);
+                                if (context.ShouldStopEvaluation)
+                                {
+                                    return rhsValue;
+                                }
+
+                                cachedVariable.Environment.WriteSlotValue(expression.Target, cachedVariable.SlotIndex,
+                                    rhsValue, context);
+                                return rhsValue;
+                            }
+                    }
+
+                    var rightJs = EvaluateAssignmentRhsWithNameHintJsValue(
+                        expression,
+                        cachedBinary.Right,
+                        environment,
+                        context);
+                    if (context.ShouldStopEvaluation)
+                    {
+                        return rightJs;
+                    }
+
+                    var compoundResult = cachedBinary.Operator switch
+                    {
+                        BinaryOperator.Add => AddValue(leftJs, rightJs, context),
+                        BinaryOperator.Subtract => SubtractValue(leftJs, rightJs, context),
+                        BinaryOperator.Multiply => MultiplyValue(leftJs, rightJs, context),
+                        BinaryOperator.Divide => DivideValue(leftJs, rightJs, context),
+                        BinaryOperator.Modulo => ModuloValue(leftJs, rightJs, context),
+                        BinaryOperator.Power => PowerValue(leftJs, rightJs, context),
+                        BinaryOperator.Equal => LooseEqualsValue(leftJs, rightJs, context) ? JsValue.True : JsValue.False,
+                        BinaryOperator.NotEqual => !LooseEqualsValue(leftJs, rightJs, context) ? JsValue.True : JsValue.False,
+                        BinaryOperator.StrictEqual => StrictEqualsValue(leftJs, rightJs) ? JsValue.True : JsValue.False,
+                        BinaryOperator.StrictNotEqual => !StrictEqualsValue(leftJs, rightJs) ? JsValue.True : JsValue.False,
+                        BinaryOperator.LessThan => LessThanValue(leftJs, rightJs, context),
+                        BinaryOperator.LessThanOrEqual => LessThanOrEqualValue(leftJs, rightJs, context),
+                        BinaryOperator.GreaterThan => GreaterThanValue(leftJs, rightJs, context),
+                        BinaryOperator.GreaterThanOrEqual => GreaterThanOrEqualValue(leftJs, rightJs, context),
+                        BinaryOperator.BitwiseAnd => BitwiseAndValue(leftJs, rightJs, context),
+                        BinaryOperator.BitwiseOr => BitwiseOrValue(leftJs, rightJs, context),
+                        BinaryOperator.BitwiseXor => BitwiseXorValue(leftJs, rightJs, context),
+                        BinaryOperator.LeftShift => LeftShiftValue(leftJs, rightJs, context),
+                        BinaryOperator.RightShift => RightShiftValue(leftJs, rightJs, context),
+                        BinaryOperator.UnsignedRightShift => UnsignedRightShiftValue(leftJs, rightJs, context),
+                        BinaryOperator.In => InOperatorJsValue(leftJs, rightJs, context) ? JsValue.True : JsValue.False,
+                        BinaryOperator.InstanceOf => InstanceofOperatorJsValue(leftJs, rightJs, context)
+                            ? JsValue.True
+                            : JsValue.False,
+                        _ => throw new NotSupportedException(
+                            $"Compound assignment operator '{cachedBinary.Operator}' is not supported yet.")
+                    };
+
+                    cachedVariable.Environment.WriteSlotValue(expression.Target, cachedVariable.SlotIndex, compoundResult,
+                        context);
+                    return compoundResult;
+                }
+
+                if (!expression.IsCompoundAssignment)
+                {
+                    var rhsValue = EvaluateAssignmentRhsWithNameHintJsValue(expression, expression.Value, environment,
+                        context);
+                    if (context.ShouldStopEvaluation)
+                    {
+                        return rhsValue;
+                    }
+
+                    cachedVariable.Environment.WriteSlotValue(expression.Target, cachedVariable.SlotIndex, rhsValue,
+                        context);
+                    return rhsValue;
+                }
+            }
+
             // Fallback to the AssignmentReference path for other cases
             var reference = AssignmentReferenceResolver.ResolveIdentifierDirect(
                 expression.Target, environment, context);

--- a/src/Asynkron.JsEngine/JsEnvironment.cs
+++ b/src/Asynkron.JsEngine/JsEnvironment.cs
@@ -34,6 +34,7 @@ public sealed class JsEnvironment : IRentable
     private string? _description;
     internal bool _hasThisValue;
     private Dictionary<Symbol, ResolvedIdentifierBinding>? _identifierBindingCache;
+    private Dictionary<Symbol, JsVariable>? _slotVariableCache;
     private bool _inheritStrictness;
     private bool _isStrictEffective;
 
@@ -208,6 +209,7 @@ public sealed class JsEnvironment : IRentable
         _description = description;
         _values?.Clear();
         _identifierBindingCache?.Clear();
+        _slotVariableCache?.Clear();
         _bindingObservers?.Clear();
         _bodyLexicalNames?.Clear();
         _simpleCatchParameters?.Clear();
@@ -272,6 +274,7 @@ public sealed class JsEnvironment : IRentable
         _description = description;
         _values?.Clear();
         _identifierBindingCache?.Clear();
+        _slotVariableCache?.Clear();
         _bindingObservers?.Clear();
         _bodyLexicalNames?.Clear();
         _simpleCatchParameters?.Clear();
@@ -1110,6 +1113,12 @@ public sealed class JsEnvironment : IRentable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal JsValue GetIdentifierJsValueDirect(Symbol name, EvaluationContext context)
     {
+        if (TryResolveSlotVariable(name, out var cachedVariable) &&
+            cachedVariable.Environment.TryReadSlotValue(name, cachedVariable.SlotIndex, context, out var slotValue))
+        {
+            return slotValue;
+        }
+
         if (TryGetCachedDeclarativeBinding(name, context, out var cached))
         {
             return cached.ReadJsValue(context);
@@ -1169,6 +1178,14 @@ public sealed class JsEnvironment : IRentable
             }
 
             value = localBinding.JsValue;
+            return true;
+        }
+
+        if (context.AllowIdentifierCache &&
+            TryResolveSlotVariable(name, out var cachedVariable) &&
+            cachedVariable.Environment.TryReadSlotValue(name, cachedVariable.SlotIndex, context, out var slotValue))
+        {
+            value = slotValue;
             return true;
         }
 
@@ -1383,6 +1400,12 @@ public sealed class JsEnvironment : IRentable
     internal void SetIdentifierJsValue(Symbol name, JsValue value, EvaluationContext context)
     {
         var isStrictContext = context.CurrentScope.IsStrict;
+
+        if (context.AllowIdentifierCache && TryResolveSlotVariable(name, out var cachedVariable))
+        {
+            cachedVariable.Environment.WriteSlotValue(name, cachedVariable.SlotIndex, value, context);
+            return;
+        }
 
         if (TryGetCachedDeclarativeBinding(name, context, out var cached))
         {
@@ -3226,6 +3249,112 @@ public sealed class JsEnvironment : IRentable
     internal bool TryGetSlotIndex(Symbol name, out int slotIndex)
     {
         return _slotMap.TryGetValue(name, out slotIndex) && slotIndex >= 0;
+    }
+
+    /// <summary>
+    /// Resolves a symbol to a cached slot variable by walking the environment chain.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryResolveSlotVariable(Symbol name, out JsVariable variable)
+    {
+        if (_slotVariableCache is not null && _slotVariableCache.TryGetValue(name, out variable))
+        {
+            return true;
+        }
+
+        var current = this;
+        var hops = 0;
+        const int maxLookupDepth = 10_000;
+
+        while (current is not null && hops++ < maxLookupDepth)
+        {
+            if (!current._slotMap.IsEmpty &&
+                current._slotMap.TryGetValue(name, out var slotIndex) &&
+                slotIndex >= 0 &&
+                current._slots is not null &&
+                slotIndex < current._slots.Length)
+            {
+                variable = new JsVariable(current, slotIndex);
+                _slotVariableCache ??=
+                    new Dictionary<Symbol, JsVariable>(ReferenceEqualityComparer<Symbol>.Instance);
+                _slotVariableCache[name] = variable;
+                return true;
+            }
+
+            if (current._varEnvironmentOverride is not null &&
+                current._varEnvironmentOverride != current &&
+                current._varEnvironmentOverride.TryResolveSlotVariable(name, out variable))
+            {
+                _slotVariableCache ??=
+                    new Dictionary<Symbol, JsVariable>(ReferenceEqualityComparer<Symbol>.Instance);
+                _slotVariableCache[name] = variable;
+                return true;
+            }
+
+            current = current.Enclosing;
+        }
+
+        variable = default;
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryReadSlotValue(Symbol name, int slotIndex, EvaluationContext context, out JsValue value)
+    {
+        value = default;
+        var slots = _slots;
+        if (slots is null || slotIndex < 0 || slotIndex >= slots.Length)
+        {
+            return false;
+        }
+
+        var slotValue = slots[slotIndex];
+        if (slotValue.IsUninitialized)
+        {
+            var errorObject = StandardLibrary.CreateReferenceError(
+                $"Cannot access '{name.Name}' before initialization",
+                context,
+                context.RealmState);
+            value = errorObject;
+            context.SetThrow(errorObject);
+            return true;
+        }
+
+        value = slotValue;
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void WriteSlotValue(Symbol name, int slotIndex, JsValue value, EvaluationContext context)
+    {
+        var slots = _slots;
+        if (slots is null || slotIndex < 0 || slotIndex >= slots.Length)
+        {
+            SetIdentifierJsValue(name, value, context);
+            return;
+        }
+
+        if (_values is not null)
+        {
+            ref var binding = ref _values.GetValueRefOrNullRef(name);
+            if (!Unsafe.IsNullRef(ref binding))
+            {
+                WriteResolvedBindingJsValue(this, ref binding, name, value, context.CurrentScope.IsStrict);
+                slots[slotIndex] = value;
+                return;
+            }
+        }
+
+        var currentSlotValue = slots[slotIndex];
+        if (currentSlotValue.IsUninitialized)
+        {
+            throw new ThrowSignal(StandardLibrary.CreateReferenceError(
+                $"Cannot access '{name.Name}' before initialization",
+                context,
+                context.RealmState));
+        }
+
+        slots[slotIndex] = value;
     }
 
     /// <summary>


### PR DESCRIPTION
Summary:
- add JsVariable slot cache in JsEnvironment for direct slot read/write
- use cached slot variables in assignment evaluation to avoid ResolveIdentifierDirect
- use slot cache for identifier reads/writes in direct paths

Tests:
- dotnet test tests/Asynkron.JsEngine.Tests