### PR TITLE
Add CompoundAssignmentSlotInstruction for faster compound assignments

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -1104,6 +1104,76 @@ public static partial class TypedAstEvaluator
                                 continue;
                             }
 
+                            case InstructionKind.CompoundAssignmentSlot:
+                            {
+                                var compoundInstruction = Unsafe.As<CompoundAssignmentSlotInstruction>(instruction);
+                                // Fast path for compound assignment on identifiers (e.g., s += i)
+                                // Read current value from target
+                                var compCurrentValue = environment.GetIdentifierJsValueDirect(compoundInstruction.TargetSymbol, context);
+                                if (context.IsThrow)
+                                {
+                                    var compThrown = context.FlowValue;
+                                    context.Clear();
+                                    if (HandleAbruptCompletion(AbruptKind.Throw, compThrown, environment))
+                                    {
+                                        continue;
+                                    }
+                                    TryCatchStateRef.TryStack.Clear();
+                                    throw new ThrowSignal(compThrown);
+                                }
+
+                                // Evaluate RHS expression
+                                var compRhsValue = compoundInstruction.RhsExpression.EvaluateExpression(environment, context);
+                                if (context.ShouldStopEvaluation)
+                                {
+                                    if (TryHandlePendingAwait(context, out var pendingCompResult, environment))
+                                    {
+                                        return pendingCompResult;
+                                    }
+                                    if (context.IsThrow)
+                                    {
+                                        var compRhsThrown = context.FlowValue;
+                                        context.Clear();
+                                        if (HandleAbruptCompletion(AbruptKind.Throw, compRhsThrown, environment))
+                                        {
+                                            continue;
+                                        }
+                                        TryCatchStateRef.TryStack.Clear();
+                                        throw new ThrowSignal(compRhsThrown);
+                                    }
+                                }
+
+                                // Apply the operator using fast-path methods
+                                var compResult = compoundInstruction.Operator switch
+                                {
+                                    BinaryOperator.Add => AddValue(compCurrentValue, compRhsValue, context),
+                                    BinaryOperator.Subtract => SubtractValue(compCurrentValue, compRhsValue, context),
+                                    BinaryOperator.Multiply => MultiplyValue(compCurrentValue, compRhsValue, context),
+                                    BinaryOperator.Divide => DivideValue(compCurrentValue, compRhsValue, context),
+                                    BinaryOperator.Modulo => ModuloValue(compCurrentValue, compRhsValue, context),
+                                    BinaryOperator.Power => PowerValue(compCurrentValue, compRhsValue, context),
+                                    BinaryOperator.BitwiseAnd => BitwiseAndValue(compCurrentValue, compRhsValue, context),
+                                    BinaryOperator.BitwiseOr => BitwiseOrValue(compCurrentValue, compRhsValue, context),
+                                    BinaryOperator.BitwiseXor => BitwiseXorValue(compCurrentValue, compRhsValue, context),
+                                    BinaryOperator.LeftShift => LeftShiftValue(compCurrentValue, compRhsValue, context),
+                                    BinaryOperator.RightShift => RightShiftValue(compCurrentValue, compRhsValue, context),
+                                    BinaryOperator.UnsignedRightShift => UnsignedRightShiftValue(compCurrentValue, compRhsValue, context),
+                                    _ => throw new NotSupportedException($"Compound assignment operator '{compoundInstruction.Operator}' not supported in CompoundAssignmentSlotInstruction.")
+                                };
+
+                                // Update the binding
+                                environment.AssignJsValue(compoundInstruction.TargetSymbol, compResult);
+
+                                // Track completion value for scripts
+                                if (_isScriptMode && !compoundInstruction.SuppressCompletionValue)
+                                {
+                                    _scriptCompletionValue = compResult;
+                                }
+
+                                _programCounter = compoundInstruction.Next;
+                                continue;
+                            }
+
                             case InstructionKind.FunctionDeclaration:
                             {
                                 var functionDeclInstruction = Unsafe.As<FunctionDeclarationInstruction>(instruction);

--- a/src/Asynkron.JsEngine/Execution/Emitters/ExpressionStatementEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/ExpressionStatementEmitter.cs
@@ -91,6 +91,36 @@ internal static class ExpressionStatementEmitter
             return true;
         }
 
+        // Fast path: compound assignment on simple identifiers (e.g., s += i, s -= 1)
+        // Only handle non-short-circuit operators (+=, -=, *=, /=, %=, **=, bitwise ops)
+        // Logical operators (&&=, ||=, ??=) need special short-circuit handling
+        // NOTE: Skip this optimization for script-level code because:
+        //   1. Scripts may contain 'with' statements that require dynamic identifier resolution
+        //   2. Eval'd code runs at script level and may be inside a with-scope from caller
+        //   3. Slot-based lookup would bypass the with-scope, breaking 'with' semantics
+        if (!ctx.IsScriptLevel &&
+            expressionStatement.Expression is AssignmentExpression
+            {
+                IsCompoundAssignment: true,
+                Value: BinaryExpression compoundBinary
+            } compoundAssign &&
+            compoundBinary.Operator is
+                BinaryOperator.Add or BinaryOperator.Subtract or
+                BinaryOperator.Multiply or BinaryOperator.Divide or
+                BinaryOperator.Modulo or BinaryOperator.Power or
+                BinaryOperator.BitwiseAnd or BinaryOperator.BitwiseOr or
+                BinaryOperator.BitwiseXor or BinaryOperator.LeftShift or
+                BinaryOperator.RightShift or BinaryOperator.UnsignedRightShift)
+        {
+            entryIndex = ctx.Append(new CompoundAssignmentSlotInstruction(
+                nextIndex,
+                compoundAssign.Target,
+                compoundBinary.Operator,
+                compoundBinary.Right,
+                suppressCompletion));
+            return true;
+        }
+
         // Use native EvaluateAndDiscardInstruction - evaluates expression and discards result
         entryIndex = ctx.Append(new EvaluateAndDiscardInstruction(nextIndex, expressionStatement.Expression, suppressCompletion));
         return true;

