### PR TITLE
Fix slot initialization order and scope handling

### DIFF
--- a/src/Asynkron.JsEngine/Ast/ProgramNodeExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ProgramNodeExtensions.cs
@@ -1,6 +1,9 @@
 #region
 
+using System;
+using System.IO;
 using System.Collections.Immutable;
+using System.Linq;
 using Asynkron.JsEngine.Execution;
 using Asynkron.JsEngine.JsTypes;
 using Asynkron.JsEngine.Runtime;
@@ -450,6 +453,79 @@ public static partial class TypedAstEvaluator
                 }
             }
 
+            var hasDynamicScope = !AllowsIdentifierCaching(program);
+            ExecutionPlan? plan = null;
+            if (!hasDynamicScope)
+            {
+                var scriptPlanCache = ((IAstCacheable<ScriptPlanCache>)program).GetOrCreateCache();
+                if (scriptPlanCache.Succeeded)
+                {
+                    plan = scriptPlanCache.Plan!;
+                    // Initialize slots before hoisting so hoisted bindings use stamped slot indices
+                    var rootSlotMap = plan.SafeRootSlotMap;
+                    var mapMax = 0;
+                    foreach (var index in rootSlotMap.Values)
+                    {
+                        var nextIndex = index + 1;
+                        if (nextIndex > mapMax)
+                        {
+                            mapMax = nextIndex;
+                        }
+                    }
+
+                    var requiredSlots = Math.Max(Math.Max(plan.RootSlotCount, mapMax),
+                        plan.SlotSymbols.IsDefaultOrEmpty ? 0 : plan.SlotSymbols.Length);
+                    if (requiredSlots > 0)
+                    {
+                        var rootScopeId = program.ScopeId >= 0 ? program.ScopeId : 0;
+                        executionEnvironment.InitializeSlots(requiredSlots, scopeId: rootScopeId, prependExisting: true);
+                        if (!rootSlotMap.IsEmpty)
+                        {
+                            executionEnvironment.SetSlotMap(rootSlotMap);
+                        }
+                        else if (!plan.SlotSymbols.IsDefaultOrEmpty)
+                        {
+                            var slotMap = ImmutableDictionary.CreateBuilder<Symbol, int>(
+                                ReferenceEqualityComparer<Symbol>.Instance);
+                            for (var i = 0; i < plan.SlotSymbols.Length; i++)
+                            {
+                                slotMap[plan.SlotSymbols[i]] = i;
+                            }
+
+                            executionEnvironment.SetSlotMap(slotMap.ToImmutable());
+                        }
+
+                        var rootLexicals = plan.SafeRootLexicalBindings;
+                        if (!rootLexicals.IsEmpty)
+                        {
+                            executionEnvironment.MarkSlotsLexicalUninitialized(rootLexicals);
+                        }
+
+                        if (Environment.GetEnvironmentVariable("DEBUG_SLOT") == "1")
+                        {
+                            var slotMapText = string.Join(",", rootSlotMap.Select(kv => $"{kv.Key.Name}:{kv.Value}"));
+                            var slotSymbolsText = plan.SlotSymbols.IsDefaultOrEmpty
+                                ? "<none>"
+                                : string.Join(",", plan.SlotSymbols.Select(s => s.Name));
+                            var lexicalText = rootLexicals.IsEmpty
+                                ? "<none>"
+                                : string.Join(",", rootLexicals.Select(l => l.Name));
+                            var planDump = ExecutionPlanPrinter.Print(plan.Instructions, plan.EntryPoint);
+                            File.AppendAllText("/tmp/slotdebug.txt",
+                                $"=== Script Plan IR ==={Environment.NewLine}" +
+                                $"RootSlotCount={plan.RootSlotCount} RootSlotMap=[{slotMapText}] SlotSymbols=[{slotSymbolsText}] Lexicals=[{lexicalText}]{Environment.NewLine}" +
+                                $"{planDump}{Environment.NewLine}");
+                        }
+                    }
+                }
+                else
+                {
+                    context.RealmState.Logger?.LogInformation(
+                        "Script IR building failed: {Reason}. Using AST walking.",
+                        scriptPlanCache.FailureReason ?? "unknown");
+                }
+            }
+
             // Per ES spec, lexical declarations (let/const/class) must be hoisted to create
             // bindings in the TDZ (Temporal Dead Zone) BEFORE function hoisting.
             // This ensures closures that reference lexical variables will find TDZ bindings
