### PR TITLE
Add AST-free assertion guard and StatementInstruction inventory

### DIFF
--- a/src/Asynkron.JsEngine/Ast/ExpressionNodeExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ExpressionNodeExtensions.cs
@@ -148,6 +148,14 @@ public static partial class TypedAstEvaluator
         private JsValue EvaluateExpression(JsEnvironment environment,
             EvaluationContext context)
         {
+#if DEBUG
+            // Guard: detect AST evaluation during IR-only execution (see #398, #415, #364)
+            if (EvaluationContext.AssertNoAstEvaluation)
+            {
+                throw new InvalidOperationException(
+                    $"AST evaluation invoked for {expression.GetType().Name} during IR execution");
+            }
+#endif
             return expression switch
             {
                 // Explicit if statements generate less IL than switch expressions

--- a/src/Asynkron.JsEngine/Ast/StatementNodeExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/StatementNodeExtensions.cs
@@ -21,6 +21,14 @@ public static partial class TypedAstEvaluator
             EvaluationContext context,
             Symbol? activeLabel = null)
         {
+#if DEBUG
+            // Guard: detect AST evaluation during IR-only execution (see #398, #415, #364)
+            if (EvaluationContext.AssertNoAstEvaluation)
+            {
+                throw new InvalidOperationException(
+                    $"AST evaluation invoked for {statement.GetType().Name} during IR execution");
+            }
+#endif
             context.SourceReference = statement.Source;
             context.ThrowIfCancellationRequested();
 

--- a/src/Asynkron.JsEngine/EvaluationContext.cs
+++ b/src/Asynkron.JsEngine/EvaluationContext.cs
@@ -21,6 +21,15 @@ public sealed class EvaluationContext(
     CancellationToken cancellationToken = default,
     ExecutionKind executionKind = ExecutionKind.Script) : IRentable
 {
+#if DEBUG
+    /// <summary>
+    ///     When set to true, any AST evaluation during IR execution will throw an
+    ///     InvalidOperationException. Used in tests to verify AST-free execution paths.
+    ///     Related to issues #398, #415, #364 (IR-only execution epic).
+    /// </summary>
+    internal static bool AssertNoAstEvaluation { get; set; }
+#endif
+
     private readonly Stack<Symbol> _functionNameHints = new();
 
     /// <summary>

--- a/src/Asynkron.JsEngine/Execution/Emitters/BlockEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/BlockEmitter.cs
@@ -39,7 +39,9 @@ internal static class BlockEmitter
                 return TryEmitBlockWithEnvironment(ctx, block, hoistPlan, nextIndex, out entryIndex);
             }
 
-            // For blocks without yield/await, StatementInstruction is fine
+            // AST fallback: block with lexical bindings but no yield/await
+            // Reason: Environment creation without yield/await is simpler via AST eval
+            // Tracking: #398, #416 (IR-only execution epic)
             entryIndex = ctx.Append(new StatementInstruction(nextIndex, block));
             return true;
         }

--- a/src/Asynkron.JsEngine/Execution/Emitters/DeclarationEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/DeclarationEmitter.cs
@@ -71,6 +71,9 @@ internal static class DeclarationEmitter
         // the value is undefined. Wrap them as StatementInstruction.
         if (DeclarationContainsYieldInBindingTargetDefaults(declaration))
         {
+            // AST fallback: var decl with yield in binding target defaults
+            // Reason: Conditional yield semantics in destructuring defaults
+            // Tracking: #398, #416 (IR-only execution epic)
             entryIndex = ctx.Append(new StatementInstruction(nextIndex, declaration));
             return true;
         }

--- a/src/Asynkron.JsEngine/Execution/Emitters/ExpressionStatementEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/ExpressionStatementEmitter.cs
@@ -44,6 +44,9 @@ internal static class ExpressionStatementEmitter
         // Wrap them as StatementInstruction to use AST evaluation's state-saving.
         if (EmitContext.ExpressionContainsDestructuringWithYieldAnywhere(expressionStatement.Expression))
         {
+            // AST fallback: expression statement with yield in destructuring
+            // Reason: Conditional yield semantics in destructuring defaults/targets
+            // Tracking: #398, #416 (IR-only execution epic)
             entryIndex = ctx.Append(new StatementInstruction(nextIndex, expressionStatement));
             return true;
         }

--- a/src/Asynkron.JsEngine/Execution/Emitters/StatementEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/StatementEmitter.cs
@@ -71,7 +71,9 @@ internal static class StatementEmitter
                     return TryEmitter.TryEmitTry(ctx, tryStatement, nextIndex, activeLabel, out entryIndex);
 
                 case ForEachStatement { Kind: ForEachKind.In } forInStatement:
-                    // For-in loops delegate to AST evaluator via StatementInstruction
+                    // AST fallback: for-in loops delegate to AST evaluator via StatementInstruction
+                    // Reason: No dedicated IR instructions for property enumeration
+                    // Tracking: #398, #416 (IR-only execution epic)
                     entryIndex = ctx.Append(new StatementInstruction(nextIndex, forInStatement));
                     return true;
 
@@ -109,6 +111,9 @@ internal static class StatementEmitter
                     // so the AST evaluator can handle labeled break/continue correctly
                     if (labeled.Statement is ForEachStatement { Kind: ForEachKind.In })
                     {
+                        // AST fallback: labeled for-in wrapper
+                        // Reason: Wraps the for-in AST fallback to preserve label semantics
+                        // Tracking: #398, #416 (IR-only execution epic)
                         entryIndex = ctx.Append(new StatementInstruction(nextIndex, labeled));
                         return true;
                     }
@@ -238,6 +243,9 @@ internal static class StatementEmitter
             !AstShapeAnalyzer.StatementContainsYield(forEachStatement.Body) &&
             !AstShapeAnalyzer.ContainsYield(forEachStatement.Iterable))
         {
+            // AST fallback: for-of with yield in binding target
+            // Reason: Conditional yield semantics in destructuring defaults
+            // Tracking: #398, #416 (IR-only execution epic)
             entryIndex = ctx.Append(new StatementInstruction(nextIndex, forEachStatement));
             return true;
         }
