### PR TITLE
Fix block-scoped function closures not capturing block variables

### DIFF
--- a/src/Asynkron.JsEngine/Ast/HoistPlan.cs
+++ b/src/Asynkron.JsEngine/Ast/HoistPlan.cs
@@ -445,6 +445,13 @@ internal sealed class HoistPlan
                     lexicalKindMap[classDeclaration.Name] = false;
                     break;
 
+                case FunctionDeclaration functionDeclaration:
+                    // Block-scoped function declarations are lexical bindings
+                    names.Add(functionDeclaration.Name);
+                    // Function declarations create mutable bindings (can be reassigned)
+                    lexicalKindMap[functionDeclaration.Name] = false;
+                    break;
+
                 // NO recursion into other statement types - they have their own scopes
             }
         }

--- a/src/Asynkron.JsEngine/Ast/StatementNodeExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/StatementNodeExtensions.cs
@@ -263,15 +263,10 @@ public static partial class TypedAstEvaluator
                         }
 
                         // In strict mode, block-level function declarations are block-scoped only
-                        // (no Annex B var-style hoisting). Skip hoisting when we are inside a block.
+                        // (no Annex B var-style hoisting). Skip hoisting entirely - the block's
+                        // FunctionDeclarationInstruction will create the binding at runtime.
                         if (inBlockScope && context.CurrentScope.IsStrict)
                         {
-                            environment.DefineJsValue(
-                                functionDeclaration.Name,
-                                JsValue.Uninitialized,
-                                isConst: true,
-                                isLexicalBinding: true,
-                                blocksFunctionScopeOverride: true);
                             break;
                         }
 

--- a/src/Asynkron.JsEngine/Execution/Emitters/BlockEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/BlockEmitter.cs
@@ -55,7 +55,6 @@ internal static class BlockEmitter
     private static bool TryEmitBlockWithEnvironment(
         EmitContext ctx,
         BlockStatement block,
-        // ReSharper disable once UnusedParameter.Local
         HoistPlan hoistPlan,
         int nextIndex,
         out int entryIndex)
@@ -65,12 +64,15 @@ internal static class BlockEmitter
         // Check if we can pool the environment (no closures or dynamic scope)
         var allowPooling = !DynamicScopeDetector.ContainsWithOrDirectEval(block) && !ContainsInnerFunctionExpression(block);
 
-        // Get scope info from the block (stamped by scope analysis)
-        var scopeId = block.ScopeId >= 0 ? block.ScopeId : -1;
-        var slotCount = block.SlotCount >= 0 ? block.SlotCount : 0;
-        var slotMap = block.SlotMap.IsEmpty
-            ? ImmutableDictionary<Symbol, int>.Empty.WithComparers(ReferenceEqualityComparer<Symbol>.Instance)
-            : block.SlotMap;
+        // Build slot map from hoistPlan.TopLevelLexicalNames at IR build time.
+        // This is necessary because scope analysis runs AFTER IR is built - we can't rely on
+        // block.SlotMap being populated yet. TopLevelLexicalNames contains all lexical bindings
+        // (let/const/class/function declarations) directly in this block.
+        var slotMap = BuildSlotMap(hoistPlan.TopLevelLexicalNames);
+        var slotCount = slotMap.Count;
+
+        // Allocate a scope ID for this block (will be remapped during scope analysis)
+        var scopeId = ctx.AllocateScopeId();
 
         // Build instructions bottom-up (reverse order):
         // 1. PopEnvironmentInstruction pointing to nextIndex
@@ -99,8 +101,30 @@ internal static class BlockEmitter
             scopeId,
             slotCount,
             slotMap,
-            allowPooling));
+            allowPooling,
+            SourceBlock: block));
 
         return true;
+    }
+
+    /// <summary>
+    /// Builds an immutable slot map from a set of lexical names.
+    /// Each symbol gets a sequential slot index starting from 0.
+    /// </summary>
+    private static ImmutableDictionary<Symbol, int> BuildSlotMap(HashSet<Symbol> lexicalNames)
+    {
+        if (lexicalNames.Count == 0)
+        {
+            return ImmutableDictionary<Symbol, int>.Empty.WithComparers(ReferenceEqualityComparer<Symbol>.Instance);
+        }
+
+        var builder = ImmutableDictionary.CreateBuilder<Symbol, int>(ReferenceEqualityComparer<Symbol>.Instance);
+        var slotIndex = 0;
+        foreach (var name in lexicalNames)
+        {
+            builder[name] = slotIndex++;
+        }
+
+        return builder.ToImmutable();
     }
 }

