### PR TITLE
Optimize slot-based assignments to skip IdentifierExpression allocation

### DIFF
--- a/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
@@ -145,7 +145,9 @@ public static partial class TypedAstEvaluator
     private static bool TryEvaluateCompoundAssignmentSlotBased(
         AssignmentExpression assignment,
         ExpressionNode candidate,
-        IdentifierExpression targetIdentifier,
+        Symbol targetName,
+        int scopeId,
+        int slotIndex,
         JsEnvironment environment,
         EvaluationContext context,
         out JsValue value,
@@ -159,7 +161,9 @@ public static partial class TypedAstEvaluator
         }
 
         if (!environment.TryReadIdentifierWithSlot(
-                targetIdentifier,
+                targetName,
+                scopeId,
+                slotIndex,
                 context,
                 out var leftJs))
         {
@@ -552,13 +556,9 @@ public static partial class TypedAstEvaluator
             // This enables O(1) slot access for variables in any scope (local or closure).
             if ( expression is { SlotIndex: >= 0, ScopeId: >= 0 })
             {
-                var targetIdentifier = expression.TargetIdentifier ??
-                                       new IdentifierExpression(
-                                           expression.Source,
-                                           expression.Target,
-                                           expression.ScopeDepth,
-                                           expression.SlotIndex,
-                                           expression.ScopeId);
+                var targetName = expression.Target;
+                var scopeId = expression.ScopeId;
+                var slotIndex = expression.SlotIndex;
 
                 if (expression.IsCompoundAssignment)
                 {
@@ -566,7 +566,9 @@ public static partial class TypedAstEvaluator
                     if (TryEvaluateCompoundAssignmentSlotBased(
                         expression,
                         expression.Value,
-                        targetIdentifier,
+                        targetName,
+                        scopeId,
+                        slotIndex,
                         environment,
                         context,
                         out var compoundJsValue,
@@ -579,7 +581,8 @@ public static partial class TypedAstEvaluator
 
                         if (shouldAssignCompound)
                         {
-                            environment.TryWriteIdentifierWithSlot(targetIdentifier, compoundJsValue, context);
+                            environment.TryWriteIdentifierWithSlot(targetName, scopeId, slotIndex, compoundJsValue,
+                                context);
                         }
 
                         return compoundJsValue;
@@ -596,7 +599,7 @@ public static partial class TypedAstEvaluator
                         return slotValueJs;
                     }
 
-                    environment.TryWriteIdentifierWithSlot(targetIdentifier, slotValueJs, context);
+                    environment.TryWriteIdentifierWithSlot(targetName, scopeId, slotIndex, slotValueJs, context);
                     return slotValueJs;
                 }
             }

--- a/src/Asynkron.JsEngine/JsEnvironment.cs
+++ b/src/Asynkron.JsEngine/JsEnvironment.cs
@@ -1288,7 +1288,7 @@ public sealed class JsEnvironment : IRentable
     /// Slot-aware identifier write. Uses slot hint when possible; otherwise falls back to normal write resolution.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool TryWriteIdentifierWithSlot(
+    internal bool TryWriteIdentifierWithSlot(
         Symbol name,
         int scopeId,
         int slotIndex,


### PR DESCRIPTION
## Summary
- avoid constructing IdentifierExpression in slot-based assignment fast path; pass Symbol/scope/slot into compound slot evaluator
- expose JsEnvironment.TryWriteIdentifierWithSlot(Symbol, scopeId, slotIndex, ...) for direct writes
- reduces assignment hot-path allocations in forloop benchmark

## Testing
- ./tools/profile forloop --cpu --calltree-depth 30 --calltree-width 8 --root RunSync (baseline ~19.6s; after change runs: 12.5s, 10.1s, 27.6s outlier, 14.4s)
- dotnet test tests/Asynkron.JsEngine.Tests
