### PR TITLE
Add block scope handling to slot analysis and assignment

### DIFF
--- a/src/Asynkron.JsEngine/Execution/IdentifierCollector.cs
+++ b/src/Asynkron.JsEngine/Execution/IdentifierCollector.cs
@@ -26,6 +26,8 @@ internal sealed class ScopeSlotCollector : AstVisitor
     private readonly bool[] _visited;
     private readonly Dictionary<int, ScopeSlotInfo> _scopes = new();
     private readonly Stack<int> _scopeStack = new();
+    private readonly Dictionary<BlockStatement, int> _blockScopeIds = new(ReferenceEqualityComparer<BlockStatement>.Instance);
+    private int _nextBlockScopeId = 1000; // Reserve lower IDs for IR-generated scopes
 
     public ScopeSlotCollector(IEnumerable<ExecutionInstruction> instructions,
         IReadOnlyList<Symbol> existingRootSlots,
@@ -57,7 +59,7 @@ internal sealed class ScopeSlotCollector : AstVisitor
             lexicalBindings[scopeId] = info.LexicalBindings.ToImmutableHashSet(ReferenceEqualityComparer<Symbol>.Instance);
         }
 
-        return new ScopeSlotAnalysis(_scopes, immutableSlotMaps, lexicalBindings);
+        return new ScopeSlotAnalysis(_scopes, immutableSlotMaps, lexicalBindings, _blockScopeIds);
     }
 
     private void TraverseFrom(int index)
@@ -425,6 +427,45 @@ internal sealed class ScopeSlotCollector : AstVisitor
         base.VisitStatement(statement);
     }
 
+    protected override void VisitBlockStatement(BlockStatement block)
+    {
+        // Check if this block needs its own lexical scope (has let/const declarations)
+        var hoistPlan = ((IAstCacheable<HoistPlan>)block).GetOrCreateCache();
+        if (!hoistPlan.NeedsEnvironment)
+        {
+            // No lexical bindings - just visit children without creating a scope
+            base.VisitBlockStatement(block);
+            return;
+        }
+
+        // Create a new scope for this block
+        var blockScopeId = _nextBlockScopeId++;
+        _blockScopeIds[block] = blockScopeId;
+
+        // Enter the block scope
+        var info = GetOrCreateScopeInfo(blockScopeId);
+
+        // Pre-allocate slots for lexical bindings in this block
+        foreach (var lexName in hoistPlan.LexicalNames)
+        {
+            var slotIndex = info.NextSlotIndex++;
+            info.IncludeSlot(lexName, slotIndex);
+            info.LexicalBindings.Add(lexName);
+        }
+
+        info.SlotCountHint = Math.Max(info.SlotCountHint, hoistPlan.LexicalNames.Count);
+
+        _scopeStack.Push(blockScopeId);
+        try
+        {
+            base.VisitBlockStatement(block);
+        }
+        finally
+        {
+            _scopeStack.Pop();
+        }
+    }
+
     private static ImmutableArray<Symbol> CollectParameterSymbols(FunctionExpression? function)
     {
         if (function is null)
@@ -497,14 +538,17 @@ internal sealed class ScopeSlotAnalysis
     public ScopeSlotAnalysis(
         Dictionary<int, ScopeSlotInfo> scopes,
         Dictionary<int, ImmutableDictionary<Symbol, int>> immutableSlotMaps,
-        Dictionary<int, ImmutableHashSet<Symbol>> lexicalBindings)
+        Dictionary<int, ImmutableHashSet<Symbol>> lexicalBindings,
+        Dictionary<BlockStatement, int> blockScopeIds)
     {
         Scopes = scopes;
         ImmutableSlotMaps = immutableSlotMaps;
         LexicalBindings = lexicalBindings;
+        BlockScopeIds = blockScopeIds;
     }
 
     public Dictionary<int, ScopeSlotInfo> Scopes { get; }
     public Dictionary<int, ImmutableDictionary<Symbol, int>> ImmutableSlotMaps { get; }
     public Dictionary<int, ImmutableHashSet<Symbol>> LexicalBindings { get; }
+    public Dictionary<BlockStatement, int> BlockScopeIds { get; }
 }

