### PR TITLE
Fix script-level slot index collision for for-of loops

### DIFF
--- a/src/Asynkron.JsEngine/Execution/ExecutionPlanBuilder.cs
+++ b/src/Asynkron.JsEngine/Execution/ExecutionPlanBuilder.cs
@@ -42,6 +42,7 @@ internal sealed partial class ExecutionPlanBuilder
     private int _catchSlotCounter;
     private string? _failureReason;
     private bool _isScriptLevel;
+    private int _initialSlotOffset; // Offset for slot indices at script level (to avoid collision with hoisted bindings)
     private int _resumeSlotCounter;
     private int _scopeIdCounter = 1; // Start at 1 because 0 is reserved for function-level scope
     private int _withScopeSlotCounter;
@@ -49,10 +50,12 @@ internal sealed partial class ExecutionPlanBuilder
 
     /// <summary>
     /// Allocates a new slot index for a generator-internal symbol.
+    /// At script level, indices are offset by _initialSlotOffset to avoid collision
+    /// with hoisted lexical bindings that already occupy slots 0..N-1.
     /// </summary>
     internal int AllocateSlot(Symbol symbol)
     {
-        var index = _slotSymbols.Count;
+        var index = _slotSymbols.Count + _initialSlotOffset;
         _slotSymbols.Add(symbol);
         return index;
     }
@@ -86,8 +89,13 @@ internal sealed partial class ExecutionPlanBuilder
     ///     When true, indicates this is a top-level script (not a function body).
     ///     Script-level var declarations must update the global object.
     /// </param>
+    /// <param name="initialSlotOffset">
+    ///     At script level, hoisting creates slots for lexical declarations before IR building.
+    ///     This offset ensures IR slot indices start after hoisted slots to avoid collision.
+    ///     For functions, this should be 0.
+    /// </param>
     public static bool TryBuild(FunctionExpression function, out ExecutionPlan plan, out string? failureReason,
-        bool reportDiagnostics = true, bool isScriptLevel = false)
+        bool reportDiagnostics = true, bool isScriptLevel = false, int initialSlotOffset = 0)
     {
         // First run the yield-lowering pre-pass so that ExecutionPlanBuilder
         // can assume a simplified, pauseable-function-friendly AST. The lowerer currently acts
@@ -105,7 +113,7 @@ internal sealed partial class ExecutionPlanBuilder
             return false;
         }
 
-        var builder = new ExecutionPlanBuilder { _isScriptLevel = isScriptLevel };
+        var builder = new ExecutionPlanBuilder { _isScriptLevel = isScriptLevel, _initialSlotOffset = initialSlotOffset };
         var succeeded = builder.TryBuildInternal(lowered, out plan);
         failureReason = builder._failureReason ?? lowerFailure;
 

--- a/src/Asynkron.JsEngine/Execution/ScriptPlanCache.cs
+++ b/src/Asynkron.JsEngine/Execution/ScriptPlanCache.cs
@@ -34,6 +34,11 @@ internal sealed class ScriptPlanCache
 
     public static ScriptPlanCache Build(ProgramNode program)
     {
+        // Count hoisted lexical declarations (let/const/class at script level).
+        // At execution time, these will occupy slots 0..N-1 before IR slots.
+        // We need to offset IR slot indices to avoid collision.
+        var hoistedSlotCount = CountHoistedLexicalDeclarations(program);
+
         // Create a synthetic function expression that wraps the script body.
         // This allows us to reuse the existing ExecutionPlanBuilder infrastructure.
         var syntheticFunction = new FunctionExpression(
@@ -55,12 +60,93 @@ internal sealed class ScriptPlanCache
         // Don't report diagnostics for script-level IR builds - these are separate from
         // function IR builds that tests track via ExecutionPlanDiagnostics.
         // Pass isScriptLevel: true so var declarations will update the global object.
+        // Pass hoistedSlotCount so IR slot indices start after hoisted bindings.
         if (ExecutionPlanBuilder.TryBuild(syntheticFunction, out var plan, out var failureReason,
-            reportDiagnostics: false, isScriptLevel: true))
+            reportDiagnostics: false, isScriptLevel: true, initialSlotOffset: hoistedSlotCount))
         {
             return new ScriptPlanCache(plan, syntheticFunction, null);
         }
 
         return new ScriptPlanCache(null, null, failureReason ?? "Script contains unsupported construct for execution plan.");