@@ -488,8 +564,6 @@ public static partial class TypedAstEvaluator
                 catchParameterNames: catchParameterNames,
                 simpleCatchParameterNames: simpleCatchParameterNames);
 
-            // Dynamic scope constructs (with/eval) require dictionary-based lookups; skip IR/slot stamping.
-            var hasDynamicScope = !AllowsIdentifierCaching(program);
             if (hasDynamicScope)
             {
                 context.RealmState.Logger?.LogInformation("Skipping IR path due to dynamic scope (with/eval).");
@@ -498,32 +572,11 @@ public static partial class TypedAstEvaluator
 
             // Try IR execution path first (unified execution model)
             // Fall back to AST walking if IR building fails or encounters unsupported constructs
-            var scriptPlanCache = ((IAstCacheable<ScriptPlanCache>)program).GetOrCreateCache();
-            if (scriptPlanCache.Succeeded)
+            if (plan is not null)
             {
-                var plan = scriptPlanCache.Plan!;
                 context.RealmState.Logger?.LogInformation(
                     "Executing script via IR path ({InstructionCount} instructions)",
                     plan.Instructions.Length);
-
-                // Initialize slots for execution plan internal variables (iterator states, etc.)
-                // This is needed for for-of loops and other IR constructs that store state in slots.
-                // NOTE: Skip slot initialization for scripts with dynamic scope features (with/eval)
-                // because slot-based lookup would bypass the with-scope check.
-                // NOTE: For scripts, hoisting happens before this point, so hoisted bindings
-                // are already in slots. We use direct 0-based indices and rely on the IR
-                // using different symbol names (internal __* symbols vs user variables).
-                if (plan.SlotCount > 0 && !plan.SlotSymbols.IsDefaultOrEmpty)
-                {
-                    executionEnvironment.InitializeSlots(plan.SlotCount, scopeId: 0);
-                    var slotMap = ImmutableDictionary.CreateBuilder<Symbol, int>(
-                        ReferenceEqualityComparer<Symbol>.Instance);
-                    for (var i = 0; i < plan.SlotSymbols.Length; i++)
-                    {
-                        slotMap[plan.SlotSymbols[i]] = i;
-                    }
-                    executionEnvironment.SetSlotMap(slotMap.ToImmutable());
-                }
 
                 try
                 {
@@ -551,13 +604,6 @@ public static partial class TypedAstEvaluator
                     // Continue to AST walking path below
                 }
             }
-            else
-            {
-                context.RealmState.Logger?.LogInformation(
-                    "Script IR building failed: {Reason}. Using AST walking.",
-                    scriptPlanCache.FailureReason ?? "unknown");
-            }
-
             // AST walking fallback path
             var resultJs = JsValue.Unit;
             foreach (var statement in program.Body)

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -1547,11 +1547,16 @@ public static partial class TypedAstEvaluator
                                 // The PerIterationBindings check is CRITICAL: it distinguishes loop iteration
                                 // scopes from nested block scopes within the loop body. Without it, nested
                                 // blocks would incorrectly become siblings of their parent iteration scope.
-                                var isSubsequentIteration =
-                                    (pushEnvInstruction.ScopeId >= 0 && environment.ScopeId == pushEnvInstruction.ScopeId) ||
-                                    (pushEnvInstruction.ScopeId < 0 &&
-                                     !pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty &&
-                                     environment.Description == "scope" && environment.Enclosing != null);
+                                var hasIterationBindings = !pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty;
+                                var isScopeMatch = hasIterationBindings &&
+                                                   pushEnvInstruction.ScopeId >= 0 &&
+                                                   environment.ScopeId == pushEnvInstruction.ScopeId &&
+                                                   environment.Description == "scope";
+                                var isHeuristicMatch = hasIterationBindings &&
+                                                       pushEnvInstruction.ScopeId < 0 &&
+                                                       environment.Description == "scope" &&
+                                                       environment.Enclosing != null;
+                                var isSubsequentIteration = isScopeMatch || isHeuristicMatch;
 
                                 // FAST PATH: For subsequent iterations with pooling enabled (no closures),
                                 // reuse the same environment in-place. The increment (i++) already updated
@@ -1565,7 +1570,7 @@ public static partial class TypedAstEvaluator
                                 // 4. The "new" iteration environment would have the same values anyway
                                 if (isSubsequentIteration &&
                                     pushEnvInstruction.AllowPooling &&
-                                    !pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty)
+                                    hasIterationBindings)
                                 {
                                     // Just continue using the same environment - bindings already have correct values
                                     _programCounter = pushEnvInstruction.Next;
@@ -1590,7 +1595,7 @@ public static partial class TypedAstEvaluator
                                 var allowPooling = pushEnvInstruction.AllowPooling;
                                 // Use different description for loop scope (empty bindings) vs per-iteration scope
                                 // This allows the subsequent iteration heuristic to correctly distinguish them
-                                var description = pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty ? "loop-scope" : "scope";
+                                var description = hasIterationBindings ? "scope" : "loop-scope";
                                 var newIterationEnv = allowPooling
                                     ? JsEnvironmentPool.Rent(loopScope, false, false, null, description, logger: _realmState.Logger)
                                     : new JsEnvironment(loopScope, false, false, null, description);
@@ -1611,7 +1616,7 @@ public static partial class TypedAstEvaluator
                                 }
 
                                 // Copy per-iteration bindings from appropriate source (for loop iterations)
