### PR TITLE
Fix scope-aware identifier reads in IR fast paths

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -821,8 +821,8 @@ public static partial class TypedAstEvaluator
                                     case LiteralExpression { Value: var lit }:
                                         leftVal = lit;
                                         break;
-                                    case IdentifierExpression { SlotIndex: >= 0, ScopeId: >= 0, Name: var leftName } leftId:
-                                        if (!environment.TryReadSlotValue(leftName, leftId.SlotIndex, context, out leftVal))
+                                    case IdentifierExpression { SlotIndex: >= 0, ScopeId: >= 0 } leftId:
+                                        if (!environment.TryReadIdentifierWithSlot(leftId, context, out leftVal))
                                             goto slowPath;
                                         break;
                                     default:
@@ -836,8 +836,8 @@ public static partial class TypedAstEvaluator
                                     case LiteralExpression { Value: var lit }:
                                         rightVal = lit;
                                         break;
-                                    case IdentifierExpression { SlotIndex: >= 0, ScopeId: >= 0, Name: var rightName } rightId:
-                                        if (!environment.TryReadSlotValue(rightName, rightId.SlotIndex, context, out rightVal))
+                                    case IdentifierExpression { SlotIndex: >= 0, ScopeId: >= 0 } rightId:
+                                        if (!environment.TryReadIdentifierWithSlot(rightId, context, out rightVal))
                                             goto slowPath;
                                         break;
                                     default:
@@ -1297,8 +1297,8 @@ public static partial class TypedAstEvaluator
                                         break;
 
                                     // Fast path: identifier with slot info (direct slot read)
-                                    case IdentifierExpression { SlotIndex: >= 0, ScopeId: >= 0, Name: var rhsName } rhsIdent:
-                                        if (environment.TryReadSlotValue(rhsName, rhsIdent.SlotIndex, context, out compRhsValue))
+                                    case IdentifierExpression { SlotIndex: >= 0, ScopeId: >= 0 } rhsIdent:
+                                        if (environment.TryReadIdentifierWithSlot(rhsIdent, context, out compRhsValue))
                                         {
                                             // Got value from slot
                                         }

--- a/tests/Asynkron.JsEngine.Tests/SlotStampingPlanTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/SlotStampingPlanTests.cs
@@ -109,4 +109,26 @@ public class SlotStampingPlanTests : IAsyncLifetime
             Assert.Equal(matching.Value, id.SlotIndex);
         }
     }
+
+    [Fact]
+    public async Task BranchFastPath_UsesScopeAwareIdentifierRead()
+    {
+        var result = await _engine.Evaluate(@"
+            let x = 1;
+            function run() {
+                let hit = 0;
+                {
+                    let y = 0;
+                    if (x < 1) {
+                        hit = 1;
+                    }
+                }
+                return hit;
+            }
+            run();
+        ");
+
+        var numericResult = Assert.IsType<double>(result);
+        Assert.Equal(0.0, numericResult);
+    }
 }


### PR DESCRIPTION
## Summary\n- use TryReadIdentifierWithSlot for branch and compound fast paths to respect ScopeId/slot hints\n- add regression test covering branch fast path with outer-scope identifiers\n\n## Testing\n- dotnet test tests/Asynkron.JsEngine.Tests --filter "BranchFastPath_UsesScopeAwareIdentifierRead"