--- a/src/Asynkron.JsEngine/Execution/ExecutionPlanPrinter.cs
+++ b/src/Asynkron.JsEngine/Execution/ExecutionPlanPrinter.cs
@@ -191,6 +191,9 @@ internal static class ExecutionPlanPrinter
                 $"{(inc.IsPrefix ? "" : (inc.IsIncrement ? "++" : "--"))}" +
                 $" → [{inc.Next}]",
 
+            CompoundAssignmentSlotInstruction compound =>
+                $"COMPOUND {compound.TargetSymbol.Name} {compound.Operator}= {FormatExpression(compound.RhsExpression)} → [{compound.Next}]",
+
             _ => instruction.ToString() ?? "<?>"
         };
     }

--- a/src/Asynkron.JsEngine/Execution/Instructions/InstructionKind.cs
+++ b/src/Asynkron.JsEngine/Execution/Instructions/InstructionKind.cs
@@ -39,6 +39,7 @@ internal enum InstructionKind : byte
     LeaveWith,
     Expression,
     SetCompletionValue,
+    CompoundAssignmentSlot,
 }
 
 /// <summary>

--- a/src/Asynkron.JsEngine/Execution/Instructions/Instructions.cs
+++ b/src/Asynkron.JsEngine/Execution/Instructions/Instructions.cs
@@ -73,6 +73,29 @@ internal sealed record IncrementSlotInstruction(
     : ExecutionInstruction(InstructionKind.IncrementSlot, Next);
 
 /// <summary>
+///     Performs a compound assignment operation directly on an identifier slot (e.g., s += i).
+///     This avoids going through the generic AssignmentExpression AST evaluator.
+/// </summary>
+/// <remarks>
+///     This instruction provides a fast path for compound assignments like <c>s += i</c>,
+///     <c>s -= value</c>, <c>s *= expr</c>, etc. on simple identifiers. It reads the
+///     current value from the target slot, applies the binary operation with the RHS,
+///     and writes the result back to the slot.
+/// </remarks>
+/// <param name="Next">Next instruction index.</param>
+/// <param name="TargetSymbol">The target identifier symbol.</param>
+/// <param name="Operator">The compound assignment operator (Add, Subtract, etc.).</param>
+/// <param name="RhsExpression">The right-hand side expression.</param>
+/// <param name="SuppressCompletionValue">When true, the completion value is NOT updated.</param>
+internal sealed record CompoundAssignmentSlotInstruction(
+    int Next,
+    Symbol TargetSymbol,
+    BinaryOperator Operator,
+    ExpressionNode RhsExpression,
+    bool SuppressCompletionValue = false)
+    : ExecutionInstruction(InstructionKind.CompoundAssignmentSlot, Next);
+
+/// <summary>
 ///     Represents a function declaration in the generator.
 ///     Function declarations are hoisted, so this instruction is a no-op at runtime
 ///     that simply advances to the next instruction.


### PR DESCRIPTION
## Summary

This PR adds a specialized IR instruction `CompoundAssignmentSlotInstruction` for compound assignments on simple identifiers (e.g., `s += i`, `s -= 1`).

### Changes

- Added `CompoundAssignmentSlotInstruction` to handle compound assignments directly in the IR execution path
- Added `InstructionKind.CompoundAssignmentSlot` enum value
- Updated `ExpressionStatementEmitter` to emit the new instruction for qualifying compound assignments
- Added handler in `ExecutionPlanRunner` for the new instruction
- Added pretty-print support in `ExecutionPlanPrinter`

### Performance Impact

The forloop benchmark shows significant improvement:

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Time | ~17-21 seconds | ~6.5-7 seconds | **~60-70% faster** |

### How It Works

The new instruction:
1. Reads the current value from the target slot
2. Evaluates the RHS expression
3. Applies the binary operator directly (Add, Subtract, Multiply, etc.)
4. Writes the result back to the slot

This avoids the full AST evaluation path which includes:
- `TryEvaluateCompoundAssignmentJsValue` overhead
- `EvaluateAssignmentRhsWithNameHintJsValue` function naming checks
- Full AST dispatch for the binary expression

### Notes

- The optimization is disabled for script-level code to preserve correct `with` statement semantics
- All 2920 internal tests pass
- Supports all arithmetic and bitwise compound operators (+=, -=, *=, /=, %=, **=, &=, |=, ^=, <<=, >>=, >>>=)
- Logical compound operators (&&=, ||=, ??=) are excluded due to short-circuit semantics

## Test plan

- [x] All internal tests pass (2920 passed, 17 skipped)
- [x] Profiler shows significant improvement on forloop benchmark
- [x] `with` statement edge case test passes (`With_EvalUsesSingleUnscopablesLookup`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)