-                                if (previousIterEnv != null && !pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty)
+                                if (previousIterEnv != null && hasIterationBindings)
                                 {
                                     // Copy from previous iteration (fast slot path if available)
                                     var useSlotCopy = newIterationEnv.HasSlots &&
@@ -1647,7 +1652,7 @@ public static partial class TypedAstEvaluator
                                         JsEnvironmentPool.Return(previousIterEnv, _realmState.Logger);
                                     }
                                 }
-                                else if (!pushEnvInstruction.PerIterationBindings.IsDefaultOrEmpty)
+                                else if (hasIterationBindings)
                                 {
                                     // First iteration - copy from loopScope where binding was defined
                                     // Preserve const flag to ensure TypeError is thrown on reassignment

--- a/src/Asynkron.JsEngine/Execution/ExecutionPlanBuilder.cs
+++ b/src/Asynkron.JsEngine/Execution/ExecutionPlanBuilder.cs
@@ -133,11 +133,7 @@ internal sealed partial class ExecutionPlanBuilder
         // 2. Scripts may contain 'with' statements that require dynamic identifier resolution
         // 3. Slot-based lookup would bypass the with-scope, breaking 'with' semantics
         // For functions, slot assignment is fine because scope analysis happens at parse time.
-        ScopeSlotAnalysis? analysis = null;
-        if (!_isScriptLevel)
-        {
-            analysis = AssignSlotsToUserVariables(entryIndex, function);
-        }
+        ScopeSlotAnalysis? analysis = AssignSlotsToUserVariables(entryIndex, function);
 
         var rootSlotCount = analysis is not null && analysis.Scopes.TryGetValue(0, out var rootInfo)
             ? rootInfo.SlotCount
@@ -279,6 +275,10 @@ internal sealed partial class ExecutionPlanBuilder
             {
                 sb.AppendLine($"  {id.Name.Name} scope={id.ScopeId} slot={id.SlotIndex}");
             }
+
+            sb.AppendLine(
+                $"=== Plan IR ({function.Name?.Name ?? "<anonymous>"}) ==={Environment.NewLine}{ExecutionPlanPrinter.Print(_instructions, entryIndex)}");
+            sb.AppendLine("=== End Plan ===");
 
             Console.WriteLine(sb.ToString());
             File.AppendAllText("/tmp/slotdebug.txt", sb.ToString());

--- a/src/Asynkron.JsEngine/Execution/IdentifierCollector.cs
+++ b/src/Asynkron.JsEngine/Execution/IdentifierCollector.cs
@@ -290,6 +290,74 @@ internal sealed class ScopeSlotCollector : AstVisitor
         }
     }
 