@@ -270,7 +278,9 @@ internal static class StatementEmitter
             return WithEmitter.TryEmitWith(ctx, withStatement, nextIndex, activeLabel, out entryIndex);
         }
 
-        // If no yield in body, emit as a simple statement instruction
+        // AST fallback: with statement (no yield in body)
+        // Reason: Dynamic scope semantics not yet supported in IR-only mode
+        // Tracking: #398, #416 (IR-only execution epic)
         entryIndex = ctx.Append(new StatementInstruction(nextIndex, withStatement));
         return true;
     }


### PR DESCRIPTION
## Summary
- Add debug-only assertion guard to detect AST evaluation during IR-only execution
- Complete and confirm inventory of all StatementInstruction fallback usages
- Add tracking comments to all AST fallback sites linking to tracking issues

## Changes

### Subtask #415: AST-free assertion guard
- Added `EvaluationContext.AssertNoAstEvaluation` static property (DEBUG builds only)
- Added assertion checks in `StatementNodeExtensions.EvaluateStatementJsValue`
- Added assertion checks in `ExpressionNodeExtensions.EvaluateExpression`
- When enabled, throws `InvalidOperationException` if AST evaluation is invoked during IR execution

### Subtask #416: StatementInstruction inventory
Confirmed all 7 StatementInstruction usages across 4 emitter files:

| File | Line | Construct | Reason |
|------|------|-----------|--------|
| StatementEmitter.cs | 77 | for-in loop | No dedicated IR instructions for property enumeration |
| StatementEmitter.cs | 117 | labeled for-in | Wraps the for-in AST fallback to preserve label semantics |
| StatementEmitter.cs | 249 | for-of with yield in binding | Conditional yield semantics in destructuring defaults |
| StatementEmitter.cs | 284 | with statement (no yield) | Dynamic scope semantics not yet supported in IR-only mode |
| ExpressionStatementEmitter.cs | 50 | expr stmt with yield in destructuring | Conditional yield semantics in destructuring defaults/targets |
| BlockEmitter.cs | 45 | block with lexical bindings (no yield/await) | Environment creation without yield/await is simpler via AST eval |
| DeclarationEmitter.cs | 77 | var decl with yield in binding target defaults | Conditional yield semantics in destructuring defaults |

## Test plan
- [x] `dotnet build` succeeds with 0 warnings, 0 errors
- [x] `dotnet test tests/Asynkron.JsEngine.Tests` passes (3057 passed, 0 failed, 13 skipped)
- [x] Assertion guard implemented with DEBUG conditional
- [x] Inventory confirmed complete with tracking comments

Fixes #415
Fixes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an AST-free execution guard and documents remaining AST fallbacks for clarity and testing.
> 
> - DEBUG guard: `EvaluationContext.AssertNoAstEvaluation` with checks in `TypedAstEvaluator` (`EvaluateExpression`, `EvaluateStatementJsValue`) to throw if AST runs during IR-only execution
> - Annotates and confirms all `StatementInstruction` fallbacks in emitters:
>   - `StatementEmitter`: `for-in`, labeled `for-in`, `for-of` with yield in binding target, `with` (no-yield body)
>   - `ExpressionStatementEmitter`: expression statements with destructuring yields
>   - `BlockEmitter`: blocks with lexical bindings (no yield/await)
>   - `DeclarationEmitter`: var declarations with yield in binding target defaults
> - Adds tracking comments linking to issues `#398`, `#415`, `#416`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 981d6a679a93d32fb9b45663598d43fd56a218f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added DEBUG-only validation guards to detect AST evaluation during IR-only execution, enabling better error detection during testing.

* **Documentation**
  * Enhanced inline comments explaining AST fallback behavior and edge case handling for destructuring expressions and yield statements.

* **Bug Fixes**
  * Improved handling of variable declarations and expressions with yield in binding targets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->