### PR TITLE
Avoid slot assignment allocations

### DIFF
--- a/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
@@ -145,7 +145,9 @@ public static partial class TypedAstEvaluator
     private static bool TryEvaluateCompoundAssignmentSlotBased(
         AssignmentExpression assignment,
         ExpressionNode candidate,
-        IdentifierExpression targetIdentifier,
+        Symbol targetName,
+        int scopeId,
+        int slotIndex,
         JsEnvironment environment,
         EvaluationContext context,
         out JsValue value,
@@ -159,7 +161,9 @@ public static partial class TypedAstEvaluator
         }
 
         if (!environment.TryReadIdentifierWithSlot(
-                targetIdentifier,
+                targetName,
+                scopeId,
+                slotIndex,
                 context,
                 out var leftJs))
         {
@@ -550,23 +554,20 @@ public static partial class TypedAstEvaluator
 
             // Fast path: slot-based assignment using ScopeId to find the declaring environment.
             // This enables O(1) slot access for variables in any scope (local or closure).
-            if ( expression is { SlotIndex: >= 0, ScopeId: >= 0 })
+            if (expression is { SlotIndex: >= 0, ScopeId: >= 0 })
             {
-                var targetIdentifier = expression.TargetIdentifier ??
-                                       new IdentifierExpression(
-                                           expression.Source,
-                                           expression.Target,
-                                           expression.ScopeDepth,
-                                           expression.SlotIndex,
-                                           expression.ScopeId);
-
+                var targetName = expression.Target;
+                var scopeId = expression.ScopeId;
+                var slotIndex = expression.SlotIndex;
                 if (expression.IsCompoundAssignment)
                 {
                     // Try slot-based compound assignment (fastest path)
                     if (TryEvaluateCompoundAssignmentSlotBased(
                         expression,
                         expression.Value,
-                        targetIdentifier,
+                        targetName,
+                        scopeId,
+                        slotIndex,
                         environment,
                         context,
                         out var compoundJsValue,
@@ -579,7 +580,8 @@ public static partial class TypedAstEvaluator
 
                         if (shouldAssignCompound)
                         {
-                            environment.TryWriteIdentifierWithSlot(targetIdentifier, compoundJsValue, context);
+                            environment.TryWriteIdentifierWithSlot(targetName, scopeId, slotIndex, compoundJsValue,
+                                context);
                         }
 
                         return compoundJsValue;
@@ -596,7 +598,7 @@ public static partial class TypedAstEvaluator
                         return slotValueJs;
                     }
 
-                    environment.TryWriteIdentifierWithSlot(targetIdentifier, slotValueJs, context);
+                    environment.TryWriteIdentifierWithSlot(targetName, scopeId, slotIndex, slotValueJs, context);
                     return slotValueJs;
                 }
             }

--- a/src/Asynkron.JsEngine/JsEnvironment.cs
+++ b/src/Asynkron.JsEngine/JsEnvironment.cs
@@ -1288,7 +1288,7 @@ public sealed class JsEnvironment : IRentable
     /// Slot-aware identifier write. Uses slot hint when possible; otherwise falls back to normal write resolution.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool TryWriteIdentifierWithSlot(
+    internal bool TryWriteIdentifierWithSlot(
         Symbol name,
         int scopeId,
         int slotIndex,


### PR DESCRIPTION
Summary:\n- Avoid per-assignment IdentifierExpression allocations in slot-based assignment fast path by using Symbol/scope/slot directly.\n- Expose internal slot-write overload for the new fast path.\n\nPerf:\n- forloop --cpu RunSync totals: 14.11s, 20.13s, 11.03s (pre-change: 20.93s, 18.50s, 18.60s; high variance).