--- a/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
+++ b/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
@@ -20,6 +20,7 @@ internal sealed class SlotAssignmentRewriter : AstRewriter
     private readonly Dictionary<int, ScopeSlotInfo> _scopes;
     private readonly Dictionary<int, ImmutableDictionary<Symbol, int>> _immutableSlotMaps;
     private readonly Dictionary<int, ImmutableHashSet<Symbol>> _lexicalBindings;
+    private readonly Dictionary<BlockStatement, int> _blockScopeIds;
     private readonly Stack<int> _scopeStack = new();
     private readonly Stack<int> _catchScopeStack = new();
     private readonly Dictionary<int, int> _scopeIdRemap = new();
@@ -31,6 +32,7 @@ internal sealed class SlotAssignmentRewriter : AstRewriter
         _scopes = analysis.Scopes;
         _immutableSlotMaps = analysis.ImmutableSlotMaps;
         _lexicalBindings = analysis.LexicalBindings;
+        _blockScopeIds = analysis.BlockScopeIds;
         var maxScopeId = 0;
         foreach (var scopeId in _scopes.Keys)
         {
@@ -253,6 +255,36 @@ internal sealed class SlotAssignmentRewriter : AstRewriter
             default:
                 return instruction;
         }
+    }
+
+    protected override StatementNode RewriteStatement(StatementNode statement)
+    {
+        // Handle BlockStatement specially to stamp with scope metadata
+        if (statement is BlockStatement block && _blockScopeIds.TryGetValue(block, out var scopeId))
+        {
+            // Push the block's scope onto the stack for rewriting children
+            _scopeStack.Push(scopeId);
+            try
+            {
+                // Rewrite children in this scope
+                var rewrittenStatements = RewriteStatementList(block.Statements);
+
+                // Stamp the block with its scope metadata
+                return block with
+                {
+                    Statements = rewrittenStatements,
+                    ScopeId = scopeId,
+                    SlotCount = GetSlotCount(scopeId),
+                    SlotMap = GetSlotMap(scopeId)
+                };
+            }
+            finally
+            {
+                _scopeStack.Pop();
+            }
+        }
+
+        return base.RewriteStatement(statement);
     }
 
     protected override IdentifierExpression RewriteIdentifier(IdentifierExpression node)

