### PR TITLE
Fix nested function scope stamping and switch break resolution

### DIFF
--- a/src/Asynkron.JsEngine/Execution/Emitters/SwitchEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/SwitchEmitter.cs
@@ -274,7 +274,14 @@ internal static class SwitchEmitter
         // This pops the breakable stack when exiting the switch (normal exit or break)
         var breakableExitIndex = ctx.Append(new BreakableExitInstruction(nextIndex));
 
-        if (!ctx.TryBuildStatement(lowered, breakableExitIndex, out var switchBodyEntry, activeLabel))
+        // Push a loop scope so break statements in nested blocks (e.g., try/catch inside
+        // switch cases) can resolve their targets during IR building. ContinueTarget is -1
+        // because switch statements do not support continue.
+        ctx.PushLoopScope(activeLabel, -1, breakableExitIndex, -1);
+        var bodyBuilt = ctx.TryBuildStatement(lowered, breakableExitIndex, out var switchBodyEntry, activeLabel);
+        ctx.PopLoopScope();
+
+        if (!bodyBuilt)
         {
             ctx.Rollback(instructionStart);
             entryIndex = -1;

--- a/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
+++ b/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
@@ -30,6 +30,13 @@ internal sealed class SlotAssignmentRewriter : AstRewriter
     private readonly int _mappedRootScopeId;
 
     /// <summary>
+    /// When true, we're re-stamping nested function instructions from an outer context.
+    /// In this mode, we skip overwriting identifiers that are already resolved to scopes
+    /// not on the current stack (i.e., inner function scopes).
+    /// </summary>
+    private bool _isRestampingNestedFunction;
+
+    /// <summary>
     /// Maps (scopeId, slotIndex) pairs to flat slot IDs for O(1) variable access.
     /// </summary>
     private readonly Dictionary<(int scopeId, int slotIndex), int> _flatSlotMap = new();
@@ -181,9 +188,19 @@ internal sealed class SlotAssignmentRewriter : AstRewriter
             _scopeStack.Push(enclosingScopeId);
         }
 
-        var result = RewriteInstruction(instruction);
-        RestoreStack(scopeSnapshot, []);
-        return result;
+        // Set the flag to indicate we're re-stamping nested function instructions.
+        // This prevents overwriting identifiers already resolved to inner scopes.
+        _isRestampingNestedFunction = true;
+        try
+        {
+            var result = RewriteInstruction(instruction);
+            return result;
+        }
+        finally
+        {
+            _isRestampingNestedFunction = false;
+            RestoreStack(scopeSnapshot, []);
+        }
     }
 
     public int GetSlotCountForScope(int mappedScopeId)
@@ -384,6 +401,29 @@ internal sealed class SlotAssignmentRewriter : AstRewriter
 
     protected override IdentifierExpression RewriteIdentifier(IdentifierExpression node)
     {
+        // When re-stamping nested function instructions, skip identifiers already resolved
+        // to inner scopes (not on the current stack). This prevents outer scope re-stamping
+        // from overwriting correctly resolved inner scope bindings.
+        if (_isRestampingNestedFunction && node.ScopeId >= 0 && node.SlotIndex >= 0)
+        {
+            // Check if the identifier's scope is on the current stack
+            var isOnStack = false;
+            foreach (var scopeId in _scopeStack)
+            {
+                if (scopeId == node.ScopeId)
+                {
+                    isOnStack = true;
+                    break;
+                }
+            }
+
+            // If resolved to a scope not on our stack, it's an inner scope - leave it alone
+            if (!isOnStack)
+            {
+                return node;
+            }
+        }
+
         if (TryResolve(node.Name, out var resolution))
         {
             var flatSlotId = GetOrCreateFlatSlotId(resolution.scopeId, resolution.slotIndex);


### PR DESCRIPTION
## Summary

- **Prevent StampNestedFunctionBodies from overwriting inner scope identifiers** by adding `_isRestampingNestedFunction` flag to `SlotAssignmentRewriter`
- **Fix SwitchEmitter to push loop scope** for break statement resolution in nested blocks (e.g., try/catch inside switch cases)
- **Add tracing infrastructure** to `ExecutionPlanDiagnostics` for debugging scope issues
- **Expand `NestedFunctionScopeRegressionTests`** with detailed diagnostics for verifying correct scope resolution

## Problem

When `StampNestedFunctionBodies` re-stamps nested function instructions with the parent's rewriter, it was incorrectly overwriting identifiers that had already been resolved to inner scope bindings. This caused shadowed variables (e.g., `let baseValue` inside an if-block shadowing an outer `baseValue`) to resolve to the wrong scope.

### Example of affected code:
```javascript
function outer(seed) {
    let baseValue = seed;
    function inner(flag) {
        if (flag) {
            let baseValue = seed + 100;  // Shadowed
            return baseValue;  // Should return 110
        }
        return baseValue;  // Should return 10
    }
    return inner;
}
const fn = outer(10);
[fn(false), fn(true), fn(false)]  // Expected: "10,110,10"
```

Before fix: `"10,10,10"` (inner `baseValue` incorrectly resolved to outer scope)
After fix: `"10,110,10"` (correct)

## Solution

Added `_isRestampingNestedFunction` flag that:
1. Is set in `StampInstructionInScope` during nested function re-stamping
2. Is checked in `RewriteIdentifier` to skip identifiers already resolved to scopes not on the current stack (inner scopes)

This preserves correctly resolved inner scope bindings during the outer function's re-stamping pass.

## Test plan

- [x] `NestedFunctionCapturesOuterLetAfterReturn` passes
- [x] `ShadowingInsideInnerDoesNotCorruptOuterClosure` passes  
- [x] `ShadowedVariables_ShouldHaveDifferentScopes` passes
- [x] All 3053 internal tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)