### PR TITLE
Fix #433: Implement ForInEmitter for IR-only for-in loops

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.ForIn.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.ForIn.cs
@@ -1,0 +1,376 @@
+#region
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Asynkron.JsEngine.Execution;
+using Asynkron.JsEngine.Execution.Instructions;
+using Asynkron.JsEngine.JsTypes;
+
+#endregion
+
+namespace Asynkron.JsEngine.Ast;
+
+public static partial class TypedAstEvaluator
+{
+    private sealed partial class ExecutionPlanRunner
+    {
+#if NO_INLINING
+        [MethodImpl(MethodImplOptions.NoInlining)]
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        private static InstructionResult HandleForInInit(
+            ExecutionPlanRunner runner,
+            ExecutionInstruction instr,
+            ref JsEnvironment environment,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var instruction = Unsafe.As<ForInInitInstruction>(instr);
+            var objectEnv = environment;
+
+            // Create TDZ environment for lexical declarations if needed
+            if (!instruction.TdzBindings.IsDefaultOrEmpty)
+            {
+                objectEnv = new JsEnvironment(environment, false, false,
+                    instruction.ObjectExpression.Source, "for-in-head-tdz");
+                foreach (var tdzSymbol in instruction.TdzBindings)
+                {
+                    objectEnv.DefineJsValue(tdzSymbol, JsValue.Uninitialized,
+                        instruction.TdzIsConst, isLexicalBinding: true,
+                        blocksFunctionScopeOverride: true);
+                }
+            }
+
+            // Evaluate the object expression
+            var objectValue = instruction.ObjectExpression.EvaluateExpression(objectEnv, context);
+            if (context.IsThrow)
+            {
+                var initThrown = context.FlowValue;
+                context.Clear();
+                if (runner.HandleAbruptCompletion(AbruptKind.Throw, initThrown, environment))
+                {
+                    returnValue = default;
+                    return InstructionResult.Continue;
+                }
+
+                runner.TryCatchStateRef.TryStack.Clear();
+                throw new ThrowSignal(initThrown);
+            }
+
+            // Rent a ForInDriverState and collect property keys
+            var forInState = ForInDriverStatePool.Rent();
+            CollectEnumerablePropertyKeys(objectValue, forInState.PropertyKeys);
+
+            // Set up the state environment
+            var stateEnv = environment;
+            var walkCount = 0;
+            if (instruction.StateSlotIndex >= 0)
+            {
+                while (stateEnv is not null &&
+                       (stateEnv.ScopeId != runner._plan!.RootScopeId ||
+                        !stateEnv.HasSlots ||
+                        stateEnv._slots!.Length <= instruction.StateSlotIndex))
+                {
+                    stateEnv = stateEnv.Enclosing;
+                    walkCount++;
+                    if (walkCount > 1000)
+                    {
+                        break;
+                    }
+                }
+
+                stateEnv ??= environment;
+            }
+
+            // Cache the JsVariable for fast slot access
+            if (instruction.StateSlotIndex >= 0 && stateEnv.HasSlots)
+            {
+                forInState.StateVariable = new JsVariable(stateEnv, instruction.StateSlotIndex);
+            }
+
+            forInState.LoopScopeEnvironment = environment;
+            runner.ForInStateRef.CurrentDriverState = forInState;
+
+            // Store the state
+            StoreValueBySlot(stateEnv, instruction.StateSlot,
+                instruction.StateSlotIndex,
+                JsValue.FromObjectUnsafe(forInState));
+
+            runner._programCounter = instruction.Next;
+            returnValue = default;
+            return InstructionResult.Continue;
+        }
+
+#if NO_INLINING
+        [MethodImpl(MethodImplOptions.NoInlining)]
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        private static InstructionResult HandleForInMoveNext(
+            ExecutionPlanRunner runner,
+            ExecutionInstruction instr,
+            ref JsEnvironment environment,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var instruction = Unsafe.As<ForInMoveNextInstruction>(instr);
+
+            // Use cached driver state for scope-correct access
+            var driverState = runner.ForInStateRef.CurrentDriverState;
+
+            if (driverState is null)
+            {
+                // Fallback: try to get state from the correct scope
+                var slotEnv = environment;
+                var slotIdx = instruction.StateSlotIndex;
+
+                if (slotIdx >= 0)
+                {
+                    var slotWalkCount = 0;
+                    while (slotEnv != null &&
+                           (slotEnv.ScopeId != runner._plan!.RootScopeId ||
+                            !slotEnv.HasSlots ||
+                            slotEnv._slots!.Length <= slotIdx))
+                    {
+                        slotEnv = slotEnv.Enclosing;
+                        slotWalkCount++;
+                        if (slotWalkCount > 100)
+                        {
+                            break;
+                        }
+                    }
+
+                    slotEnv ??= environment;
+                }
+
+                if (slotEnv is null || !TryGetValueBySlot(slotEnv,
+                        instruction.StateSlot,
+                        slotIdx, out var stateValue))
+                {
+                    runner._programCounter = instruction.BreakIndex;
+                    returnValue = default;
+                    return InstructionResult.Continue;
+                }
+
+                if (!stateValue.TryGetObject(out driverState))
+                {
+                    runner._programCounter = instruction.BreakIndex;
+                    returnValue = default;
+                    return InstructionResult.Continue;
+                }
+
+                runner.ForInStateRef.CurrentDriverState = driverState;
+            }
+
+            // Get JsVariables directly from driverState (O(1) access)
+            var stateVar = driverState.StateVariable;
+            var valueVar = driverState.ValueVariable;
+
+            // Capture value JsVariable on first execution
+            if (!valueVar.IsValid && instruction.ValueSlotIndex >= 0)
+            {
+                var loopScopeEnv = stateVar.IsValid ? stateVar.Environment : environment;
+                if (loopScopeEnv.HasSlots && loopScopeEnv._slots!.Length > instruction.ValueSlotIndex)
+                {
+                    valueVar = new JsVariable(loopScopeEnv, instruction.ValueSlotIndex);
+                    driverState.ValueVariable = valueVar;
+                }
+            }
+
+            // Check if we have more property keys
+            if (driverState.CurrentIndex >= driverState.PropertyKeys.Count)
+            {
+                // Iteration complete - clean up and jump to break
+                runner.ForInStateRef.CurrentDriverState = null;
+                ForInDriverStatePool.Return(driverState);
+                runner._programCounter = instruction.BreakIndex;
+                returnValue = default;
+                return InstructionResult.Continue;
+            }
+
+            // Get the current property key
+            var currentKey = driverState.PropertyKeys[driverState.CurrentIndex];
+            driverState.CurrentIndex++;
+
+            // Store the value in the value slot
+            if (valueVar.IsValid)
+            {
+                valueVar.Write(currentKey);
+            }
+            else
+            {
+                var loopScopeEnv = stateVar.IsValid ? stateVar.Environment : environment;
+                StoreValueBySlot(loopScopeEnv, instruction.ValueSlot,
+                    instruction.ValueSlotIndex, currentKey);
+            }
+
+            // Continue to loop body
+            runner._programCounter = instruction.Next;
+            returnValue = default;
+            return InstructionResult.Continue;
+        }
+
+        /// <summary>
+        /// Collects all enumerable property keys from an object and its prototype chain.
+        /// Per ES spec, for-in enumerates string-keyed enumerable properties.
+        /// </summary>
+        private static void CollectEnumerablePropertyKeys(JsValue value, List<JsValue> keys)
+        {
+            // Per ES spec, for-in over null or undefined should not iterate
+            if (value.IsNull || value.IsUndefined)
+            {
+                return;
+            }
+
+            switch (value.Kind)
+            {
+                case JsValueKind.Object when value.ObjectValue is JsArray array:
+                    CollectArrayPropertyKeys(array, keys);
+                    break;
+
+                case JsValueKind.Object when value.ObjectValue is TypedArrayBase typedArray:
+                    CollectTypedArrayPropertyKeys(typedArray, keys);
+                    break;
+
+                case JsValueKind.String when value.ObjectValue is string s:
+                    CollectStringPropertyKeys(s, keys);
+                    break;
+
+                case JsValueKind.Object when value.ObjectValue is IJsObjectLike accessor:
+                    CollectObjectPropertyKeys(accessor, keys);
+                    break;
+            }
+        }
+
+        private static void CollectArrayPropertyKeys(JsArray array, List<JsValue> keys)
+        {
+            // First, enumerate numeric indices (array elements)
+            for (var i = 0; i < array.Items.Count; i++)
+            {
+                keys.Add(JsValue.FromString(i.ToString(CultureInfo.InvariantCulture)));
+            }
+
+            // Track seen keys to properly handle shadowing
+            var seenKeys = new HashSet<string>(StringComparer.Ordinal);
+
+            // Add all numeric indices as seen (already enumerated above)
+            for (var i = 0; i < array.Items.Count; i++)
+            {
+                seenKeys.Add(JsValueCache.GetIndexString(i));
+            }
+
+            // Now enumerate non-index properties on the array and its prototype chain
+            IJsPropertyAccessor? current = array;
+            while (current is not null)
+            {
+                var ownKeys = current.GetOwnPropertyNames().ToList();
+
+                foreach (var key in ownKeys)
+                {
+                    // Skip if we've already seen this key
+                    if (!seenKeys.Add(key))
+                    {
+                        continue;
+                    }
+
+                    // Skip 'length' - it's not enumerable
+                    if (string.Equals(key, "length", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    var desc = current.GetOwnPropertyDescriptor(key);
+                    if (desc is null or { Enumerable: false })
+                    {
+                        continue;
+                    }
+
+                    keys.Add(JsValue.FromString(key));
+                }
+
+                // Move to prototype
+                current = current switch
+                {
+                    IJsObjectLike objectLike => objectLike.Prototype,
+                    IPrototypeAccessorProvider provider => provider.PrototypeAccessor,
+                    _ => null
+                };
+            }
+        }
+
+        private static void CollectTypedArrayPropertyKeys(TypedArrayBase typedArray, List<JsValue> keys)
+        {
+            // TypedArray for-in only exposes own enumerable properties (indices and custom slots)
+            var seenKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var key in typedArray.GetOwnPropertyNames().ToList())
+            {
+                if (!seenKeys.Add(key))
+                {
+                    continue;
+                }
+
+                var desc = typedArray.GetOwnPropertyDescriptor(key);
+                if (desc is null or { Enumerable: false })
+                {
+                    continue;
+                }
+
+                keys.Add(JsValue.FromString(key));
+            }
+        }
+
+        private static void CollectStringPropertyKeys(string s, List<JsValue> keys)
+        {
+            for (var i = 0; i < s.Length; i++)
+            {
+                keys.Add(JsValue.FromString(JsValueCache.GetIndexString(i)));
+            }
+        }
+
+        private static void CollectObjectPropertyKeys(IJsObjectLike accessor, List<JsValue> keys)
+        {
+            // Track seen keys to properly handle shadowing
+            var seenKeys = new HashSet<string>(StringComparer.Ordinal);
+
+            // Walk prototype chain, starting with the object itself
+            IJsPropertyAccessor? current = accessor;
+            while (current is not null)
+            {
+                // Collect keys from this object in the chain
+                var ownKeys = current.GetOwnPropertyNames().ToList();
+
+                foreach (var key in ownKeys)
+                {
+                    // Skip if we've already seen this key (shadowed by own/earlier property)
+                    if (!seenKeys.Add(key))
+                    {
+                        continue;
+                    }
+
+                    // Per ECMAScript spec, check that the property still exists
+                    var desc = current.GetOwnPropertyDescriptor(key);
+                    if (desc is null)
+                    {
+                        continue;
+                    }
+
+                    if (desc is { Enumerable: false })
+                    {
+                        continue;
+                    }
+
+                    keys.Add(JsValue.FromString(key));
+                }
+
+                // Move to prototype
+                current = current switch
+                {
+                    IJsObjectLike objectLike => objectLike.Prototype,
+                    IPrototypeAccessorProvider provider => provider.PrototypeAccessor,
+                    _ => null
+                };
+            }
+        }
+    }
+}

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.InstructionHandlers.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.InstructionHandlers.cs
@@ -25,7 +25,7 @@ public static partial class TypedAstEvaluator
 
         private static InstructionHandler[] InitializeHandlers()
         {
-            var handlers = new InstructionHandler[34];
+            var handlers = new InstructionHandler[36];
             handlers[(int)InstructionKind.Statement] = HandleStatement;
             handlers[(int)InstructionKind.Throw] = HandleThrow;
             handlers[(int)InstructionKind.EvaluateAndDiscard] = HandleEvaluateAndDiscard;
@@ -60,6 +60,8 @@ public static partial class TypedAstEvaluator
             handlers[(int)InstructionKind.IteratorClose] = HandleIteratorClose;
             handlers[(int)InstructionKind.SetCompletionValue] = HandleSetCompletionValue;
             handlers[(int)InstructionKind.Expression] = DispatchExpression;
+            handlers[(int)InstructionKind.ForInInit] = HandleForInInit;
+            handlers[(int)InstructionKind.ForInMoveNext] = HandleForInMoveNext;
             return handlers;
         }
 

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.States.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.States.cs
@@ -73,5 +73,14 @@ public static partial class TypedAstEvaluator
         {
             public readonly Stack<Symbol> ActiveWithScopes = new();
         }
+
+        /// <summary>
+        /// State for for-in loop handling.
+        /// Only allocated when the function uses for-in loops.
+        /// </summary>
+        private sealed class ForInState
+        {
+            public ForInDriverState? CurrentDriverState;
+        }
     }
 }

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.cs
@@ -107,6 +107,7 @@ public static partial class TypedAstEvaluator
         private TryCatchState TryCatchStateRef => _tryCatchState ??= new TryCatchState();
         private BreakableState BreakableStateRef => field ??= new BreakableState();
         private WithState WithStateRef => field ??= new WithState();
