### PR TITLE
Fix IR scope-aware identifier slot reads

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -821,8 +821,8 @@ public static partial class TypedAstEvaluator
                                     case LiteralExpression { Value: var lit }:
                                         leftVal = lit;
                                         break;
-                                    case IdentifierExpression { SlotIndex: >= 0, ScopeId: >= 0, Name: var leftName } leftId:
-                                        if (!environment.TryReadSlotValue(leftName, leftId.SlotIndex, context, out leftVal))
+                                    case IdentifierExpression { SlotIndex: >= 0, ScopeId: >= 0 } leftId:
+                                        if (!environment.TryReadIdentifierWithSlot(leftId, context, out leftVal))
                                             goto slowPath;
                                         break;
                                     default:
@@ -836,8 +836,8 @@ public static partial class TypedAstEvaluator
                                     case LiteralExpression { Value: var lit }:
                                         rightVal = lit;
                                         break;
-                                    case IdentifierExpression { SlotIndex: >= 0, ScopeId: >= 0, Name: var rightName } rightId:
-                                        if (!environment.TryReadSlotValue(rightName, rightId.SlotIndex, context, out rightVal))
+                                    case IdentifierExpression { SlotIndex: >= 0, ScopeId: >= 0 } rightId:
+                                        if (!environment.TryReadIdentifierWithSlot(rightId, context, out rightVal))
                                             goto slowPath;
                                         break;
                                     default:
@@ -1297,8 +1297,8 @@ public static partial class TypedAstEvaluator
                                         break;
 
                                     // Fast path: identifier with slot info (direct slot read)
-                                    case IdentifierExpression { SlotIndex: >= 0, ScopeId: >= 0, Name: var rhsName } rhsIdent:
-                                        if (environment.TryReadSlotValue(rhsName, rhsIdent.SlotIndex, context, out compRhsValue))
+                                    case IdentifierExpression { SlotIndex: >= 0, ScopeId: >= 0 } rhsIdent:
+                                        if (environment.TryReadIdentifierWithSlot(rhsIdent, context, out compRhsValue))
                                         {
                                             // Got value from slot
                                         }

--- a/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
+++ b/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
@@ -25,13 +25,26 @@ internal sealed class SlotAssignmentRewriter : AstRewriter
     private readonly Stack<int> _catchScopeStack = new();
     private readonly Dictionary<int, int> _scopeIdRemap = new();
     private readonly Dictionary<int, int> _reverseScopeIdRemap = new();
-    private int _nextSyntheticScopeId = 1;
+    private int _nextSyntheticScopeId;
 
     public SlotAssignmentRewriter(ScopeSlotAnalysis analysis)
     {
         _scopes = analysis.Scopes;
         _immutableSlotMaps = analysis.ImmutableSlotMaps;
         _lexicalBindings = analysis.LexicalBindings;
+
+        // IMPORTANT: synthetic scope ids must not collide with existing scope ids from analysis.
+        // Scope ids from the analyzer are non-negative, so allocate synthetic ids after the max.
+        var maxScopeId = RootScopeId;
+        foreach (var scopeId in _scopes.Keys)
+        {
+            if (scopeId > maxScopeId)
+            {
+                maxScopeId = scopeId;
+            }
+        }
+        _nextSyntheticScopeId = maxScopeId + 1;
+
         _scopeStack.Push(RootScopeId);
     }
 


### PR DESCRIPTION
- Use scope-aware slot reads in IR ExecutionPlanRunner fast paths (branch + compound assignment)
- Prevent SlotAssignmentRewriter synthetic scope-id collisions by allocating after max analyzed scope id

Validation:
- dotnet test tests/Asynkron.JsEngine.Tests --filter FullyQualifiedName~AsyncGenerator_DelayedAwaitInLoopBody