### PR TITLE
Ensure slot rewriter visits loop/try edges and persist await env

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -3358,6 +3358,7 @@ public static partial class TypedAstEvaluator
             // Remember which await site is pending so we can stash the
             // resolved value on resume.
             AsyncStateRef.PendingAwaitKey = awaitKey;
+            _executionEnvironment = environment;
             _state = GeneratorState.Suspended;
             _programCounter = _currentInstructionIndex;
             context.SetPendingAwait();

--- a/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
+++ b/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
@@ -69,6 +69,55 @@ internal sealed class SlotAssignmentRewriter : AstRewriter
     {
         switch (instruction)
         {
+            case IteratorMoveNextInstruction moveNext:
+                if (moveNext.Next >= 0)
+                {
+                    yield return moveNext.Next;
+                }
+                if (moveNext.BreakIndex >= 0)
+                {
+                    yield return moveNext.BreakIndex;
+                }
+                yield break;
+
+            case EnterTryInstruction enterTry:
+                if (enterTry.Next >= 0)
+                {
+                    yield return enterTry.Next;
+                }
+                if (enterTry.HandlerIndex >= 0)
+                {
+                    yield return enterTry.HandlerIndex;
+                }
+                if (enterTry.FinallyIndex >= 0)
+                {
+                    yield return enterTry.FinallyIndex;
+                }
+                if (enterTry.LoopContinueTarget >= 0)
+                {
+                    yield return enterTry.LoopContinueTarget;
+                }
+                if (enterTry.LoopBreakTarget >= 0)
+                {
+                    yield return enterTry.LoopBreakTarget;
+                }
+                yield break;
+
+            case BreakableEnterInstruction breakableEnter:
+                if (breakableEnter.Next >= 0)
+                {
+                    yield return breakableEnter.Next;
+                }
+                if (breakableEnter.ContinueTarget >= 0)
+                {
+                    yield return breakableEnter.ContinueTarget;
+                }
+                if (breakableEnter.BreakTarget >= 0)
+                {
+                    yield return breakableEnter.BreakTarget;
+                }
+                yield break;
+
             case BranchInstruction branch:
                 yield return branch.ConsequentIndex;
                 yield return branch.AlternateIndex;


### PR DESCRIPTION
## Summary
- traverse IteratorMoveNext, EnterTry (handler/finally/loop targets), and BreakableEnter successors so slot stamping rewrites loop bodies and try/catch/finally branches
- persist the current execution environment when suspending on pending await to resume with the correct scope

## Testing
- dotnet test tests/Asynkron.JsEngine.Tests (14 failures remain in the known async for-of/async generator/env-pooling cluster: AsyncGenerator_SwitchInBody; AsyncIterationTests.ForAwaitOf_WithPromiseArray; RegularForOf_WithAwaitInBody; RegularForOf_WithAwaitInBodyWithDebug; CpsTransformDebugTests.ForOf_WithConsoleLog_Debug; SimpleForOf_WithAwait_Debug; EnvironmentPoolingTests.ForOfLoop_WithClosureInsideBody_ClosuresCaptureEnvironments; LabeledLoop_WithBreak_EnvironmentsReturned; NestedForOfLoops_IndependentPooling; GeneratorTests.Generator_ForAwaitPromiseValuesAreAwaitedIr; NpmPackageTests.Fibonacci_IterativeVersion; plus the remaining async-generator/for-of cases from the todo list)