+        private ForInState ForInStateRef => field ??= new ForInState();
 
         internal JsValue EvaluateAwaitInGenerator(AwaitExpression expression, JsEnvironment environment,
             EvaluationContext context)

--- a/src/Asynkron.JsEngine/Execution/Emitters/ForInEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/ForInEmitter.cs
@@ -1,0 +1,198 @@
+#region
+
+using System.Collections.Immutable;
+using Asynkron.JsEngine.Ast;
+using Asynkron.JsEngine.Ast.ShapeAnalyzer;
+using Asynkron.JsEngine.Execution.Instructions;
+using Asynkron.JsEngine.JsTypes;
+
+#endregion
+
+namespace Asynkron.JsEngine.Execution.Emitters;
+
+/// <summary>
+/// Emits IR instructions for for-in loops.
+/// For-in loops enumerate property keys from an object and its prototype chain.
+/// Unlike for-of, there is no iterator protocol - property keys are collected upfront.
+/// </summary>
+internal static class ForInEmitter
+{
+    /// <summary>
+    /// Emit IR for a for-in statement.
+    /// </summary>
+    public static bool TryEmit(
+        EmitContext ctx,
+        ForEachStatement statement,
+        int nextIndex,
+        Symbol? label,
+        out int entryIndex)
+    {
+        // for-in should only be called for ForEachKind.In
+        if (statement.Kind != ForEachKind.In)
+        {
+            entryIndex = -1;
+            return false;
+        }
+
+        // Yield in the object expression is not supported in IR
+        if (AstShapeAnalyzer.ContainsYield(statement.Iterable))
+        {
+            entryIndex = -1;
+            return false;
+        }
+
+        // Use the cached iterator plan to ensure any synthetic scope ids (for per-iteration bindings)
+        // are stable across IR emission, slot analysis, and later plan stamping.
+        var iteratorPlan = ((IAstCacheable<IteratorDriverPlan>)statement).GetOrCreateCache();
+
+        var instructionStart = ctx.InstructionCount;
+        var lexicalBindings = iteratorPlan.PerIterationBindings.IsDefaultOrEmpty
+            ? null
+            : iteratorPlan.PerIterationBindings.ToImmutableHashSet(ReferenceEqualityComparer<Symbol>.Instance);
+
+        // Pre-create symbols and allocate slots for O(1) access
+        var stateSymbol = Symbol.Intern($"__forIn_state_{instructionStart}");
+        var valueSymbol = Symbol.Intern($"__forIn_value_{instructionStart}");
+
+        var stateSlotIndex = ctx.AllocateSlot(stateSymbol);
+        var valueSlotIndex = ctx.AllocateSlot(valueSymbol);
+
+        // For let/const declarations, the per-iteration bindings need TDZ during object evaluation.
+        // This ensures `for (const x in {[x]: 1})` throws ReferenceError for accessing x before initialization.
+        var tdzBindings =
+            iteratorPlan.DeclarationKind is VariableKind.Let or VariableKind.Const or VariableKind.Using
+                or VariableKind.AwaitUsing
+                ? iteratorPlan.PerIterationBindings
+                : default;
+        var tdzIsConst = iteratorPlan.DeclarationKind is VariableKind.Const or VariableKind.Using
+            or VariableKind.AwaitUsing;
+
+        // Build the structure bottom-up:
+        // 1. BreakableExit -> nextIndex
+        // 2. Body -> MoveNext (with PopEnvironment for per-iteration bindings)
+        // 3. MoveNext -> Body, BreakIndex -> BreakableExit
+        // 4. BreakableEnter -> MoveNext
+        // 5. ForInInit -> BreakableEnter
+
+        // Create ForInInit instruction
+        var initIndex = ctx.Append(new ForInInitInstruction(
+            statement.Iterable,
+            stateSymbol,
+            stateSlotIndex,
+            valueSymbol,
+            valueSlotIndex,
+            -1, // Will be wired later
+            tdzBindings,
+            tdzIsConst));
+
+        // Create ForInMoveNext instruction
+        var moveNextIndex = ctx.Append(new ForInMoveNextInstruction(
+            stateSymbol,
+            valueSymbol,
+            stateSlotIndex,
+            valueSlotIndex,
+            -1, // BreakIndex will be patched later
+            -1)); // Next (body) will be wired later
+
+        // BreakableExit - pops breakable context from runtime stack
+        var loopExitIndex = ctx.Append(new BreakableExitInstruction(nextIndex));
+
+        // For loops with per-iteration bindings, create PopEnvironment before BreakableExit
+        var loopExitTarget = loopExitIndex;
+        if (iteratorPlan.DeclarationKind is VariableKind.Let or VariableKind.Const &&
+            !iteratorPlan.PerIterationBindings.IsDefaultOrEmpty)
+        {
+            loopExitTarget = ctx.Append(new PopEnvironmentInstruction(
+                iteratorPlan.IterationScopeId,
+                iteratorPlan.CanReuseIterationEnvironment,
+                loopExitIndex));
+        }
+
+        // Now update the MoveNext break target
+        ctx.Patch(moveNextIndex,
+            (ForInMoveNextInstruction)ctx.Instructions[moveNextIndex] with
+            {
+                BreakIndex = loopExitTarget
+            });
+
+        // Build the loop body.
+        // Create the binding statement for the loop variable
+        var bindingStatement = EmitContext.CreateIteratorBindingStatement(iteratorPlan, valueSymbol, valueSlotIndex);
+        var targetScopeId = iteratorPlan.IterationScopeId >= 0 ? iteratorPlan.IterationScopeId : -1;
+
+        // For per-iteration bindings, we need to POP the iteration environment at the END of each
+        // iteration body, BEFORE going back to FORIN_MOVE_NEXT. This ensures the environment stack
+        // stays balanced and we return to the correct scope for the next iteration.
+        var bodyNextTarget = moveNextIndex;
+        var continueTarget = moveNextIndex;
+        if (iteratorPlan.DeclarationKind is VariableKind.Let or VariableKind.Const &&
+            !iteratorPlan.PerIterationBindings.IsDefaultOrEmpty)
+        {
+            // Create POP_ENV that goes to FORIN_MOVE_NEXT - body will flow to this
+            var popEnvForContinue = ctx.Append(new PopEnvironmentInstruction(
+                iteratorPlan.IterationScopeId,
+                iteratorPlan.CanReuseIterationEnvironment,
+                moveNextIndex));
+            bodyNextTarget = popEnvForContinue;
+            continueTarget = popEnvForContinue;
+        }
+
+        ctx.PushLoopScope(label, continueTarget, loopExitTarget, targetScopeId);
+        var iterationEntry = -1;
+        var bodyBuilt = ctx.TryBuildStatement(iteratorPlan.Body, bodyNextTarget, out var bodyEntry, label);
+        if (bodyBuilt)
+        {
+            bodyBuilt = ctx.TryBuildStatement(bindingStatement, bodyEntry, out iterationEntry, label);
+        }
+
+        ctx.PopLoopScope();
+
+        if (!bodyBuilt)
+        {
+            ctx.Rollback(instructionStart);
+            entryIndex = -1;
+            return false;
+        }
+
+        // For lexical declarations (let/const), emit PushEnvironmentInstruction
+        // to create fresh per-iteration bindings. This ensures closures capture separate values.
+        var loopEntry = iterationEntry;
+        if (iteratorPlan.DeclarationKind is VariableKind.Let or VariableKind.Const &&
+            !iteratorPlan.PerIterationBindings.IsDefaultOrEmpty)
+        {
+            var slotMap =
+                EmitContext.BuildSlotMap(iteratorPlan.PerIterationBindings, iteratorPlan.PerIterationSlotIndices);
+            var slotNames =
+                EmitContext.BuildSlotNames(iteratorPlan.PerIterationBindings, iteratorPlan.PerIterationSlotIndices);
+
+            var createEnvIndex = ctx.Append(new PushEnvironmentInstruction(
+                iterationEntry,
+                iteratorPlan.PerIterationBindings,
+                iteratorPlan.IterationScopeId,
+                iteratorPlan.IterationSlotCount,
+                slotMap,
+                iteratorPlan.CanReuseIterationEnvironment,
+                lexicalBindings,
+                SlotNames: slotNames));
+            loopEntry = createEnvIndex;
+        }
+
+        // Wire up the MoveNext to point to the loop entry (env instruction or body)
+        ctx.Patch(moveNextIndex,
+            (ForInMoveNextInstruction)ctx.Instructions[moveNextIndex] with { Next = loopEntry });
+
+        // BreakableEnter - pushes context to runtime stack for break/continue
+        var loopEnterIndex = ctx.Append(new BreakableEnterInstruction(
+            moveNextIndex,
+            label,
+            loopExitTarget,
+            continueTarget));
+
+        // Wire ForInInit to point to BreakableEnter
+        ctx.Patch(initIndex,
+            (ForInInitInstruction)ctx.Instructions[initIndex] with { Next = loopEnterIndex });
+
+        entryIndex = initIndex;
+        return true;
+    }
+}