--- a/src/Asynkron.JsEngine/Execution/IdentifierCollector.cs
+++ b/src/Asynkron.JsEngine/Execution/IdentifierCollector.cs
@@ -178,7 +178,8 @@ internal sealed class ScopeSlotCollector : AstVisitor
     private void EnterScope(int scopeId,
         ImmutableDictionary<Symbol, int> slotMap,
         ImmutableArray<Symbol> perIterationBindings,
-        int slotCount)
+        int slotCount,
+        BlockStatement? sourceBlock = null)
     {
         var info = GetOrCreateScopeInfo(scopeId);
         if (!slotMap.IsEmpty)
@@ -198,6 +199,13 @@ internal sealed class ScopeSlotCollector : AstVisitor
                 AllocateSlotInScope(scopeId, binding);
                 info.LexicalBindings.Add(binding);
             }
+        }
+
+        // Register block-to-scopeId mapping if a source block was provided.
+        // This enables SlotAssignmentRewriter to stamp the BlockStatement with scope metadata.
+        if (sourceBlock is not null && !_blockScopeIds.ContainsKey(sourceBlock))
+        {
+            _blockScopeIds[sourceBlock] = scopeId;
         }
 
         if (slotCount > 0)
@@ -288,7 +296,7 @@ internal sealed class ScopeSlotCollector : AstVisitor
         switch (instruction)
         {
             case PushEnvironmentInstruction push:
-                EnterScope(push.ScopeId, push.SlotMap, push.PerIterationBindings, push.SlotCount);
+                EnterScope(push.ScopeId, push.SlotMap, push.PerIterationBindings, push.SlotCount, push.SourceBlock);
                 return;
 
             case PopEnvironmentInstruction pop:

--- a/src/Asynkron.JsEngine/Execution/Instructions/Instructions.cs
+++ b/src/Asynkron.JsEngine/Execution/Instructions/Instructions.cs
@@ -186,7 +186,8 @@ internal sealed record PushEnvironmentInstruction(
     bool AllowPooling = false,
     ImmutableHashSet<Symbol>? LexicalBindings = null,
     ImmutableArray<(int SlotIndex, int FlatSlotId)> FlatSlotMappings = default,
-    ImmutableArray<(Symbol Name, int SlotIndex)> SlotNames = default)
+    ImmutableArray<(Symbol Name, int SlotIndex)> SlotNames = default,
+    BlockStatement? SourceBlock = null)
     : ExecutionInstruction(InstructionKind.PushEnvironment, Next);
 
 /// <summary>

--- a/tests/Asynkron.JsEngine.Tests/BlockScopeClosureTest.cs
+++ b/tests/Asynkron.JsEngine.Tests/BlockScopeClosureTest.cs
@@ -81,6 +81,7 @@ public sealed class BlockScopeClosureTest(ITestOutputHelper output) : InternalTe
 
         // First parse and inspect the AST
         var program = engine.ParseProgram("""
+            "use strict";
             function outer() {
                 {
                     let z = 42;
@@ -94,7 +95,7 @@ public sealed class BlockScopeClosureTest(ITestOutputHelper output) : InternalTe
             """);
 
         // Debug output
-        var outerDecl = program.Body[0] as FunctionDeclaration;
+        var outerDecl = program.Body.OfType<FunctionDeclaration>().FirstOrDefault();
         Output.WriteLine($"outer function found: {outerDecl != null}");
         if (outerDecl != null)
         {
@@ -198,7 +199,12 @@ public sealed class BlockScopeClosureTest(ITestOutputHelper output) : InternalTe
                     log.Message.Contains("TraceLookup") ||
                     log.Message.Contains("SyncFunctionInvoker") ||
                     log.Message.Contains("TryResolve") ||
-                    log.Message.Contains("Invoke.ALL"))
+                    log.Message.Contains("Invoke.ALL") ||
+                    log.Message.Contains("ENSURE_ENV") ||
+                    log.Message.Contains("CLOSURE_CHAIN") ||
+                    log.Message.Contains("[IR:") ||
+                    log.Message.Contains("[FUNC_DECL]") ||
+                    log.Message.Contains("PushEnv:"))
                 {
                     Output.WriteLine(log.Message);
                 }


### PR DESCRIPTION
## Summary
- Add FunctionDeclaration to HoistPlan.CollectTopLevelLexical so block-scoped functions get slots allocated
- Build slot map from TopLevelLexicalNames in BlockEmitter at IR build time
- Add SourceBlock parameter to PushEnvironmentInstruction for scope mapping
- Update ScopeSlotCollector.EnterScope to register block-to-scopeId mapping
- Remove StatementNodeExtensions DefineJsValue call for strict block functions (binding handled at runtime)
- Restore yield/await check in BlockEmitter to avoid regressions

## Test plan
- [x] All 3053 internal tests pass
- [x] BlockScopeClosureTests pass (including ClosureInBlock_AccessesBlockVariable)
- [x] ScopeIdentityTests pass
- [x] AsyncFunction_WithParallelDelays passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)