+    private void RegisterDeclaration(VariableKind kind, BindingTarget binding)
+    {
+        var targetScope = kind == VariableKind.Var ? RootScopeId : CurrentScopeId;
+        if (kind == VariableKind.Var &&
+            targetScope == RootScopeId &&
+            binding is IdentifierBinding idBinding &&
+            _bindingScopeHints.TryGetValue(idBinding.Name, out var hintedScope))
+        {
+            targetScope = hintedScope;
+        }
+
+        RegisterBindingTargetSlots(binding, targetScope, kind);
+    }
+
+    private void RegisterBindingTargetSlots(BindingTarget target, int scopeId, VariableKind kind)
+    {
+        while (true)
+        {
+            switch (target)
+            {
+                case IdentifierBinding identifier:
+                    AllocateSlotInScope(scopeId, identifier.Name);
+                    var scopeInfo = GetOrCreateScopeInfo(scopeId);
+                    if (kind == VariableKind.Var)
+                    {
+                        scopeInfo.LexicalBindings.Remove(identifier.Name);
+                    }
+                    else
+                    {
+                        scopeInfo.LexicalBindings.Add(identifier.Name);
+                    }
+
+                    return;
+                case ArrayBinding arrayBinding:
+                    foreach (var element in arrayBinding.Elements)
+                    {
+                        if (element.Target is not null)
+                        {
+                            RegisterBindingTargetSlots(element.Target, scopeId, kind);
+                        }
+                    }
+
+                    if (arrayBinding.RestElement is not null)
+                    {
+                        target = arrayBinding.RestElement;
+                        continue;
+                    }
+
+                    return;
+                case ObjectBinding objectBinding:
+                    foreach (var property in objectBinding.Properties)
+                    {
+                        RegisterBindingTargetSlots(property.Target, scopeId, kind);
+                    }
+
+                    if (objectBinding.RestElement is not null)
+                    {
+                        target = objectBinding.RestElement;
+                        continue;
+                    }
+
+                    return;
+                default:
+                    return;
+            }
+        }
+    }
+
     public void VisitInstruction(ExecutionInstruction instruction)
     {
         switch (instruction)
@@ -405,17 +473,22 @@ internal sealed class ScopeSlotCollector : AstVisitor
         }
     }
 
-    protected override void VisitIdentifier(IdentifierExpression node)
-    {
-        // Compiler-generated identifiers (resume slots, iterator state, etc.) live in the root scope.
-        if (node.Name.Name.StartsWith('\u0001'))
-        {
-            AllocateSlotInScope(RootScopeId, node.Name);
-        }
-    }
-
     protected override void VisitStatement(StatementNode statement)
     {
+        if (statement is VariableDeclaration varDecl)
+        {
+            foreach (var declarator in varDecl.Declarators)
+            {
+                RegisterDeclaration(varDecl.Kind, declarator.Target);
+                if (declarator.Initializer is not null)
+                {
+                    VisitExpression(declarator.Initializer);
+                }
+            }
+
+            return;
+        }
+
         if (statement is FunctionDeclaration funcDecl)
         {
             // Function declarations are hoisted to the function/global scope.
@@ -424,6 +497,15 @@ internal sealed class ScopeSlotCollector : AstVisitor
         }
 
         base.VisitStatement(statement);
+    }
+
+    protected override void VisitIdentifier(IdentifierExpression node)
+    {
+        // Compiler-generated identifiers (resume slots, iterator state, etc.) live in the root scope.
+        if (node.Name.Name.StartsWith('\u0001'))
+        {
+            AllocateSlotInScope(RootScopeId, node.Name);
+        }
     }
 
     private static ImmutableArray<Symbol> CollectParameterSymbols(FunctionExpression? function)

--- a/src/Asynkron.JsEngine/Execution/IteratorDriverFactory.cs
+++ b/src/Asynkron.JsEngine/Execution/IteratorDriverFactory.cs
@@ -43,13 +43,19 @@ internal static class IteratorDriverFactory
                 ? Enumerable.Repeat(-1, perIterationBindings.Length).ToImmutableArray()
                 : ImmutableArray<int>.Empty);
 