--- a/src/Asynkron.JsEngine/Execution/Emitters/StatementEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/StatementEmitter.cs
@@ -71,11 +71,7 @@ internal static class StatementEmitter
                     return TryEmitter.TryEmitTry(ctx, tryStatement, nextIndex, activeLabel, out entryIndex);
 
                 case ForEachStatement { Kind: ForEachKind.In } forInStatement:
-                    // AST fallback: for-in loops delegate to AST evaluator via StatementInstruction
-                    // Reason: No dedicated IR instructions for property enumeration
-                    // Tracking: #398, #416 (IR-only execution epic)
-                    entryIndex = ctx.Append(new StatementInstruction(nextIndex, forInStatement));
-                    return true;
+                    return TryEmitForIn(ctx, forInStatement, nextIndex, activeLabel, out entryIndex);
 
                 case ForEachStatement { Kind: ForEachKind.Of or ForEachKind.AwaitOf } forEachStatement
                     when IsSimpleForOfBinding(forEachStatement):
@@ -107,18 +103,7 @@ internal static class StatementEmitter
                     return DeclarationEmitter.TryEmitThrow(ctx, throwStatement, out entryIndex);
 
                 case LabeledStatement labeled:
-                    // For for-in loops that are AST-evaluated, keep the label wrapper
-                    // so the AST evaluator can handle labeled break/continue correctly
-                    if (labeled.Statement is ForEachStatement { Kind: ForEachKind.In })
-                    {
-                        // AST fallback: labeled for-in wrapper
-                        // Reason: Wraps the for-in AST fallback to preserve label semantics
-                        // Tracking: #398, #416 (IR-only execution epic)
-                        entryIndex = ctx.Append(new StatementInstruction(nextIndex, labeled));
-                        return true;
-                    }
-
-                    // For other loop-like statements, pass the label through - they handle it internally
+                    // For loop-like statements, pass the label through - they handle it internally
                     if (labeled.Statement is WhileStatement or DoWhileStatement or ForStatement
                         or ForEachStatement or SwitchStatement)
                     {
@@ -251,6 +236,32 @@ internal static class StatementEmitter
         }
 
         return ForOfEmitter.TryEmit(ctx, forEachStatement, nextIndex, activeLabel, out entryIndex);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // For-In Helper
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static bool TryEmitForIn(
+        EmitContext ctx,
+        ForEachStatement forInStatement,
+        int nextIndex,
+        Symbol? activeLabel,
+        out int entryIndex)
+    {
+        // If binding target has yields anywhere (defaults or assignment target expressions),
+        // we cannot emit IR - fall back to StatementInstruction.
+        if (EmitContext.BindingTargetContainsYieldAnywhere(forInStatement.Target) &&
+            !AstShapeAnalyzer.StatementContainsYield(forInStatement.Body) &&
+            !AstShapeAnalyzer.ContainsYield(forInStatement.Iterable))
+        {
+            // AST fallback: for-in with yield in binding target
+            // Reason: Conditional yield semantics in destructuring defaults
+            entryIndex = ctx.Append(new StatementInstruction(nextIndex, forInStatement));
+            return true;
+        }
+
+        return ForInEmitter.TryEmit(ctx, forInStatement, nextIndex, activeLabel, out entryIndex);
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/src/Asynkron.JsEngine/Execution/ExecutionPlanPrinter.cs
+++ b/src/Asynkron.JsEngine/Execution/ExecutionPlanPrinter.cs
@@ -173,6 +173,12 @@ internal static class ExecutionPlanPrinter
             IteratorCloseInstruction iterClose =>
                 $"ITER_CLOSE (iter: {iterClose.IteratorSlot.Name}) → [{iterClose.Next}]",
 
+            ForInInitInstruction forInInit =>
+                $"FORIN_INIT {FormatExpression(forInInit.ObjectExpression)} (state: {forInInit.StateSlot.Name}, value: {forInInit.ValueSlot.Name}) → [{forInInit.Next}]",
+
+            ForInMoveNextInstruction forInMoveNext =>
+                $"FORIN_MOVE_NEXT (state: {forInMoveNext.StateSlot.Name}, value: {forInMoveNext.ValueSlot.Name}) body: [{forInMoveNext.Next}], done: [{forInMoveNext.BreakIndex}]",
+
             EnterWithInstruction enterWith =>
                 $"ENTER_WITH {FormatExpression(enterWith.ObjectExpression)} → [{enterWith.Next}]",
 

--- a/src/Asynkron.JsEngine/Execution/ForInDriverState.cs
+++ b/src/Asynkron.JsEngine/Execution/ForInDriverState.cs
@@ -1,0 +1,100 @@
+#region
+
+using System.Runtime.CompilerServices;
+using Asynkron.JsEngine.Ast;
+using Asynkron.JsEngine.JsTypes;
+using Microsoft.Extensions.Logging;
+
+#endregion
+
+namespace Asynkron.JsEngine.Execution;
+
+/// <summary>
+/// Holds the iteration state for a for-in loop, including the list of property keys
+/// and the current iteration index.
+/// </summary>
+internal sealed class ForInDriverState : IRentable, IAsJsValue
+{
+    private JsValue _cachedJsValue;
+
+    /// <summary>
+    /// The list of property keys to iterate over. Collected upfront from the object
+    /// and its prototype chain.
+    /// </summary>
+    public List<JsValue> PropertyKeys { get; } = new(16);
+
+    /// <summary>
+    /// The current index in the PropertyKeys list.
+    /// </summary>
+    public int CurrentIndex { get; set; }
+
+    /// <summary>
+    /// Pre-resolved JsVariable for fast state access (avoids dictionary lookups per iteration).
+    /// </summary>
+    public JsVariable StateVariable { get; set; }
+
+    /// <summary>
+    /// Pre-resolved JsVariable for fast value access (avoids dictionary lookups per iteration).
+    /// </summary>
+    public JsVariable ValueVariable { get; set; }
+
+    /// <summary>
+    /// The loop scope environment captured at ForInInit time.
+    /// </summary>
+    public JsEnvironment? LoopScopeEnvironment { get; set; }
+
+    public ref readonly JsValue AsJsValue
+    {
+        get
+        {
+            if (_cachedJsValue.ObjectValue is null)
+            {
+                _cachedJsValue = new JsValue(JsValueKind.Object, 0.0, this);
+            }
+
+            return ref _cachedJsValue;
+        }
+    }
+
+    /// <summary>
+    /// Called when state is rented from pool.
+    /// </summary>
+    void IRentable.Activate(ILogger? logger)
+    {
+        logger?.LogInformation("ForInDriverState.Activate");
+    }
+
+    /// <summary>
+    /// Resets the state for reuse from pool.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Reset(ILogger? logger)
+    {
+        logger?.LogInformation("ForInDriverState.Reset");
+        PropertyKeys.Clear();
+        CurrentIndex = 0;
+        StateVariable = default;
+        ValueVariable = default;
+        LoopScopeEnvironment = null;
+    }
+}
+
+/// <summary>
+/// Pool for ForInDriverState instances to reduce per-loop allocations.
+/// </summary>
+internal static class ForInDriverStatePool
+{
+    private static readonly ObjectPool<ForInDriverState> Pool = new(32, static () => new ForInDriverState());
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ForInDriverState Rent()
+    {
+        return Pool.Rent();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Return(ForInDriverState state)
+    {
+        Pool.Return(state);
+    }
+}

--- a/src/Asynkron.JsEngine/Execution/Instructions/InstructionKind.cs
+++ b/src/Asynkron.JsEngine/Execution/Instructions/InstructionKind.cs
@@ -40,7 +40,9 @@ internal enum InstructionKind : byte
     LeaveWith,
     Expression,
     SetCompletionValue,
-    CompoundAssignmentSlot
+    CompoundAssignmentSlot,
+    ForInInit,
+    ForInMoveNext
 }
 
 /// <summary>

--- a/src/Asynkron.JsEngine/Execution/Instructions/Instructions.cs
+++ b/src/Asynkron.JsEngine/Execution/Instructions/Instructions.cs
@@ -431,3 +431,47 @@ internal sealed record ExpressionInstruction(int Next, ExpressionNode Expression
 /// </summary>
 internal sealed record SetCompletionValueInstruction(int Next)
     : ExecutionInstruction(InstructionKind.SetCompletionValue, Next);
+
+/// <summary>
+///     Initializes the for-in loop by evaluating the object expression and collecting
+///     enumerable property keys.
+/// </summary>
+/// <param name="ObjectExpression">Expression that produces the object to iterate.</param>
+/// <param name="StateSlot">Symbol for the for-in state.</param>
+/// <param name="StateSlotIndex">Pre-resolved slot index for fast state access (-1 if not resolved).</param>
+/// <param name="ValueSlot">Symbol for the current property key value.</param>
+/// <param name="ValueSlotIndex">Pre-resolved slot index for fast value access (-1 if not resolved).</param>
+/// <param name="Next">Jump target after initialization.</param>
+/// <param name="TdzBindings">
+///     Symbols that need TDZ bindings during object evaluation (for let/const declarations).
+///     This ensures `for (const x in {[x]: 1})` throws ReferenceError for accessing x before initialization.
+/// </param>
+/// <param name="TdzIsConst">Whether the TDZ bindings are const (true) or let (false).</param>
+internal sealed record ForInInitInstruction(
+    ExpressionNode ObjectExpression,
+    Symbol StateSlot,
+    int StateSlotIndex,
+    Symbol ValueSlot,
+    int ValueSlotIndex,
+    int Next,
+    ImmutableArray<Symbol> TdzBindings = default,
+    bool TdzIsConst = false)
+    : ExecutionInstruction(InstructionKind.ForInInit, Next);
+
+/// <summary>
+///     Advances the for-in loop to the next enumerable property key.
+/// </summary>
+/// <param name="StateSlot">Symbol for the for-in state.</param>
+/// <param name="ValueSlot">Symbol for the current property key value.</param>
+/// <param name="StateSlotIndex">Pre-resolved slot index for fast state access (-1 if not resolved).</param>
+/// <param name="ValueSlotIndex">Pre-resolved slot index for fast value access (-1 if not resolved).</param>
+/// <param name="BreakIndex">Jump target when iteration completes.</param>
+/// <param name="Next">Jump target for the loop body.</param>
+internal sealed record ForInMoveNextInstruction(
+    Symbol StateSlot,
+    Symbol ValueSlot,
+    int StateSlotIndex,
+    int ValueSlotIndex,
+    int BreakIndex,
+    int Next)
+    : ExecutionInstruction(InstructionKind.ForInMoveNext, Next);


### PR DESCRIPTION
## Summary

- Add `ForInEmitter.cs` based on `ForOfEmitter` pattern for IR emission
- Add `ForInInitInstruction` and `ForInMoveNextInstruction` for property enumeration
- Add `ForInDriverState` to hold the property keys list and current index
- Add instruction handlers in `Handlers.ForIn.cs`
- Remove `StatementInstruction` fallback for for-in loops in `StatementEmitter.cs`
- Update `ExecutionPlanPrinter` with ForIn instruction formatting

The for-in loop now collects enumerable property keys upfront (from the object and its prototype chain) and iterates over them using IR instructions, matching the for-of pattern but without the iterator protocol complexity.

### Supports
- Per-iteration let/const bindings with closures
- break/continue with labels  
- TDZ for lexical declarations in object expression
- Prototype chain property enumeration
- Proper handling of null/undefined (no iteration)

## Test plan

- [x] All 3057 existing tests pass
- [x] 20 for-in specific tests pass
- [x] 10 labeled break/continue tests pass
- [x] TDZ tests pass for const/let in for-in head

Fixes #433
Unblocks #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces IR-only execution for `for...in` loops.
> 
> - New `ForInEmitter` builds loop IR with per-iteration env push/pop, label-aware break/continue, and TDZ for let/const in the head
> - Adds `ForInInitInstruction` and `ForInMoveNextInstruction` (+ `InstructionKind` entries) and wires handlers in `InstructionHandlers`
> - Implements `ForInDriverState` (+ pool) to hold collected property keys and iteration index for fast slot access
> - Runtime handlers (`Handlers.ForIn.cs`) evaluate the object, collect enumerable keys (arrays/typed arrays/strings/objects with prototype chain), and advance iteration; cleans up state on completion
> - `StatementEmitter` now emits IR for for-in (fallback only when binding target contains yield); `ExecutionPlanPrinter` prints new instructions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b97bce161daa8449ed4b13c3e95bd2eab04fede5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added for-in loop iteration support enabling proper enumeration of object properties
  * Implemented complete initialization and advancement of for-in loops with correct scoping semantics
  * Added property enumeration across diverse value types including arrays, typed arrays, strings, and objects
  * Included optimized state management for efficient per-iteration bindings and variable initialization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->