--- a/tests/Asynkron.JsEngine.Tests/BlockScopeShadowingDebugTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/BlockScopeShadowingDebugTests.cs
@@ -1,0 +1,197 @@
+using Asynkron.JsEngine.Tests.Helpers;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+using Asynkron.JsEngine.Ast;
+
+namespace Asynkron.JsEngine.Tests;
+
+public class BlockScopeShadowingDebugTests(ITestOutputHelper output) : InternalTestBase(output)
+{
+    [Fact]
+    public async Task SimpleBlockShadowing_DirectReturn()
+    {
+        // Simplest possible test case - no function, just a block
+        await using var engine = new JsEngine();
+
+        var result = await engine.Evaluate("""
+            let x = 1;
+            {
+                let x = 2;
+                x;
+            }
+            """);
+
+        Output.WriteLine($"Result: {result}");
+        // The last expression in the block should be 2 (the shadowed x)
+        Assert.Equal(2.0, (double)result!);
+    }
+
+    [Fact]
+    public async Task DebugBlockScopeIdStamping()
+    {
+        // Let's trace what happens with scope IDs
+        var source = """
+            let x = 1;
+            {
+                let x = 2;
+                x;
+            }
+            """;
+
+        await using var engine = new JsEngine();
+
+        // Parse the program
+        var program = engine.ParseProgram(source);
+
+        // Find the BlockStatement and check its ScopeId/SlotMap
+        Output.WriteLine("Program body:");
+        foreach (var stmt in program.Body)
+        {
+            Output.WriteLine($"  {stmt.GetType().Name}");
+            if (stmt is BlockStatement block)
+            {
+                Output.WriteLine($"    ScopeId={block.ScopeId} SlotCount={block.SlotCount}");
+                Output.WriteLine($"    SlotMap count={block.SlotMap.Count}");
+                foreach (var kv in block.SlotMap)
+                {
+                    Output.WriteLine($"    SlotMap[{kv.Key}]={kv.Value}");
+                }
+            }
+        }
+
+        // Execute the program
+        var result = await engine.Evaluate(program);
+        Output.WriteLine($"Result: {result}");
+    }
+
+
+    [Fact]
+    public async Task InnerBlockShadowsOuterLetVariable()
+    {
+        // This is the exact pattern from Test262
+        await using var engine = new JsEngine();
+
+        var result = await engine.Evaluate("""
+            (function() {
+                function fn(a) {
+                    let b = 1;
+                    {
+                        let a = 2;
+                        let b = 2;
+                        return [a, b];
+                    }
+                }
+                return fn(1);
+            })();
+            """);
+
+        Output.WriteLine($"Result: {result}");
+
+        var array = Assert.IsType<JsTypes.JsArray>(result);
+        var elem0 = array.GetElement(0).AsDouble();
+        var elem1 = array.GetElement(1).AsDouble();
+
+        Output.WriteLine($"elem0 = {elem0}, elem1 = {elem1}");
+
+        // The inner block should shadow both 'a' and 'b'
+        Assert.Equal(2.0, elem0);  // inner a = 2
+        Assert.Equal(2.0, elem1);  // inner b = 2
+    }
+
+    [Fact]
+    public async Task InnerBlockShadowsOuterLetVariableWithLogging()
+    {
+        // Same test but with debug logging to understand what's happening
+        await using var engine = CreateEngine();
+
+        var result = await engine.Evaluate("""
+            (function() {
+                function fn(a) {
+                    let b = 1;
+                    {
+                        let a = 2;
+                        let b = 2;
+                        return [a, b];
+                    }
+                }
+                return fn(1);
+            })();
+            """);
+
+        Output.WriteLine($"Result: {result}");
+
+        var array = Assert.IsType<JsTypes.JsArray>(result);
+        var elem0 = array.GetElement(0).AsDouble();
+        var elem1 = array.GetElement(1).AsDouble();
+
+        Output.WriteLine($"elem0 = {elem0}, elem1 = {elem1}");
+
+        Assert.Equal(2.0, elem0);
+        Assert.Equal(2.0, elem1);
+    }
+
+    [Fact]
+    public async Task SimpleBlockShadowing()
+    {
+        // Minimal test case to understand shadowing
+        await using var engine = new JsEngine();
+
+        var result = await engine.Evaluate("""
+            (function() {
+                let x = 1;
+                {
+                    let x = 2;
+                    return x;
+                }
+            })();
+            """);
+
+        Output.WriteLine($"Result: {result}");
+        Assert.Equal(2.0, (double)result!);
+    }
+
+    [Fact]
+    public async Task SimpleBlockShadowingInScript()
+    {
+        // Top-level script version (no wrapping IIFE)
+        await using var engine = new JsEngine();
+
+        var result = await engine.Evaluate("""
+            let x = 1;
+            let result;
+            {
+                let x = 2;
+                result = x;
+            }
+            result;
+            """);
+
+        Output.WriteLine($"Result: {result}");
+        Assert.Equal(2.0, (double)result!);
+    }
+
+    [Fact]
+    public async Task ClosureAccessesBlockScopedVariable()
+    {
+        // This is the exact Test262 failure case: closure inside a block
+        await using var engine = new JsEngine();
+
+        var result = await engine.Evaluate("""
+            function outer() {
+                let x = 1;
+                {
+                    let z = 2;
+                    function inner() {
+                        return z;  // closure should access block-scoped z
+                    }
+                    return inner();
+                }
+            }
+            outer();
+            """);
+
+        Output.WriteLine($"Result: {result}");
+        Assert.Equal(2.0, (double)result!);
+    }
+}


### PR DESCRIPTION
## Summary
- IdentifierCollector now tracks block-scoped let/const declarations with their own scope IDs (starting at 1000)
- SlotAssignmentRewriter stamps BlockStatement nodes with ScopeId, SlotCount, and SlotMap metadata
- ScopeSlotAnalysis now carries BlockScopeIds mapping for runtime environment creation

## Test plan
- [x] Added BlockScopeShadowingDebugTests for block scope scenarios
- [ ] Run `dotnet test --filter "FullyQualifiedName~BlockScopeShadowing"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)