### PR TITLE
Fix nested function closure scope collision

### DIFF
--- a/src/Asynkron.JsEngine/Execution/ExecutionPlanBuilder.cs
+++ b/src/Asynkron.JsEngine/Execution/ExecutionPlanBuilder.cs
@@ -203,9 +203,11 @@ internal sealed partial class ExecutionPlanBuilder
         // Stamp iterator driver bodies (executed via AST) with slot metadata so identifiers resolve to slots.
         StampIteratorBodies(function, rewriter);
 
-        // Stamp nested function bodies so that closures can reference outer scope variables.
-        // This is critical for closures accessing block-scoped variables.
-        StampNestedFunctionBodies(function, rewriter, analysis);
+        // Nested function stamping disabled - scope IDs in IR plans are not globally unique
+        // across nested functions (all use RootScopeId=0). Unresolved identifiers in nested
+        // functions fall back to dynamic lookup which correctly traverses the closure chain.
+        // See issue #351 for details. Re-enable once unique scope IDs are implemented (PR #355).
+        // StampNestedFunctionBodies(function, rewriter, analysis);
 
         return analysis;
     }


### PR DESCRIPTION
## Summary
- Disables `StampNestedFunctionBodies` to fix scope ID collision bug
- Nested functions now use dynamic lookup for outer scope variables
- All 2968 tests pass

## Problem
`StampNestedFunctionBodies` uses `RootScopeId=0` for all functions. When nested functions are stamped with slot hints like `(scopeId=0, slotIndex=X)`, at runtime the inner function looks for `scopeId=0` in its **own** environment (which also has `scopeId=0`) instead of traversing to the captured closure.

This caused the `StrictMode_NestedFunctions` test to fail with `NaN` because `x` was found as `undefined` in the wrong scope.

## Solution
Disable `StampNestedFunctionBodies` so nested function closures fall back to dynamic (dictionary-based) lookup which correctly traverses the closure chain.

## Trade-off
- **Before**: O(1) slot lookup (broken)
- **After**: O(n) chain traversal (correct)

## Future Work
Re-enable once unique scope IDs are implemented (see WIP PRs #353, #354, #355).

Fixes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)