+        var iterationScopeId = statement.PerIterationScopeId;
+        if (!perIterationBindings.IsDefaultOrEmpty && iterationScopeId < 0)
+        {
+            iterationScopeId = SyntheticScopeIdAllocator.Next();
+        }
+
         return new IteratorDriverPlan(
             kind,
             statement.Iterable,
             statement.Target,
             statement.DeclarationKind,
             rewrittenBody,
-            statement.PerIterationScopeId,
+            iterationScopeId,
             statement.PerIterationParentScopeId,
             perIterationSlotCount,
             perIterationSlotIndices,

--- a/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
+++ b/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
@@ -33,6 +33,26 @@ internal sealed class SlotAssignmentRewriter : AstRewriter
         _immutableSlotMaps = analysis.ImmutableSlotMaps;
         _lexicalBindings = analysis.LexicalBindings;
         _scopeStack.Push(RootScopeId);
+        // Start synthetic scope ids after the max existing id to avoid collisions
+        var maxExistingScopeId = _scopes.Count > 0 ? _scopes.Keys.Max() : RootScopeId;
+        _nextSyntheticScopeId = maxExistingScopeId + 1;
+    }
+
+    protected override StatementNode RewriteStatement(StatementNode statement)
+    {
+        if (statement is BlockStatement block)
+        {
+            var mappedScope = RemapScopeId(block.ScopeId);
+            return block with
+            {
+                ScopeId = mappedScope,
+                SlotCount = GetSlotCount(mappedScope),
+                SlotMap = GetSlotMap(mappedScope),
+                Statements = RewriteStatementList(block.Statements)
+            };
+        }
+
+        return base.RewriteStatement(statement);
     }
 
     public void RewriteInstructions(IList<ExecutionInstruction> instructions, int entryIndex)

--- a/src/Asynkron.JsEngine/Execution/SyntheticScopeIdAllocator.cs
+++ b/src/Asynkron.JsEngine/Execution/SyntheticScopeIdAllocator.cs
@@ -1,0 +1,20 @@
+#region
+
+using System.Threading;
+
+#endregion
+
+namespace Asynkron.JsEngine.Execution;
+
+/// <summary>
+/// Generates unique synthetic (negative) scope ids for IR constructs that need
+/// distinct scopes even when the analyzer did not stamp an id (e.g. per-iteration scopes).
+/// Using unique ids avoids collisions when SlotAssignmentRewriter remaps negatives
+/// to positive scope ids.
+/// </summary>
+internal static class SyntheticScopeIdAllocator
+{
+    private static int _next = -2;
+
+    public static int Next() => Interlocked.Decrement(ref _next);
+}

--- a/src/Asynkron.JsEngine/JsEnvironment.cs
+++ b/src/Asynkron.JsEngine/JsEnvironment.cs
@@ -332,12 +332,18 @@ public sealed class JsEnvironment : IRentable
             }
 
             slot.Value = value;
