### PR TITLE
Refactor JsEnvironment slots to use JsSlot struct

### DIFF
--- a/src/Asynkron.JsEngine/Ast/FunctionExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/FunctionExpressionExtensions.cs
@@ -471,9 +471,9 @@ public static partial class TypedAstEvaluator
             if (functionNameEnvironment is not null)
             {
                 // Store in slot if slots are initialized (with scope analysis)
-                if (functionNameEnvironment._slots is not null)
+                if (functionNameEnvironment._slots is not null && functionNameEnvironment._slotCount > 0)
                 {
-                    functionNameEnvironment._slots[0] = JsValue.FromObjectUnsafe(callable);
+                    functionNameEnvironment._slots[0].Value = JsValue.FromObjectUnsafe(callable);
                 }
                 // Register as immutable binding in dictionary for eval compatibility and fallback lookup
                 // Per ES spec 9.2.10, function name binding is immutable:

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Completion.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Completion.cs
@@ -432,10 +432,11 @@ public static partial class TypedAstEvaluator
                 // Also scan slots for IteratorDriverState (for-of loop state)
                 if (env.HasSlots && env._slots is { } slots)
                 {
-                    foreach (var slot in slots)
+                    for (var i = 0; i < env._slotCount; i++)
                     {
-                        if (!slot.IsNullOrUndefined &&
-                            slot.TryGetObject<IActiveIteratorState>(out var state) &&
+                        var slotValue = slots[i].Value;
+                        if (!slotValue.IsNullOrUndefined &&
+                            slotValue.TryGetObject<IActiveIteratorState>(out var state) &&
                             state.TryGetActiveIterator(out var iterator))
                         {
                             results.Add((state, iterator));

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -2037,12 +2037,12 @@ public static partial class TypedAstEvaluator
 
             // Bind parameters to slots
             var slots = functionEnvironment._slots;
-            if (slots is not null)
+            if (slots is not null && functionEnvironment._slotCount > 0)
             {
                 for (var i = 0; i < _parameterNames.Length; i++)
                 {
                     var value = i < arguments.Count ? arguments[i] : JsValue.Undefined;
-                    slots[i] = value;
+                    slots[i].Value = value;
                     // When this function has closures (inner functions that capture variables),
                     // also bind to dictionary so closure lookups via TryLocateBinding work.
                     // This is needed when inner functions use dynamic scope (with/eval).
@@ -2131,9 +2131,9 @@ public static partial class TypedAstEvaluator
 
             // Bind first parameter directly - no array allocation
             var slots = functionEnvironment._slots;
-            if (slots is not null && _parameterNames.Length > 0)
+            if (slots is not null && functionEnvironment._slotCount > 0 && _parameterNames.Length > 0)
             {
-                slots[0] = arg0;
+                slots[0].Value = arg0;
                 if (_function.HasClosures)
                 {
                     functionEnvironment.DefineParameterFast(_parameterNames[0], arg0);
@@ -2141,7 +2141,7 @@ public static partial class TypedAstEvaluator
                 // Bind remaining parameters to undefined (when function has more params than args)
                 for (var i = 1; i < _parameterNames.Length; i++)
                 {
-                    slots[i] = JsValue.Undefined;
+                    slots[i].Value = JsValue.Undefined;
                     if (_function.HasClosures)
                     {
                         functionEnvironment.DefineParameterFast(_parameterNames[i], JsValue.Undefined);
@@ -2222,9 +2222,9 @@ public static partial class TypedAstEvaluator
 
             // Bind first parameter directly - no array allocation, no Array.Fill needed
             var slots = reuseEnvironment._slots;
-            if (slots is not null && _parameterNames.Length > 0)
+            if (slots is not null && reuseEnvironment._slotCount > 0 && _parameterNames.Length > 0)
             {
-                slots[0] = arg0;
+                slots[0].Value = arg0;
                 if (_function.HasClosures)
                 {
                     reuseEnvironment.DefineParameterFast(_parameterNames[0], arg0);
@@ -2232,7 +2232,7 @@ public static partial class TypedAstEvaluator
                 // Bind remaining parameters to undefined (when function has more params than args)
                 for (var i = 1; i < _parameterNames.Length; i++)
                 {
-                    slots[i] = JsValue.Undefined;
+                    slots[i].Value = JsValue.Undefined;
                     if (_function.HasClosures)
                     {
                         reuseEnvironment.DefineParameterFast(_parameterNames[i], JsValue.Undefined);
@@ -2314,11 +2314,11 @@ public static partial class TypedAstEvaluator
 
             // Bind first two parameters directly - no array allocation
             var slots = functionEnvironment._slots;
-            if (slots is not null)
+            if (slots is not null && functionEnvironment._slotCount > 0)
             {
                 if (_parameterNames.Length > 0)
                 {
-                    slots[0] = arg0;
+                    slots[0].Value = arg0;
                     if (_function.HasClosures)
                     {
                         functionEnvironment.DefineParameterFast(_parameterNames[0], arg0);
@@ -2327,7 +2327,7 @@ public static partial class TypedAstEvaluator
 
                 if (_parameterNames.Length > 1)
                 {
-                    slots[1] = arg1;
+                    slots[1].Value = arg1;
                     if (_function.HasClosures)
                     {
                         functionEnvironment.DefineParameterFast(_parameterNames[1], arg1);
@@ -2337,7 +2337,7 @@ public static partial class TypedAstEvaluator
                 // Bind remaining parameters to undefined (when function has more params than args)
                 for (var i = 2; i < _parameterNames.Length; i++)
                 {
-                    slots[i] = JsValue.Undefined;
+                    slots[i].Value = JsValue.Undefined;
                     if (_function.HasClosures)
                     {
                         functionEnvironment.DefineParameterFast(_parameterNames[i], JsValue.Undefined);
@@ -2443,13 +2443,13 @@ public static partial class TypedAstEvaluator
 
             // Bind parameters directly to slots for O(1) access (avoids dictionary allocation)
             var slots = functionEnvironment._slots;
-            if (slots is not null)
+            if (slots is not null && functionEnvironment._slotCount > 0)
             {
                 // Fast path: use slots
                 for (var i = 0; i < _parameterNames.Length; i++)
                 {
                     var value = i < arguments.Count ? arguments[i] : JsValue.Undefined;
-                    slots[i] = value;
+                    slots[i].Value = value;
                     // When this function has closures (inner functions that capture variables),
                     // also bind to dictionary so closure lookups via TryLocateBinding work.
                     if (_function.HasClosures)

--- a/src/Asynkron.JsEngine/JsEnvironment.cs
+++ b/src/Asynkron.JsEngine/JsEnvironment.cs
@@ -1,6 +1,5 @@
 #region
 
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -21,13 +20,6 @@ public sealed class JsEnvironment : IRentable
     private const int MaxDepth = 1_000;
     internal static readonly object Uninitialized = new();
 
-    /// <summary>
-    /// Cached empty slot map with reference equality comparer.
-    /// Avoids allocating ImmutableDictionary + Comparers on every environment creation.
-    /// </summary>
-    private static readonly ImmutableDictionary<Symbol, int> EmptySlotMap =
-        ImmutableDictionary<Symbol, int>.Empty.WithComparers(ReferenceEqualityComparer<Symbol>.Instance);
-
     private Dictionary<Symbol, List<Action<JsValue>>>? _bindingObservers;
     private HashSet<Symbol>? _bodyLexicalNames;
     private SourceReference? _creatingSource;
@@ -40,13 +32,16 @@ public sealed class JsEnvironment : IRentable
     private bool _isDefaultDerivedConstructor;
     private HashSet<Symbol>? _simpleCatchParameters;
 
-    private ImmutableDictionary<Symbol, int> _slotMap = EmptySlotMap;
+    /// <summary>
+    /// Slot-based storage for variable access. Each slot contains name, value, and flags.
+    /// Uses linear scan for name lookup - fast for typical JS scopes (1-10 bindings).
+    /// </summary>
+    internal JsSlot[]? _slots;
 
     /// <summary>
-    /// Slot-based storage for fast variable access when scope analysis is available.
-    /// This enables O(1) array indexing instead of dictionary lookup.
+    /// Number of slots currently in use (may be less than array length due to pooling).
     /// </summary>
-    internal JsValue[]? _slots;
+    internal int _slotCount;
 
     /// <summary>
     /// Fast storage for 'this' binding in slot-only environments (InvokeSimpleFast).
@@ -226,12 +221,12 @@ public sealed class JsEnvironment : IRentable
         IsAsyncModule = enclosing?.IsAsyncModule ?? false;
         Depth = (enclosing?.Depth ?? 0) + 1;
         // Reset slot-based state - return slots array to pool
-        JsValueArrayPool.Return(_slots);
+        JsSlotArrayPool.Return(_slots);
         _slots = null;
+        _slotCount = 0;
         _thisValue = default;
         _hasThisValue = false;
         ScopeId = -1;
-        _slotMap = EmptySlotMap;
     }
 
     /// <summary>
@@ -284,12 +279,12 @@ public sealed class JsEnvironment : IRentable
         _inheritStrictness = true;
         // Cache effective strictness - inheritStrictness is always true in ResetForReuse
         _isStrictEffective = isStrict || (enclosing?.IsStrict ?? false);
-        _slotMap = EmptySlotMap;
         RealmState = enclosing?.RealmState;
         ModulePath = enclosing?.ModulePath;
         IsAsyncModule = enclosing?.IsAsyncModule ?? false;
         Depth = (enclosing?.Depth ?? 0) + 1;
         // Keep _slots for reuse - InitializeSlots will reuse if same size
+        // Note: _slotCount is NOT reset here - InitializeSlots will set it
         _thisValue = default;
         _hasThisValue = false;
         ScopeId = -1;
@@ -1227,7 +1222,7 @@ public sealed class JsEnvironment : IRentable
             var slots = targetEnv?._slots;
             if (targetEnv is not null && slots is not null && slotIndex < slots.Length)
             {
-                var slotValue = slots[slotIndex];
+                ref var slot = ref slots[slotIndex];
                 if (shouldLogSlots)
                 {
                     logger?.LogInformation(
@@ -1236,10 +1231,10 @@ public sealed class JsEnvironment : IRentable
                         name.Name,
                         scopeId,
                         slotIndex,
-                        slotValue.Kind);
+                        slot.Value.Kind);
                 }
 
-                if (slotValue.IsUninitialized)
+                if (slot.IsUninitialized)
                 {
                     var errorObject = StandardLibrary.CreateReferenceError(
                         $"Cannot access '{name.Name}' before initialization",
@@ -1250,7 +1245,7 @@ public sealed class JsEnvironment : IRentable
                     return true;
                 }
 
-                value = slotValue;
+                value = slot.Value;
                 return true;
             }
 
@@ -1314,7 +1309,7 @@ public sealed class JsEnvironment : IRentable
                     {
                         targetEnv.WriteResolvedBindingJsValue(targetEnv, ref binding, name, value,
                             context.CurrentScope.IsStrict);
-                        slots[slotIndex] = value;
+                        slots[slotIndex].Value = value;
                         if (shouldLogSlots)
                         {
                             logger?.LogInformation(
@@ -1332,8 +1327,8 @@ public sealed class JsEnvironment : IRentable
 
                 // TDZ check for slot-only path: if the slot is uninitialized, this is a TDZ violation.
                 // This happens when trying to write to a let/const variable before its declaration.
-                var currentSlotValue = slots[slotIndex];
-                if (currentSlotValue.IsUninitialized)
+                ref var currentSlot = ref slots[slotIndex];
+                if (currentSlot.IsUninitialized)
                 {
                     throw new ThrowSignal(StandardLibrary.CreateReferenceError(
                         $"Cannot access '{name.Name}' before initialization",
@@ -1341,7 +1336,7 @@ public sealed class JsEnvironment : IRentable
                         context.RealmState));
                 }
 
-                slots[slotIndex] = value;
+                currentSlot.Value = value;
                 if (shouldLogSlots)
                 {
                     logger?.LogInformation(
@@ -1390,8 +1385,8 @@ public sealed class JsEnvironment : IRentable
             return false;
         }
 
-        var slotValue = slots[slotIndex];
-        if (slotValue.IsUninitialized)
+        ref var slot = ref slots[slotIndex];
+        if (slot.IsUninitialized)
         {
             var errorValue = StandardLibrary.CreateReferenceError(
                 $"Cannot access '{name.Name}' before initialization",
@@ -1402,7 +1397,7 @@ public sealed class JsEnvironment : IRentable
             return true;
         }
 
-        value = slotValue;
+        value = slot.Value;
         return true;
     }
 
@@ -1421,12 +1416,13 @@ public sealed class JsEnvironment : IRentable
             if (!Unsafe.IsNullRef(ref binding))
             {
                 WriteResolvedBindingJsValue(this, ref binding, name, value, context.CurrentScope.IsStrict);
-                slots[slotIndex] = value;
+                slots[slotIndex].Value = value;
                 return true;
             }
         }
 
-        if (slots[slotIndex].IsUninitialized)
+        ref var slot = ref slots[slotIndex];
+        if (slot.IsUninitialized)
         {
             throw new ThrowSignal(StandardLibrary.CreateReferenceError(
                 $"Cannot access '{name.Name}' before initialization",
@@ -1434,7 +1430,7 @@ public sealed class JsEnvironment : IRentable
                 context.RealmState));
         }
 
-        slots[slotIndex] = value;
+        slot.Value = value;
         return true;
     }
 
@@ -2822,16 +2818,16 @@ public sealed class JsEnvironment : IRentable
             var slotVars = new Dictionary<int, object?>();
             if (current._slots is not null)
             {
-                for (var i = 0; i < current._slots.Length; i++)
+                for (var i = 0; i < current._slotCount; i++)
                 {
-                    slotVars[i] = current._slots[i].ToObject();
+                    slotVars[i] = current._slots[i].Value.ToObject();
                 }
             }
 
             chain.Add(new EnvironmentInfo(
                 current.ScopeId,
                 current._slots is not null,
-                current._slots?.Length ?? 0,
+                current._slotCount,
                 dictVars,
                 slotVars,
                 current._description
@@ -3196,6 +3192,7 @@ public sealed class JsEnvironment : IRentable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void InitializeSlots(int slotCount)
     {
+        _slotCount = slotCount;
         if (slotCount <= 0)
         {
             return;
@@ -3205,12 +3202,12 @@ public sealed class JsEnvironment : IRentable
         if (_slots is null || _slots.Length < slotCount)
         {
             // Return old array to pool before getting new one
-            JsValueArrayPool.Return(_slots);
-            _slots = JsValueArrayPool.Rent(slotCount);
+            JsSlotArrayPool.Return(_slots);
+            _slots = JsSlotArrayPool.Rent(slotCount);
         }
 
-        // Initialize all slots to undefined (only up to slotCount, not full array)
-        Array.Fill(_slots, JsValue.Undefined, 0, slotCount);
+        // Clear all slots (set to empty)
+        Array.Clear(_slots, 0, slotCount);
     }
 
     /// <summary>
@@ -3223,6 +3220,7 @@ public sealed class JsEnvironment : IRentable
     internal void InitializeSlots(int slotCount, int scopeId)
     {
         ScopeId = scopeId;
+        _slotCount = slotCount;
         if (slotCount <= 0)
         {
             return;
@@ -3232,62 +3230,160 @@ public sealed class JsEnvironment : IRentable
         if (_slots is null || _slots.Length < slotCount)
         {
             // Return old array to pool before getting new one
-            JsValueArrayPool.Return(_slots);
-            _slots = JsValueArrayPool.Rent(slotCount);
+            JsSlotArrayPool.Return(_slots);
+            _slots = JsSlotArrayPool.Rent(slotCount);
         }
 
-        // Initialize all slots to undefined (only up to slotCount, not full array)
-        Array.Fill(_slots, JsValue.Undefined, 0, slotCount);
+        // Clear all slots (set to empty)
+        Array.Clear(_slots, 0, slotCount);
     }
 
     /// <summary>
-    /// Initializes all scope-related metadata for this environment: scope ID, slot map, and slots array.
-    /// This is the primary method to call when setting up an environment for a function or block scope.
-    /// The slot count is derived from the slot map.
+    /// Initializes all scope-related metadata for this environment using a slot map.
+    /// This converts from the old ImmutableDictionary-based approach.
     /// </summary>
     /// <param name="scopeId">Unique ID for this scope from scope analysis.</param>
     /// <param name="slotMap">Mapping from symbol names to slot indices.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Initialize(int scopeId, ImmutableDictionary<Symbol, int> slotMap)
+    public void Initialize(int scopeId, System.Collections.Immutable.ImmutableDictionary<Symbol, int> slotMap)
     {
         ScopeId = scopeId;
-        _slotMap = slotMap;
+        var count = slotMap.Count;
+        _slotCount = count;
 
-        var slotCount = slotMap.Count;
-        if (slotCount <= 0)
+        if (count <= 0)
         {
             return;
         }
 
-        // Reuse existing array if it's big enough, otherwise rent from pool
-        if (_slots is null || _slots.Length < slotCount)
+        // Ensure capacity
+        if (_slots is null || _slots.Length < count)
         {
-            // Return old array to pool before getting new one
-            JsValueArrayPool.Return(_slots);
-            _slots = JsValueArrayPool.Rent(slotCount);
+            JsSlotArrayPool.Return(_slots);
+            _slots = JsSlotArrayPool.Rent(count);
         }
 
-        // Initialize all slots to undefined (only up to slotCount, not full array)
-        Array.Fill(_slots, JsValue.Undefined, 0, slotCount);
+        // Populate slots from slotMap - each entry maps Symbol -> index
+        foreach (var (symbol, index) in slotMap)
+        {
+            if (index >= 0 && index < count)
+            {
+                _slots[index] = new JsSlot(symbol, JsValue.Undefined, SlotFlags.None);
+            }
+        }
     }
 
     /// <summary>
-    /// Sets the slot map for this environment.
-    /// Internal use only - prefer Initialize() for public API.
+    /// Sets slot names from a slot map. Used for compatibility with old API.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void SetSlotMap(ImmutableDictionary<Symbol, int> slotMap)
+    internal void SetSlotMap(System.Collections.Immutable.ImmutableDictionary<Symbol, int> slotMap)
     {
-        _slotMap = slotMap;
+        var count = slotMap.Count;
+
+        // Ensure we have capacity
+        if (count > 0)
+        {
+            if (_slots is null || _slots.Length < count)
+            {
+                JsSlotArrayPool.Return(_slots);
+                _slots = JsSlotArrayPool.Rent(count);
+                Array.Clear(_slots, 0, count);
+            }
+
+            // Set slot names from the map (values remain as initialized)
+            foreach (var (symbol, index) in slotMap)
+            {
+                if (index >= 0 && index < _slots.Length)
+                {
+                    _slots[index].Name = symbol;
+                }
+            }
+
+            _slotCount = Math.Max(_slotCount, count);
+        }
     }
 
     /// <summary>
-    /// Tries to get the slot index for a symbol from this environment's slot map.
+    /// Finds the slot index for a given symbol name using linear scan.
+    /// Returns -1 if not found. Fast for typical JS scopes (1-10 bindings).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal int FindSlotIndex(Symbol name)
+    {
+        var slots = _slots;
+        if (slots is null)
+        {
+            return -1;
+        }
+
+        var count = _slotCount;
+        for (var i = 0; i < count; i++)
+        {
+            if (ReferenceEquals(slots[i].Name, name))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Tries to get the slot index for a symbol from this environment.
+    /// Uses linear scan over slot names.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal bool TryGetSlotIndex(Symbol name, out int slotIndex)
     {
-        return _slotMap.TryGetValue(name, out slotIndex) && slotIndex >= 0;
+        slotIndex = FindSlotIndex(name);
+        return slotIndex >= 0;
+    }
+
+    /// <summary>
+    /// Gets a reference to a slot by index. Caller must ensure index is valid.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ref JsSlot GetSlotByIndex(int index)
+    {
+        return ref _slots![index];
+    }
+
+    /// <summary>
+    /// Defines a new slot with the given name, value, and flags.
+    /// Returns the index of the new slot.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal int DefineSlot(Symbol name, JsValue value, SlotFlags flags)
+    {
+        var index = _slotCount;
+
+        // Ensure we have capacity
+        if (_slots is null || index >= _slots.Length)
+        {
+            GrowSlots();
+        }
+
+        _slots![index] = new JsSlot(name, value, flags);
+        _slotCount = index + 1;
+        return index;
+    }
+
+    /// <summary>
+    /// Grows the slots array when capacity is exceeded.
+    /// </summary>
+    private void GrowSlots()
+    {
+        var newCapacity = _slots is null ? 4 : _slots.Length * 2;
+        var newSlots = JsSlotArrayPool.Rent(newCapacity);
+
+        if (_slots is not null)
+        {
+            Array.Copy(_slots, newSlots, _slotCount);
+            JsSlotArrayPool.Return(_slots);
+        }
+
+        _slots = newSlots;
     }
 
     /// <summary>
@@ -3333,7 +3429,7 @@ public sealed class JsEnvironment : IRentable
             }
         }
 
-        return env._slots![slotIndex];
+        return env._slots![slotIndex].Value;
     }
 
     /// <summary>
@@ -3356,7 +3452,7 @@ public sealed class JsEnvironment : IRentable
             }
         }
 
-        env._slots![slotIndex] = value;
+        env._slots![slotIndex].Value = value;
     }
 
     /// <summary>
@@ -3368,40 +3464,36 @@ public sealed class JsEnvironment : IRentable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void SetSlot(int slotIndex, JsValue value)
     {
-        _slots![slotIndex] = value;
+        _slots![slotIndex].Value = value;
     }
 
+    /// <summary>
+    /// Tries to set a slot value by name. Uses linear scan to find the slot.
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void TrySetSlot(Symbol name, JsValue value)
     {
-        var slots = _slots;
-        if (slots is null || _slotMap.IsEmpty)
+        var slotIndex = FindSlotIndex(name);
+        if (slotIndex >= 0)
         {
-            return;
-        }
-
-        if (_slotMap.TryGetValue(name, out var slotIndex) &&
-            slotIndex >= 0 &&
-            slotIndex < slots.Length)
-        {
-            slots[slotIndex] = value;
+            _slots![slotIndex].Value = value;
         }
     }
 
     /// <summary>
     /// Checks if this environment has slot storage initialized.
     /// </summary>
-    public bool HasSlots => _slots is not null;
+    public bool HasSlots => _slots is not null && _slotCount > 0;
 
     /// <summary>
-    /// Gets a direct reference to a slot value. This enables zero-overhead read/write
+    /// Gets a direct reference to a slot's value. This enables zero-overhead read/write
     /// when the caller has already resolved the target environment.
     /// WARNING: Caller must ensure slotIndex is valid and _slots is initialized.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal ref JsValue GetSlotRef(int slotIndex)
     {
-        return ref _slots![slotIndex];
+        return ref _slots![slotIndex].Value;
     }
 
     /// <summary>
@@ -3412,7 +3504,7 @@ public sealed class JsEnvironment : IRentable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void SetSlotDirect(int slotIndex, JsValue value)
     {
-        _slots![slotIndex] = value;
+        _slots![slotIndex].Value = value;
     }
 
     /// <summary>
@@ -3427,7 +3519,7 @@ public sealed class JsEnvironment : IRentable
             // Fast path: if current environment matches scopeId, use it directly
             // This avoids the FindByScopeId loop traversal in the common case
             targetEnv = (ScopeId == scopeId) ? this : FindByScopeId(scopeId);
-            if (targetEnv?._slots is not null && slotIndex < targetEnv._slots.Length)
+            if (targetEnv?._slots is not null && slotIndex < targetEnv._slotCount)
             {
                 return true;
             }

--- a/src/Asynkron.JsEngine/JsSlot.cs
+++ b/src/Asynkron.JsEngine/JsSlot.cs
@@ -1,0 +1,156 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Asynkron.JsEngine.Ast;
+using Asynkron.JsEngine.JsTypes;
+
+namespace Asynkron.JsEngine;
+
+/// <summary>
+/// Flags for slot binding metadata, packed into a single byte.
+/// </summary>
+[Flags]
+public enum SlotFlags : byte
+{
+    None = 0,
+    Const = 1,
+    Lexical = 2,
+    Uninitialized = 4,
+    GlobalConstant = 8,
+    BlocksFunctionScopeOverride = 16,
+    CanDelete = 32,
+    ImmutableBinding = 64,
+}
+
+/// <summary>
+/// A slot in the environment that holds a binding's name, value, and metadata.
+/// Uses struct layout for cache-friendly access - name, value, and flags are co-located.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public struct JsSlot
+{
+    /// <summary>
+    /// The symbol name for this binding. Set once during initialization.
+    /// </summary>
+    public Symbol Name;
+
+    /// <summary>
+    /// The current value of this binding.
+    /// </summary>
+    public JsValue Value;
+
+    /// <summary>
+    /// Packed binding flags (const, lexical, uninitialized, etc.).
+    /// </summary>
+    public SlotFlags Flags;
+
+    /// <summary>
+    /// Creates a new slot with the given name, value, and flags.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public JsSlot(Symbol name, JsValue value, SlotFlags flags)
+    {
+        Name = name;
+        Value = value;
+        Flags = flags;
+    }
+
+    /// <summary>
+    /// Creates an uninitialized slot (for let/const before initialization).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static JsSlot Uninitialized(Symbol name, SlotFlags flags)
+    {
+        return new JsSlot(name, JsValue.Undefined, flags | SlotFlags.Uninitialized);
+    }
+
+    /// <summary>
+    /// Returns true if this slot has not been initialized yet (TDZ).
+    /// </summary>
+    public readonly bool IsUninitialized
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (Flags & SlotFlags.Uninitialized) != 0;
+    }
+
+    /// <summary>
+    /// Returns true if this is a const binding.
+    /// </summary>
+    public readonly bool IsConst
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (Flags & SlotFlags.Const) != 0;
+    }
+
+    /// <summary>
+    /// Returns true if this is a lexical binding (let/const).
+    /// </summary>
+    public readonly bool IsLexical
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (Flags & SlotFlags.Lexical) != 0;
+    }
+
+    /// <summary>
+    /// Returns true if this is a global constant (built-in like undefined, NaN).
+    /// </summary>
+    public readonly bool IsGlobalConstant
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (Flags & SlotFlags.GlobalConstant) != 0;
+    }
+
+    /// <summary>
+    /// Returns true if this binding blocks function-scope override.
+    /// </summary>
+    public readonly bool BlocksFunctionScopeOverride
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (Flags & SlotFlags.BlocksFunctionScopeOverride) != 0;
+    }
+
+    /// <summary>
+    /// Returns true if this binding can be deleted.
+    /// </summary>
+    public readonly bool CanDelete
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (Flags & SlotFlags.CanDelete) != 0;
+    }
+
+    /// <summary>
+    /// Returns true if this binding is immutable (imports).
+    /// </summary>
+    public readonly bool IsImmutableBinding
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (Flags & SlotFlags.ImmutableBinding) != 0;
+    }
+
+    /// <summary>
+    /// Clears the uninitialized flag (called when binding is initialized).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void MarkInitialized()
+    {
+        Flags &= ~SlotFlags.Uninitialized;
+    }
+
+    /// <summary>
+    /// Sets the value and clears the uninitialized flag.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Initialize(JsValue value)
+    {
+        Value = value;
+        Flags &= ~SlotFlags.Uninitialized;
+    }
+
+    /// <summary>
+    /// Returns true if this slot is empty (no name assigned).
+    /// </summary>
+    public readonly bool IsEmpty
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => Name is null;
+    }
+}

--- a/src/Asynkron.JsEngine/JsSlotArrayPool.cs
+++ b/src/Asynkron.JsEngine/JsSlotArrayPool.cs
@@ -1,0 +1,94 @@
+#region
+
+using System.Runtime.CompilerServices;
+
+#endregion
+
+namespace Asynkron.JsEngine;
+
+/// <summary>
+/// Pool for JsSlot[] arrays using fixed-size buckets.
+/// Avoids allocating new arrays for slot storage in environments.
+/// Bucket sizes: 8, 16, 32, 64, 128, 256, 512, 1024
+/// </summary>
+internal static class JsSlotArrayPool
+{
+    private const int PoolSize = 100; // Pre-heat size per bucket
+
+    // Fixed-size bucket pools
+    private static readonly ObjectPool<JsSlot[]> Pool8 = new(PoolSize, static () => new JsSlot[8]);
+    private static readonly ObjectPool<JsSlot[]> Pool16 = new(PoolSize, static () => new JsSlot[16]);
+    private static readonly ObjectPool<JsSlot[]> Pool32 = new(PoolSize, static () => new JsSlot[32]);
+    private static readonly ObjectPool<JsSlot[]> Pool64 = new(PoolSize, static () => new JsSlot[64]);
+    private static readonly ObjectPool<JsSlot[]> Pool128 = new(PoolSize, static () => new JsSlot[128]);
+    private static readonly ObjectPool<JsSlot[]> Pool256 = new(PoolSize, static () => new JsSlot[256]);
+    private static readonly ObjectPool<JsSlot[]> Pool512 = new(PoolSize, static () => new JsSlot[512]);
+    private static readonly ObjectPool<JsSlot[]> Pool1024 = new(PoolSize, static () => new JsSlot[1024]);
+
+    /// <summary>
+    /// Rents an array from the pool with at least the requested capacity.
+    /// The actual array may be larger than requested (rounded up to bucket size).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static JsSlot[] Rent(int minimumLength)
+    {
+        // Round up to nearest bucket size
+        return minimumLength switch
+        {
+            <= 8 => Pool8.Rent(),
+            <= 16 => Pool16.Rent(),
+            <= 32 => Pool32.Rent(),
+            <= 64 => Pool64.Rent(),
+            <= 128 => Pool128.Rent(),
+            <= 256 => Pool256.Rent(),
+            <= 512 => Pool512.Rent(),
+            <= 1024 => Pool1024.Rent(),
+            // For very large arrays, just allocate (rare case)
+            _ => new JsSlot[minimumLength]
+        };
+    }
+
+    /// <summary>
+    /// Returns an array to the pool.
+    /// NOTE: We skip Array.Clear() here because InitializeSlots() always initializes
+    /// all slots which overwrites all entries anyway.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Return(JsSlot[]? array)
+    {
+        if (array is null)
+        {
+            return;
+        }
+
+        // Return to appropriate pool based on length
+        switch (array.Length)
+        {
+            case 8:
+                Pool8.Return(array);
+                break;
+            case 16:
+                Pool16.Return(array);
+                break;
+            case 32:
+                Pool32.Return(array);
+                break;
+            case 64:
+                Pool64.Return(array);
+                break;
+            case 128:
+                Pool128.Return(array);
+                break;
+            case 256:
+                Pool256.Return(array);
+                break;
+            case 512:
+                Pool512.Return(array);
+                break;
+            case 1024:
+                Pool1024.Return(array);
+                break;
+            // Non-pooled sizes are just discarded (will be GC'd)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replace separate `JsValue[]` and `ImmutableDictionary<Symbol, int>` slotMap with unified `JsSlot[]` struct
- Add `JsSlot` struct combining name, value, and flags in one cache-friendly structure
- Add `FindSlotIndex()` for linear scan lookup by symbol name
- Keep `_values` dictionary as fallback for imports/exports (to be removed in follow-up)

## Changes

- **JsSlot.cs**: New struct with `Symbol Name`, `JsValue Value`, `SlotFlags Flags`
- **JsSlotArrayPool.cs**: Pooling for `JsSlot[]` arrays
- **JsEnvironment.cs**: Updated to use `JsSlot[]` with `_slotCount`
- **Evaluator files**: Updated to access `slots[i].Value` instead of `slots[i]`

## Test plan

- [x] Build succeeds (0 errors)
- [x] 2924 tests pass
- [x] 8 pre-existing failures (also fail on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)