+    }
+
+    /// <summary>
+    /// Counts the number of top-level lexical declarations (let/const/class) that will be
+    /// hoisted and occupy slots at execution time. This is used to offset IR slot indices
+    /// to avoid collision with hoisted bindings.
+    /// </summary>
+    private static int CountHoistedLexicalDeclarations(ProgramNode program)
+    {
+        var count = 0;
+        foreach (var statement in program.Body)
+        {
+            switch (statement)
+            {
+                case VariableDeclaration { Kind: VariableKind.Let or VariableKind.Const or VariableKind.Using or VariableKind.AwaitUsing } lexDecl:
+                    count += CountBindingTargets(lexDecl);
+                    break;
+                case ClassDeclaration:
+                    count++;
+                    break;
+            }
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// Counts the number of individual bindings in a variable declaration.
+    /// For simple declarations like 'const x = 1', this is 1.
+    /// For destructuring like 'const {a, b} = obj', this counts each binding.
+    /// </summary>
+    private static int CountBindingTargets(VariableDeclaration decl)
+    {
+        var count = 0;
+        foreach (var declarator in decl.Declarators)
+        {
+            count += CountBindingNames(declarator.Target);
+        }
+        return count;
+    }
+
+    private static int CountBindingNames(BindingTarget target)
+    {
+        return target switch
+        {
+            IdentifierBinding => 1,
+            ArrayBinding arrayBinding => CountArrayBindingNames(arrayBinding),
+            ObjectBinding objectBinding => CountObjectBindingNames(objectBinding),
+            _ => 0
+        };
+    }
+
+    private static int CountArrayBindingNames(ArrayBinding binding)
+    {
+        var count = 0;
+        foreach (var element in binding.Elements)
+        {
+            if (element.Target is not null)
+            {
+                count += CountBindingNames(element.Target);
+            }
+        }
+        if (binding.RestElement is not null)
+        {
+            count += CountBindingNames(binding.RestElement);
+        }
+        return count;
+    }
+
+    private static int CountObjectBindingNames(ObjectBinding binding)
+    {
+        var count = 0;
+        foreach (var prop in binding.Properties)
+        {
+            count += CountBindingNames(prop.Target);
+        }
+        if (binding.RestElement is not null)
+        {
+            count += CountBindingNames(binding.RestElement);
+        }
+        return count;
     }
 }


### PR DESCRIPTION
## Summary

- Fix slot index collision at script level where hoisting creates slots before IR execution
- Add `initialSlotOffset` parameter to `ExecutionPlanBuilder.TryBuild` to offset IR slot indices past hoisted bindings
- Add `CountHoistedLexicalDeclarations` in `ScriptPlanCache` to count lexical declarations (let/const/class/using) at build time

## Problem

At script level, lexical declarations like `const funcs = []` are hoisted and occupy slot 0. When IR instructions are generated for for-of loops, they also allocate slots starting at 0 for iterator temps (e.g., `__forOf_iter_2`), causing collision.

Example:
```javascript
const funcs = [];  // hoisted → slot 0
for (const x of [1,2,3]) {  // IR allocates __forOf_iter_2 → slot 0 (collision!)
  funcs.push(() => x);
}
```

## Solution

Count hoisted lexical declarations at IR build time and offset all slot allocations by that count. This ensures IR slots start after hoisted binding slots.

## Test Results

- 3 of 4 originally failing tests now pass:
  - ✅ `EnvironmentPoolingTests.ForOfLoop_WithClosureInsideBody_ClosuresCaptureEnvironments`
  - ✅ `EnvironmentPoolingTests.LabeledLoop_WithBreak_EnvironmentsReturned`
  - ✅ `EnvironmentPoolingTests.NestedForOfLoops_IndependentPooling`
- 1 failure (`SlotStampingTests.ForAwait_PerIteration_Bindings_Are_Stamped_With_Slots`) is a pre-existing bug, not caused by this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)