-            // Upgrade lexical flags if needed
-            if (isLexical) slot.Flags |= SlotFlags.Lexical;
-            if (blocksFunctionScopeOverride) slot.Flags |= SlotFlags.BlocksFunctionScopeOverride;
-            if (value.IsUninitialized) slot.Flags |= SlotFlags.Uninitialized;
-            // Clear uninitialized flag when setting an initialized value (TDZ completion)
-            if (!value.IsUninitialized) slot.Flags &= ~SlotFlags.Uninitialized;
+            // Upgrade flags when the slot was pre-created (e.g., via SetSlotMap).
+            var updatedFlags = slot.Flags;
+            if (isConst) updatedFlags |= SlotFlags.Const;
+            if (isGlobalConstant) updatedFlags |= SlotFlags.GlobalConstant;
+            if (isLexical) updatedFlags |= SlotFlags.Lexical;
+            if (blocksFunctionScopeOverride) updatedFlags |= SlotFlags.BlocksFunctionScopeOverride;
+            if (canDelete) updatedFlags |= SlotFlags.CanDelete;
+            if (isImmutableBinding) updatedFlags |= SlotFlags.ImmutableBinding;
+            updatedFlags = value.IsUninitialized
+                ? updatedFlags | SlotFlags.Uninitialized
+                : updatedFlags & ~SlotFlags.Uninitialized;
+            slot.Flags = updatedFlags;
 
             if (_bindingObservers is not null)
             {
@@ -3437,7 +3443,7 @@ public sealed class JsEnvironment : IRentable
     /// <param name="slotCount">Number of slots needed for this scope.</param>
     /// <param name="scopeId">Unique ID for this scope from scope analysis.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void InitializeSlots(int slotCount, int scopeId)
+    internal void InitializeSlots(int slotCount, int scopeId, bool prependExisting = false)
     {
         ScopeId = scopeId;
 
@@ -3447,26 +3453,55 @@ public sealed class JsEnvironment : IRentable
         var existingCount = _slotCount;
         if (existingCount > 0)
         {
-            // Ensure we have capacity for existing slots + new slots
-            var neededCapacity = existingCount + slotCount;
-            if (_slots is null || _slots.Length < neededCapacity)
+            if (prependExisting)
             {
-                var oldSlots = _slots;
-                _slots = JsSlotArrayPool.Rent(neededCapacity);
-                if (oldSlots is not null)
+                var neededCapacity = existingCount + slotCount;
+                if (_slots is null || _slots.Length < neededCapacity)
                 {
-                    Array.Copy(oldSlots, _slots, existingCount);
-                    JsSlotArrayPool.Return(oldSlots);
+                    var oldSlots = _slots;
+                    _slots = JsSlotArrayPool.Rent(neededCapacity);
+                    if (oldSlots is not null && existingCount > 0)
+                    {
+                        Array.Copy(oldSlots, 0, _slots, slotCount, existingCount);
+                        JsSlotArrayPool.Return(oldSlots);
+                    }
                 }
+                else if (existingCount > 0 && slotCount > 0)
+                {
+                    Array.Copy(_slots, 0, _slots, slotCount, existingCount);
+                }
+
+                if (slotCount > 0)
+                {
+                    Array.Clear(_slots!, 0, slotCount);
+                }
+
+                _slotCount = neededCapacity;
+                return;
             }
-            // Clear only the new slots (after existing ones)
-            if (slotCount > 0)
+            else
             {
-                Array.Clear(_slots, existingCount, slotCount);
+                // Ensure we have capacity for existing slots + new slots
+                var neededCapacity = existingCount + slotCount;
+                if (_slots is null || _slots.Length < neededCapacity)
+                {
+                    var oldSlots = _slots;
+                    _slots = JsSlotArrayPool.Rent(neededCapacity);
+                    if (oldSlots is not null)
+                    {
+                        Array.Copy(oldSlots, _slots, existingCount);
+                        JsSlotArrayPool.Return(oldSlots);
+                    }
+                }
+                // Clear only the new slots (after existing ones)
+                if (slotCount > 0)
+                {
+                    Array.Clear(_slots, existingCount, slotCount);
+                }
+                // Keep _slotCount as the sum of existing + new
+                _slotCount = neededCapacity;
+                return;
             }
-            // Keep _slotCount as the sum of existing + new
-            _slotCount = neededCapacity;
-            return;
         }
 
         _slotCount = slotCount;


### PR DESCRIPTION
## Summary

- Move slot initialization before hoisting so hoisted bindings use stamped slot indices
- Add `prependExisting` option to `InitializeSlots` for correct slot layout when combining IR slots with hoisted bindings
- Add `RegisterDeclaration` method to `IdentifierCollector` to properly handle variable declarations with slot allocation
- Add `SyntheticScopeIdAllocator` for unique negative scope IDs in IR constructs that need distinct scopes
- Improve `BlockStatement` handling in `SlotAssignmentRewriter` with proper scope remapping
- Fix iteration scope detection logic in `ExecutionPlanRunner` to correctly identify loop iterations vs nested blocks

## Test plan

- [ ] Run `dotnet build` to verify compilation
- [ ] Run `dotnet test tests/Asynkron.JsEngine.Tests` to verify all tests pass
- [ ] Verify slot-based lookups work correctly with hoisted bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)