### PR TITLE
Optimize compound assignment RHS evaluation with fast paths

### DIFF
--- a/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
@@ -212,12 +212,35 @@ public static partial class TypedAstEvaluator
                 return true;
         }
 
-        var rightJs = EvaluateAssignmentRhsWithNameHintJsValue(assignment, binary.Right, environment, context);
-        if (context.ShouldStopEvaluation)
+        // Fast path: evaluate RHS directly for simple expressions to avoid function call overhead
+        JsValue rightJs;
+        if (binary.Right is LiteralExpression rhsLiteral)
         {
-            value = JsValue.Undefined;
-            shouldAssign = false;
-            return true;
+            // Literal - use pre-computed value directly (no evaluation needed)
+            rightJs = rhsLiteral.Value;
+        }
+        else if (binary.Right is IdentifierExpression rhsIdentifier &&
+                 environment.TryReadIdentifierWithSlot(rhsIdentifier, context, out var rhsSlotValue))
+        {
+            // Identifier with slot - read directly
+            rightJs = rhsSlotValue;
+            if (context.ShouldStopEvaluation)
+            {
+                value = JsValue.Undefined;
+                shouldAssign = false;
+                return true;
+            }
+        }
+        else
+        {
+            // Fall back to full evaluation for complex expressions
+            rightJs = EvaluateAssignmentRhsWithNameHintJsValue(assignment, binary.Right, environment, context);
+            if (context.ShouldStopEvaluation)
+            {
+                value = JsValue.Undefined;
+                shouldAssign = false;
+                return true;
+            }
         }
 
         // Use JsValue arithmetic operations to avoid boxing
@@ -326,12 +349,35 @@ public static partial class TypedAstEvaluator
                 return true;
         }
 
-        var rightJs = EvaluateAssignmentRhsWithNameHintJsValue(assignment, binary.Right, environment, context);
-        if (context.ShouldStopEvaluation)
+        // Fast path: evaluate RHS directly for simple expressions to avoid function call overhead
+        JsValue rightJs;
+        if (binary.Right is LiteralExpression rhsLiteral)
         {
-            value = JsValue.Undefined;
-            shouldAssign = false;
-            return true;
+            // Literal - use pre-computed value directly (no evaluation needed)
+            rightJs = rhsLiteral.Value;
+        }
+        else if (binary.Right is IdentifierExpression rhsIdentifier &&
+                 environment.TryReadIdentifierWithSlot(rhsIdentifier, context, out var rhsSlotValue))
+        {
+            // Identifier with slot - read directly
+            rightJs = rhsSlotValue;
+            if (context.ShouldStopEvaluation)
+            {
+                value = JsValue.Undefined;
+                shouldAssign = false;
+                return true;
+            }
+        }
+        else
+        {
+            // Fall back to full evaluation for complex expressions
+            rightJs = EvaluateAssignmentRhsWithNameHintJsValue(assignment, binary.Right, environment, context);
+            if (context.ShouldStopEvaluation)
+            {
+                value = JsValue.Undefined;
+                shouldAssign = false;
+                return true;
+            }
         }
 
         value = binary.Operator switch
@@ -433,12 +479,35 @@ public static partial class TypedAstEvaluator
                 return true;
         }
 
-        var rightJs = EvaluateAssignmentRhsWithNameHintJsValue(assignment, binary.Right, environment, context);
-        if (context.ShouldStopEvaluation)
+        // Fast path: evaluate RHS directly for simple expressions to avoid function call overhead
+        JsValue rightJs;
+        if (binary.Right is LiteralExpression rhsLiteral)
         {
-            value = JsValue.Undefined;
-            shouldAssign = false;
-            return true;
+            // Literal - use pre-computed value directly (no evaluation needed)
+            rightJs = rhsLiteral.Value;
+        }
+        else if (binary.Right is IdentifierExpression rhsIdentifier &&
+                 environment.TryReadIdentifierWithSlot(rhsIdentifier, context, out var rhsSlotValue))
+        {
+            // Identifier with slot - read directly
+            rightJs = rhsSlotValue;
+            if (context.ShouldStopEvaluation)
+            {
+                value = JsValue.Undefined;
+                shouldAssign = false;
+                return true;
+            }
+        }
+        else
+        {
+            // Fall back to full evaluation for complex expressions
+            rightJs = EvaluateAssignmentRhsWithNameHintJsValue(assignment, binary.Right, environment, context);
+            if (context.ShouldStopEvaluation)
+            {
+                value = JsValue.Undefined;
+                shouldAssign = false;
+                return true;
+            }
         }
 
         // Use JsValue arithmetic operations to avoid boxing


### PR DESCRIPTION
## Summary

Add direct evaluation fast paths for simple RHS expressions in compound assignments (like `s += i` or `s += 1`), bypassing the full `EvaluateAssignmentRhsWithNameHintJsValue` and `EvaluateExpression` call chain.

### Changes

In the three compound assignment evaluation methods:
- `TryEvaluateCompoundAssignmentSlotBased`
- `TryEvaluateCompoundAssignmentCachedSlot`
- `TryEvaluateCompoundAssignmentJsValue`

Added fast paths that check if the RHS is:
1. **LiteralExpression**: Use pre-computed `.Value` directly (no evaluation needed)
2. **IdentifierExpression with slot info**: Read via `TryReadIdentifierWithSlot` directly

This eliminates for simple expressions:
- `ShouldApplyAssignmentNameHint` check (unnecessary for non-function expressions)
- `EvaluateExpression` dispatch overhead
- Function call overhead from wrapper methods

### Performance Impact

- Baseline: ~16.7-23.6ms per forloop run (1M iterations of `s += i`)
- After optimization: ~9.4-21.5ms per forloop run
- Hot path (`TryEvaluateCompoundAssignmentJsValue`) reduced by avoiding multiple function calls per iteration

### Test Results

All 2920 tests pass.

## Test plan

- [x] Run `dotnet test tests/Asynkron.JsEngine.Tests` - all pass
- [x] Run `./tools/profile forloop --cpu` - verified performance improvement
- [x] Verify compound assignments with literals work: `x += 1`
- [x] Verify compound assignments with identifiers work: `s += i`

🤖 Generated with [Claude Code](https://claude.com/claude-code)