### PR TITLE
Fix per-iteration scope id collisions

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -1547,11 +1547,12 @@ public static partial class TypedAstEvaluator
                                 // The PerIterationBindings check is CRITICAL: it distinguishes loop iteration
                                 // scopes from nested block scopes within the loop body. Without it, nested
                                 // blocks would incorrectly become siblings of their parent iteration scope.
+                                var hasIterationBindings = !pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty;
                                 var isSubsequentIteration =
-                                    (pushEnvInstruction.ScopeId >= 0 && environment.ScopeId == pushEnvInstruction.ScopeId) ||
-                                    (pushEnvInstruction.ScopeId < 0 &&
-                                     !pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty &&
-                                     environment.Description == "scope" && environment.Enclosing != null);
+                                    hasIterationBindings &&
+                                    ((pushEnvInstruction.ScopeId >= 0 && environment.ScopeId == pushEnvInstruction.ScopeId) ||
+                                     (pushEnvInstruction.ScopeId < 0 &&
+                                      environment.Description == "scope" && environment.Enclosing != null));
 
                                 // FAST PATH: For subsequent iterations with pooling enabled (no closures),
                                 // reuse the same environment in-place. The increment (i++) already updated

--- a/src/Asynkron.JsEngine/Execution/IteratorDriverFactory.cs
+++ b/src/Asynkron.JsEngine/Execution/IteratorDriverFactory.cs
@@ -33,6 +33,12 @@ internal static class IteratorDriverFactory
             perIterationBindings = [..bindingNames];
         }
 
+        var iterationScopeId = statement.PerIterationScopeId;
+        if (iterationScopeId < 0 && !perIterationBindings.IsDefaultOrEmpty)
+        {
+            iterationScopeId = SyntheticScopeIdAllocator.Next();
+        }
+
         var perIterationSlotCount = statement.PerIterationSlotCount >= 0
             ? statement.PerIterationSlotCount
             : (!perIterationBindings.IsDefaultOrEmpty ? perIterationBindings.Length : -1);
@@ -49,7 +55,7 @@ internal static class IteratorDriverFactory
             statement.Target,
             statement.DeclarationKind,
             rewrittenBody,
-            statement.PerIterationScopeId,
+            iterationScopeId,
             statement.PerIterationParentScopeId,
             perIterationSlotCount,
             perIterationSlotIndices,

--- a/src/Asynkron.JsEngine/Execution/LoopNormalizer.cs
+++ b/src/Asynkron.JsEngine/Execution/LoopNormalizer.cs
@@ -168,6 +168,11 @@ internal static class LoopNormalizer
             !StatementsContainInnerFunctionExpression(conditionPrologue) &&
             !StatementsContainInnerFunctionExpression(postIteration);
 
+        if (iterationScopeId < 0 && !perIterationBindings.IsDefaultOrEmpty)
+        {
+            iterationScopeId = SyntheticScopeIdAllocator.Next();
+        }
+
         return new LoopPlan(
             kind,
             leading,

--- a/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
+++ b/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
@@ -25,13 +25,22 @@ internal sealed class SlotAssignmentRewriter : AstRewriter
     private readonly Stack<int> _catchScopeStack = new();
     private readonly Dictionary<int, int> _scopeIdRemap = new();
     private readonly Dictionary<int, int> _reverseScopeIdRemap = new();
-    private int _nextSyntheticScopeId = 1;
+    private int _nextSyntheticScopeId;
 
     public SlotAssignmentRewriter(ScopeSlotAnalysis analysis)
     {
         _scopes = analysis.Scopes;
         _immutableSlotMaps = analysis.ImmutableSlotMaps;
         _lexicalBindings = analysis.LexicalBindings;
+        var maxScopeId = 0;
+        foreach (var scopeId in _scopes.Keys)
+        {
+            if (scopeId > maxScopeId)
+            {
+                maxScopeId = scopeId;
+            }
+        }
+        _nextSyntheticScopeId = maxScopeId + 1;
         _scopeStack.Push(RootScopeId);
     }
 

--- a/src/Asynkron.JsEngine/Execution/SyntheticScopeIdAllocator.cs
+++ b/src/Asynkron.JsEngine/Execution/SyntheticScopeIdAllocator.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+
+namespace Asynkron.JsEngine.Execution;
+
+internal static class SyntheticScopeIdAllocator
+{
+    private static int _nextScopeId = -1;
+
+    public static int Next()
+    {
+        return Interlocked.Decrement(ref _nextScopeId);
+    }
+}


### PR DESCRIPTION
Summary:
- allocate unique synthetic scope ids for per-iteration loop bindings when analysis has none
- avoid collisions between per-iteration scopes and block scopes in IR slot stamping
- keep synthetic scope ids offset from analyzed scopes and tighten iteration reuse detection

Tests:
- dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~AsyncIterationTests.ForAwaitOf_WithPromiseArray|FullyQualifiedName~AsyncIterationTests.RegularForOf_WithAwaitInBody|FullyQualifiedName~AsyncIterationTests.RegularForOf_WithAwaitInBodyWithDebug"