### PR TITLE
Task 1 (partial): Remove StatementInstruction for with statements

### DIFF
--- a/src/Asynkron.JsEngine/Execution/Emitters/BlockEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/BlockEmitter.cs
@@ -50,9 +50,8 @@ internal static class BlockEmitter
     }
 
     /// <summary>
-    /// Builds a block that needs its own environment AND contains yield/await.
-    /// Instead of using StatementInstruction (which causes duplicate execution on resume),
-    /// we emit PushEnvironment + individual statements + PopEnvironment.
+    /// Builds a block that needs its own environment.
+    /// Emits PushEnvironment + individual statements + PopEnvironment for proper IR execution.
     /// </summary>
     private static bool TryEmitBlockWithEnvironment(
         EmitContext ctx,

--- a/src/Asynkron.JsEngine/Execution/Emitters/StatementEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/StatementEmitter.cs
@@ -272,17 +272,9 @@ internal static class StatementEmitter
             return false;
         }
 
-        // If the body contains yield, we need to use EnterWith/LeaveWith instructions
-        if (AstShapeAnalyzer.StatementContainsYield(withStatement.Body))
-        {
-            return WithEmitter.TryEmitWith(ctx, withStatement, nextIndex, activeLabel, out entryIndex);
-        }
-
-        // AST fallback: with statement (no yield in body)
-        // Reason: Dynamic scope semantics not yet supported in IR-only mode
-        // Tracking: #398, #416 (IR-only execution epic)
-        entryIndex = ctx.Append(new StatementInstruction(nextIndex, withStatement));
-        return true;
+        // Always use EnterWith/LeaveWith instructions for proper IR execution.
+        // This removes the StatementInstruction fallback for with statements.
+        return WithEmitter.TryEmitWith(ctx, withStatement, nextIndex, activeLabel, out entryIndex);
     }
 
     // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Remove `StatementInstruction` fallback for `with` statements - now always uses `EnterWith`/`LeaveWith` IR instructions
- Update comment in `TryEmitBlockWithEnvironment` to reflect current behavior

This is a **partial implementation** of Task 1 (#399). The with statement change (#406) is complete and all 3062 tests pass.

## What's Completed
- **#406 (with statements)**: Removed the yield-check conditional and now always uses `WithEmitter.TryEmitWith` which emits `EnterWithInstruction` and `LeaveWithInstruction`
- **#407, #408, #409**: Already implemented - these use dedicated IR instructions (`ComplexVariableDeclarationInstruction`, `ClassDeclarationInstruction`, `EvaluateAndDiscardInstruction`)

## What's Blocked/Requires Additional Work
- **#404 (block statements with lexical bindings)**: Removing the `StatementInstruction` fallback causes 17 test failures. The issue is related to environment management when exceptions are thrown inside blocks that need lexical environments. The current IR path (`PushEnvironment` + body + `PopEnvironment`) doesn't properly handle exception propagation when combined with `for await...of` loops.
- **#405 (for-in loops)**: Requires implementing a new `ForInEmitter` with dedicated IR instructions for property enumeration
- **#410 (yield in binding defaults)**: Requires complex yield lowering for conditional evaluation of default values

## Test Plan
- [x] All 3062 tests pass
- [x] `with` statements work correctly with and without yield in body
- [x] No regression in async iteration, try/catch, or generator functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **`with` statements**: `StatementEmitter.TryEmitWith` now always delegates to `WithEmitter.TryEmitWith`, removing the `StatementInstruction` fallback and the yield-in-body conditional. Ensures IR uses `EnterWith`/`LeaveWith` consistently.
> - **Block emitter comments**: Update `TryEmitBlockWithEnvironment` summary to state it builds blocks that need their own environment and emits `PushEnvironment` + body + `PopEnvironment` for proper IR execution (no functional change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5c7e6f93b21c5fd3450ac5a1a2e1c82f85af827. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal code execution logic for improved consistency and maintainability.

* **Chores**
  * Updated internal documentation for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->