### PR TITLE
Perf: direct slot reads/writes for assignment expressions

### DIFF
--- a/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
@@ -138,15 +138,13 @@ public static partial class TypedAstEvaluator
         return true;
     }
 
-    /// <summary>
-    /// Slot-based compound assignment evaluation - fastest path for resolved identifiers.
-    /// Only used when ScopeDepth=0 (local variables in the current function scope).
-    /// </summary>
     private static bool TryEvaluateCompoundAssignmentSlotBased(
         AssignmentExpression assignment,
         ExpressionNode candidate,
-        IdentifierExpression targetIdentifier,
+        Symbol name,
+        int slotIndex,
         JsEnvironment environment,
+        JsEnvironment targetEnvironment,
         EvaluationContext context,
         out JsValue value,
         out bool shouldAssign)
@@ -158,10 +156,7 @@ public static partial class TypedAstEvaluator
             return false;
         }
 
-        if (!environment.TryReadIdentifierWithSlot(
-                targetIdentifier,
-                context,
-                out var leftJs))
+        if (!targetEnvironment.TryReadSlotValue(name, slotIndex, context, out var leftJs))
         {
             value = JsValue.Undefined;
             shouldAssign = false;
@@ -550,27 +545,25 @@ public static partial class TypedAstEvaluator
 
             // Fast path: slot-based assignment using ScopeId to find the declaring environment.
             // This enables O(1) slot access for variables in any scope (local or closure).
-            if ( expression is { SlotIndex: >= 0, ScopeId: >= 0 })
+            if (expression is { SlotIndex: >= 0, ScopeId: >= 0 })
             {
-                var targetIdentifier = expression.TargetIdentifier ??
-                                       new IdentifierExpression(
-                                           expression.Source,
-                                           expression.Target,
-                                           expression.ScopeDepth,
-                                           expression.SlotIndex,
-                                           expression.ScopeId);
+                var targetEnvironment =
+                    environment.ScopeId == expression.ScopeId ? environment : environment.FindByScopeId(expression.ScopeId);
 
                 if (expression.IsCompoundAssignment)
                 {
                     // Try slot-based compound assignment (fastest path)
-                    if (TryEvaluateCompoundAssignmentSlotBased(
-                        expression,
-                        expression.Value,
-                        targetIdentifier,
-                        environment,
-                        context,
-                        out var compoundJsValue,
-                        out var shouldAssignCompound))
+                    if (targetEnvironment is not null &&
+                        TryEvaluateCompoundAssignmentSlotBased(
+                            expression,
+                            expression.Value,
+                            expression.Target,
+                            expression.SlotIndex,
+                            environment,
+                            targetEnvironment,
+                            context,
+                            out var compoundJsValue,
+                            out var shouldAssignCompound))
                     {
                         if (context.ShouldStopEvaluation)
                         {
@@ -579,7 +572,17 @@ public static partial class TypedAstEvaluator
 
                         if (shouldAssignCompound)
                         {
-                            environment.TryWriteIdentifierWithSlot(targetIdentifier, compoundJsValue, context);
+                            if (targetEnvironment is null ||
+                                !targetEnvironment.TryWriteSlotValue(expression.Target, expression.SlotIndex, compoundJsValue,
+                                    context))
+                            {
+                                environment.TryWriteIdentifierWithSlot(
+                                    expression.Target,
+                                    expression.ScopeId,
+                                    expression.SlotIndex,
+                                    compoundJsValue,
+                                    context);
+                            }
                         }
 
                         return compoundJsValue;
@@ -596,7 +599,16 @@ public static partial class TypedAstEvaluator
                         return slotValueJs;
                     }
 
-                    environment.TryWriteIdentifierWithSlot(targetIdentifier, slotValueJs, context);
+                    if (targetEnvironment is null ||
+                        !targetEnvironment.TryWriteSlotValue(expression.Target, expression.SlotIndex, slotValueJs, context))
+                    {
+                        environment.TryWriteIdentifierWithSlot(
+                            expression.Target,
+                            expression.ScopeId,
+                            expression.SlotIndex,
+                            slotValueJs,
+                            context);
+                    }
                     return slotValueJs;
                 }
             }

--- a/src/Asynkron.JsEngine/JsEnvironment.cs
+++ b/src/Asynkron.JsEngine/JsEnvironment.cs
@@ -1288,7 +1288,7 @@ public sealed class JsEnvironment : IRentable
     /// Slot-aware identifier write. Uses slot hint when possible; otherwise falls back to normal write resolution.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool TryWriteIdentifierWithSlot(
+    internal bool TryWriteIdentifierWithSlot(
         Symbol name,
         int scopeId,
         int slotIndex,


### PR DESCRIPTION
Uses JsEnvironment.TryReadSlotValue/TryWriteSlotValue for slot-stamped AssignmentExpression fast paths (resolving target env once) and exposes JsEnvironment.TryWriteIdentifierWithSlot(Symbol,scopeId,slotIndex,...) for internal callers.

Profiler (./tools/profile forloop --cpu --root RunSync): ~15.3–17.7s baseline → ~13.5–14.0s after.

Tests: dotnet test tests/Asynkron.JsEngine.Tests -c Release (2920 passed, 0 failed).