### PR TITLE
Fix build errors from extension blocks

### DIFF
--- a/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/AssignmentExpressionExtensions.cs
@@ -281,7 +281,7 @@ public static partial class TypedAstEvaluator
 
         if (assignment is not null &&
             jsValue.ObjectValue is IFunctionNameTarget nameTarget &&
-            ExpressionNode.IsAnonymousFunctionDefinitionNode(rhs) &&
+            rhs.IsAnonymousFunctionDefinitionNode() &&
             !IsParenthesizedIdentifierAssignment(assignment))
         {
             nameTarget.EnsureHasName(assignment.Target.Name);
@@ -293,7 +293,7 @@ public static partial class TypedAstEvaluator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool ShouldApplyAssignmentNameHint(AssignmentExpression? assignment, ExpressionNode rhs)
     {
-        return assignment is not null && ExpressionNode.IsAnonymousFunctionDefinitionNode(rhs) &&
+        return assignment is not null && rhs.IsAnonymousFunctionDefinitionNode() &&
                !IsParenthesizedIdentifierAssignment(assignment);
     }
 
@@ -461,7 +461,7 @@ public static partial class TypedAstEvaluator
             catch (InvalidOperationException ex) when (ex.Message.StartsWith("ReferenceError:",
                                                            StringComparison.Ordinal))
             {
-                return AssignmentExpression.HandleReferenceError(ex, environment, context);
+                return expression.HandleReferenceError(ex, environment, context);
             }
         }
 
@@ -680,27 +680,24 @@ public static partial class TypedAstEvaluator
         catch (InvalidOperationException ex) when (ex.Message.StartsWith("ReferenceError:",
                                                        StringComparison.Ordinal))
         {
-            return AssignmentExpression.HandleReferenceError(ex, environment, context);
+            return expression.HandleReferenceError(ex, environment, context);
         }
     }
 
-    extension(AssignmentExpression expression)
+    private static JsValue HandleReferenceError(this AssignmentExpression _, InvalidOperationException ex, JsEnvironment environment,
+        EvaluationContext context)
     {
-        private static JsValue HandleReferenceError(InvalidOperationException ex, JsEnvironment environment,
-            EvaluationContext context)
+        var errorValue = (JsValue)ex.Message;
+
+        // If a ReferenceError constructor is available, use it to
+        // create a proper JS error instance so user code can catch
+        // and inspect it.
+        if (environment.TryGetObject<IJsCallable>(Symbol.ReferenceErrorIdentifier, out var callable))
         {
-            var errorValue = (JsValue)ex.Message;
-
-            // If a ReferenceError constructor is available, use it to
-            // create a proper JS error instance so user code can catch
-            // and inspect it.
-            if (environment.TryGetObject<IJsCallable>(Symbol.ReferenceErrorIdentifier, out var callable))
-            {
-                errorValue = callable.Invoke(new SingleValueArgs((JsValue)ex.Message), JsValue.Undefined);
-            }
-
-            context.SetThrow(errorValue);
-            return errorValue;
+            errorValue = callable.Invoke(new SingleValueArgs((JsValue)ex.Message), JsValue.Undefined);
         }
+
+        context.SetThrow(errorValue);
+        return errorValue;
     }
 }

--- a/src/Asynkron.JsEngine/Ast/BinaryExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/BinaryExpressionExtensions.cs
@@ -107,7 +107,7 @@ public static partial class TypedAstEvaluator
             BinaryOperator.LessThanOrEqual => LessThanOrEqualValue(leftVal, rightVal, context),
             BinaryOperator.StrictEqual => StrictEqualsValue(leftVal, rightVal) ? JsValue.True : JsValue.False,
             BinaryOperator.StrictNotEqual => StrictEqualsValue(leftVal, rightVal) ? JsValue.False : JsValue.True,
-            _ => BinaryExpression.EvaluateBinaryOperator(op, leftVal, rightVal, context)
+            _ => expression.EvaluateBinaryOperator(op, leftVal, rightVal, context)
         };
 
         // Medium frequency operators
@@ -155,33 +155,30 @@ public static partial class TypedAstEvaluator
         };
     }
 
-    extension(BinaryExpression expression)
+    /// <summary>
+    /// Handles medium frequency binary operators.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static JsValue EvaluateBinaryOperator(this BinaryExpression _, BinaryOperator op, in JsValue left, in JsValue right,
+        EvaluationContext context)
     {
-        /// <summary>
-        /// Handles medium frequency binary operators.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static JsValue EvaluateBinaryOperator(BinaryOperator op, in JsValue left, in JsValue right,
-            EvaluationContext context)
+        return op switch
         {
-            return op switch
-            {
-                BinaryOperator.Multiply => MultiplyValue(left, right, context),
-                BinaryOperator.Divide => DivideValue(left, right, context),
-                BinaryOperator.Modulo => ModuloValue(left, right, context),
-                BinaryOperator.Power => PowerValue(left, right, context),
-                BinaryOperator.Equal => LooseEqualsValue(left, right, context) ? JsValue.True : JsValue.False,
-                BinaryOperator.NotEqual => LooseEqualsValue(left, right, context) ? JsValue.False : JsValue.True,
-                BinaryOperator.GreaterThan => GreaterThanValue(left, right, context),
-                BinaryOperator.GreaterThanOrEqual => GreaterThanOrEqualValue(left, right, context),
-                BinaryOperator.BitwiseAnd => BitwiseAndValue(left, right, context),
-                BinaryOperator.BitwiseOr => BitwiseOrValue(left, right, context),
-                BinaryOperator.BitwiseXor => BitwiseXorValue(left, right, context),
-                BinaryOperator.LeftShift => LeftShiftValue(left, right, context),
-                BinaryOperator.RightShift => RightShiftValue(left, right, context),
-                BinaryOperator.UnsignedRightShift => UnsignedRightShiftValue(left, right, context),
-                _ => throw new NotSupportedException($"Operator '{op}' is not supported yet.")
-            };
-        }
+            BinaryOperator.Multiply => MultiplyValue(left, right, context),
+            BinaryOperator.Divide => DivideValue(left, right, context),
+            BinaryOperator.Modulo => ModuloValue(left, right, context),
+            BinaryOperator.Power => PowerValue(left, right, context),
+            BinaryOperator.Equal => LooseEqualsValue(left, right, context) ? JsValue.True : JsValue.False,
+            BinaryOperator.NotEqual => LooseEqualsValue(left, right, context) ? JsValue.False : JsValue.True,
+            BinaryOperator.GreaterThan => GreaterThanValue(left, right, context),
+            BinaryOperator.GreaterThanOrEqual => GreaterThanOrEqualValue(left, right, context),
+            BinaryOperator.BitwiseAnd => BitwiseAndValue(left, right, context),
+            BinaryOperator.BitwiseOr => BitwiseOrValue(left, right, context),
+            BinaryOperator.BitwiseXor => BitwiseXorValue(left, right, context),
+            BinaryOperator.LeftShift => LeftShiftValue(left, right, context),
+            BinaryOperator.RightShift => RightShiftValue(left, right, context),
+            BinaryOperator.UnsignedRightShift => UnsignedRightShiftValue(left, right, context),
+            _ => throw new NotSupportedException($"Operator '{op}' is not supported yet.")
+        };
     }
 }

--- a/src/Asynkron.JsEngine/Ast/CallExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/CallExpressionExtensions.cs
@@ -137,8 +137,7 @@ public static partial class TypedAstEvaluator
     private static JsValue EvaluateCallSlow(this CallExpression expression, JsEnvironment environment, EvaluationContext context)
     {
         // Fast-path for plain Map/Set method calls - bypasses prototype lookup and host function machinery
-        if (
-            CallExpression.TryFastPathMapSetCall(expression, environment, context, out var fastResult))
+        if (expression.TryFastPathMapSetCall(environment, context, out var fastResult))
         {
             return fastResult;
         }
@@ -704,26 +703,24 @@ public static partial class TypedAstEvaluator
         return callResult;
     }
 
-    extension(CallExpression expression)
+    /// <summary>
+    ///     Fast-path for plain Map/Set method calls.
+    ///     Bypasses prototype lookup, host function creation, and argument array allocation.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TryFastPathMapSetCall(
+        this CallExpression callExpr,
+        JsEnvironment environment,
+        EvaluationContext context,
+        out JsValue result)
     {
-        /// <summary>
-        ///     Fast-path for plain Map/Set method calls.
-        ///     Bypasses prototype lookup, host function creation, and argument array allocation.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryFastPathMapSetCall(
-            CallExpression callExpr,
-            JsEnvironment environment,
-            EvaluationContext context,
-            out JsValue result)
-        {
-            result = JsValue.Unit;
+        result = JsValue.Unit;
 
-            // Only handle simple member expression calls like map.set(), map.get(), etc.
-            if (callExpr.Callee is not MemberExpression { IsComputed: false, IsOptional: false } member)
-            {
-                return false;
-            }
+        // Only handle simple member expression calls like map.set(), map.get(), etc.
+        if (callExpr.Callee is not MemberExpression { IsComputed: false, IsOptional: false } member)
+        {
+            return false;
+        }
 
             // IMPORTANT: Only use fast path for simple identifier targets (e.g., `myMap.set(...)`)
             // If we evaluate a complex target expression (like `getMap().set(...)`) and it's NOT
@@ -772,15 +769,15 @@ public static partial class TypedAstEvaluator
                 {
                     result = methodName switch
                     {
-                        "set" when callExpr.Arguments.Length >= 2 => CallExpression.FastMapSet(map, callExpr.Arguments,
+                        "set" when callExpr.Arguments.Length >= 2 => FastMapSet(map, callExpr.Arguments,
                             environment, context),
-                        "get" when callExpr.Arguments.Length >= 1 => CallExpression.FastMapGet(map, callExpr.Arguments,
+                        "get" when callExpr.Arguments.Length >= 1 => FastMapGet(map, callExpr.Arguments,
                             environment, context),
-                        "has" when callExpr.Arguments.Length >= 1 => CallExpression.FastMapHas(map, callExpr.Arguments,
+                        "has" when callExpr.Arguments.Length >= 1 => FastMapHas(map, callExpr.Arguments,
                             environment, context),
-                        "delete" when callExpr.Arguments.Length >= 1 => CallExpression.FastMapDelete(map,
+                        "delete" when callExpr.Arguments.Length >= 1 => FastMapDelete(map,
                             callExpr.Arguments, environment, context),
-                        "clear" => CallExpression.FastMapClear(map),
+                        "clear" => FastMapClear(map),
                         _ => JsValue
                             .Unit // Fall back to normal path for other methods (size is a property, not a method)
                     };
@@ -810,13 +807,13 @@ public static partial class TypedAstEvaluator
                 {
                     result = methodName switch
                     {
-                        "add" when callExpr.Arguments.Length >= 1 => CallExpression.FastSetAdd(set, callExpr.Arguments,
+                        "add" when callExpr.Arguments.Length >= 1 => FastSetAdd(set, callExpr.Arguments,
                             environment, context),
-                        "has" when callExpr.Arguments.Length >= 1 => CallExpression.FastSetHas(set, callExpr.Arguments,
+                        "has" when callExpr.Arguments.Length >= 1 => FastSetHas(set, callExpr.Arguments,
                             environment, context),
-                        "delete" when callExpr.Arguments.Length >= 1 => CallExpression.FastSetDelete(set,
+                        "delete" when callExpr.Arguments.Length >= 1 => FastSetDelete(set,
                             callExpr.Arguments, environment, context),
-                        "clear" => CallExpression.FastSetClear(set),
+                        "clear" => FastSetClear(set),
                         _ => JsValue
                             .Unit // Fall back to normal path for other methods (size is a property, not a method)
                     };
@@ -946,6 +943,5 @@ public static partial class TypedAstEvaluator
         {
             set.Clear();
             return JsValue.Undefined;
-        }
     }
 }

--- a/src/Asynkron.JsEngine/Ast/ClassDefinitionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ClassDefinitionExtensions.cs
@@ -121,7 +121,7 @@ public static partial class TypedAstEvaluator
             definition.StaticElements.Length,
             evaluationEnvironment.IsStrict);
         var resolvedFields =
-            ClassDefinition.ResolveFieldNames(definition.Fields, evaluationEnvironment, context, privateNameScope);
+            definition.ResolveFieldNames(definition.Fields, evaluationEnvironment, context, privateNameScope);
         if (context.ShouldStopEvaluation)
         {
             return JsValue.Undefined;
@@ -130,7 +130,7 @@ public static partial class TypedAstEvaluator
         var constructorDefinition = definition.Constructor;
         if (definition.Extends is not null &&
             !constructorDefinition.IsDefaultDerivedConstructor &&
-            IsImplicitDefaultDerivedConstructor(constructorDefinition))
+            constructorDefinition.IsImplicitDefaultDerivedConstructor())
         {
             constructorDefinition = constructorDefinition with { IsDefaultDerivedConstructor = true };
         }
@@ -173,7 +173,7 @@ public static partial class TypedAstEvaluator
         {
             typedFunction.SetSuperBinding(superConstructor, superPrototype);
             var instanceFields = resolvedFields.Where(static field => !field.IsStatic).ToImmutableArray();
-            var resolvedInstanceFields = ClassDefinition.ResolveInstanceFieldNames(instanceFields,
+            var resolvedInstanceFields = definition.ResolveInstanceFieldNames(instanceFields,
                 evaluationEnvironment, context, privateNameScope);
             if (context.ShouldStopEvaluation)
             {
@@ -262,97 +262,94 @@ public static partial class TypedAstEvaluator
         return hasPrivateFields || hasPrivateMembers ? new PrivateNameScope(realm) : null;
     }
 
-    extension(ClassDefinition definition)
+    // ClassFieldDefinitionEvaluation evaluates computed field names during class evaluation,
+    // so resolve all field keys eagerly in declaration order (static + instance).
+    private static ImmutableArray<ClassField> ResolveFieldNames(this ClassDefinition _,
+        ImmutableArray<ClassField> fields,
+        JsEnvironment environment,
+        EvaluationContext context,
+        PrivateNameScope? privateNameScope)
     {
-        // ClassFieldDefinitionEvaluation evaluates computed field names during class evaluation,
-        // so resolve all field keys eagerly in declaration order (static + instance).
-        private static ImmutableArray<ClassField> ResolveFieldNames(
-            ImmutableArray<ClassField> fields,
-            JsEnvironment environment,
-            EvaluationContext context,
-            PrivateNameScope? privateNameScope)
+        if (fields.IsDefaultOrEmpty)
         {
-            if (fields.IsDefaultOrEmpty)
-            {
-                return fields;
-            }
-
-            var builder = ImmutableArray.CreateBuilder<ClassField>(fields.Length);
-            foreach (var field in fields)
-            {
-                var propertyName = field.Name;
-                if (!field.TryResolveFieldName(expr => expr.EvaluateExpression(environment, context),
-                        context,
-                        privateNameScope,
-                        out propertyName))
-                {
-                    context.RealmState.Logger?.LogInformation(
-                        "Class field name resolution aborted (computed={IsComputed}, static={IsStatic}, private={IsPrivate})",
-                        field.IsComputed,
-                        field.IsStatic,
-                        field.IsPrivate);
-                    return fields;
-                }
-
-                context.RealmState.Logger?.LogInformation(
-                    "Class field resolved name: original='{Original}' resolved='{Resolved}' (computed={IsComputed}, static={IsStatic}, private={IsPrivate})",
-                    field.Name,
-                    propertyName,
-                    field.IsComputed,
-                    field.IsStatic,
-                    field.IsPrivate);
-
-                builder.Add(field with { Name = propertyName, IsComputed = false, ComputedName = null });
-            }
-
-            return builder.ToImmutable();
-        }
-
-        // Instance field keys must already be resolved; this simply returns
-        // the provided collection (kept for clarity / future adjustments).
-        [UsedImplicitly]
-        public static ImmutableArray<ClassField> ResolveInstanceFieldNames(
-            ImmutableArray<ClassField> fields,
-            JsEnvironment environment,
-            EvaluationContext context,
-            PrivateNameScope? privateNameScope)
-        {
-            _ = environment;
-            _ = context;
-            _ = privateNameScope;
             return fields;
         }
 
-        [UsedImplicitly]
-        public static bool IsImplicitDefaultDerivedConstructor(FunctionExpression constructor)
+        var builder = ImmutableArray.CreateBuilder<ClassField>(fields.Length);
+        foreach (var field in fields)
         {
-            if (constructor.Parameters.Length != 0)
+            var propertyName = field.Name;
+            if (!field.TryResolveFieldName(expr => expr.EvaluateExpression(environment, context),
+                    context,
+                    privateNameScope,
+                    out propertyName))
             {
-                return false;
+                context.RealmState.Logger?.LogInformation(
+                    "Class field name resolution aborted (computed={IsComputed}, static={IsStatic}, private={IsPrivate})",
+                    field.IsComputed,
+                    field.IsStatic,
+                    field.IsPrivate);
+                return fields;
             }
 
-            if (constructor.Body.Statements.Length != 1)
-            {
-                return false;
-            }
+            context.RealmState.Logger?.LogInformation(
+                "Class field resolved name: original='{Original}' resolved='{Resolved}' (computed={IsComputed}, static={IsStatic}, private={IsPrivate})",
+                field.Name,
+                propertyName,
+                field.IsComputed,
+                field.IsStatic,
+                field.IsPrivate);
 
-            if (constructor.Body.Statements[0] is not ExpressionStatement
-                {
-                    Expression: CallExpression
-                    {
-                        Callee: SuperExpression,
-                        Arguments.Length: 1
-                    } superCall
-                })
-            {
-                return false;
-            }
-
-            var arg = superCall.Arguments[0];
-            return arg.IsSpread && arg.Expression is IdentifierExpression
-            {
-                Name.Name: "arguments"
-            };
+            builder.Add(field with { Name = propertyName, IsComputed = false, ComputedName = null });
         }
+
+        return builder.ToImmutable();
+    }
+
+    // Instance field keys must already be resolved; this simply returns
+    // the provided collection (kept for clarity / future adjustments).
+    [UsedImplicitly]
+    public static ImmutableArray<ClassField> ResolveInstanceFieldNames(this ClassDefinition _definition,
+        ImmutableArray<ClassField> fields,
+        JsEnvironment environment,
+        EvaluationContext context,
+        PrivateNameScope? privateNameScope)
+    {
+        _ = environment;
+        _ = context;
+        _ = privateNameScope;
+        return fields;
+    }
+
+    [UsedImplicitly]
+    public static bool IsImplicitDefaultDerivedConstructor(this FunctionExpression constructor)
+    {
+        if (constructor.Parameters.Length != 0)
+        {
+            return false;
+        }
+
+        if (constructor.Body.Statements.Length != 1)
+        {
+            return false;
+        }
+
+        if (constructor.Body.Statements[0] is not ExpressionStatement
+            {
+                Expression: CallExpression
+                {
+                    Callee: SuperExpression,
+                    Arguments.Length: 1
+                } superCall
+            })
+        {
+            return false;
+        }
+
+        var arg = superCall.Arguments[0];
+        return arg.IsSpread && arg.Expression is IdentifierExpression
+        {
+            Name.Name: "arguments"
+        };
     }
 }

--- a/src/Asynkron.JsEngine/Ast/ClassFieldInitializer.cs
+++ b/src/Asynkron.JsEngine/Ast/ClassFieldInitializer.cs
@@ -44,7 +44,7 @@ public static partial class TypedAstEvaluator
                 return false;
             }
 
-            if (ExpressionNode.IsAnonymousFunctionDefinitionNode(field.Initializer))
+            if (field.Initializer.IsAnonymousFunctionDefinitionNode())
             {
                 SetAnonymousFunctionName(valueJs, displayName);
             }

--- a/src/Asynkron.JsEngine/Ast/ExpressionNodeExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ExpressionNodeExtensions.cs
@@ -232,7 +232,7 @@ public static partial class TypedAstEvaluator
 
     private static bool IsAnonymousFunctionDefinition(this ExpressionNode expression)
     {
-        return ExpressionNode.IsAnonymousFunctionDefinitionNode(expression);
+        return expression.IsAnonymousFunctionDefinitionNode();
     }
 
     private static bool ContainsDirectEvalCall(this ExpressionNode expression)
@@ -330,24 +330,21 @@ public static partial class TypedAstEvaluator
         }
     }
 
-    extension(ExpressionNode expression)
+    internal static bool IsAnonymousFunctionDefinitionNode(this ExpressionNode node)
     {
-        internal static bool IsAnonymousFunctionDefinitionNode(ExpressionNode node)
+        // Per ES spec, sequence expressions (comma operator) do not qualify for name inference
+        // e.g., `const x = (0, function() {})` should not infer name
+        if (node is SequenceExpression)
         {
-            // Per ES spec, sequence expressions (comma operator) do not qualify for name inference
-            // e.g., `const x = (0, function() {})` should not infer name
-            if (node is SequenceExpression)
-            {
-                return false;
-            }
-
-            return node switch
-            {
-                FunctionExpression func => func.Name is null,
-                ClassExpression classExpression => classExpression.Name is null,
-                _ => false
-            };
+            return false;
         }
+
+        return node switch
+        {
+            FunctionExpression func => func.Name is null,
+            ClassExpression classExpression => classExpression.Name is null,
+            _ => false
+        };
     }
 
     private static (JsValue Callee, JsValue thisValue, bool SkippedOptional) EvaluateCallTarget(this ExpressionNode callee, JsEnvironment environment,

--- a/src/Asynkron.JsEngine/Ast/ForEachStatementExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ForEachStatementExtensions.cs
@@ -148,7 +148,7 @@ public static partial class TypedAstEvaluator
                 break;
             }
 
-            IteratorDriverPlan.SyncIterationSlots(cachedPlan, iterationEnvironment, context);
+            cachedPlan.SyncIterationSlots(iterationEnvironment, context);
 
             // Per ES spec 14.7.5.7 ForIn/OfBodyEvaluation step 5.k-l:
             // Only update V (completion value) if result.[[Value]] is not empty

--- a/src/Asynkron.JsEngine/Ast/ImmutableArrayClassMemberExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ImmutableArrayClassMemberExtensions.cs
@@ -36,9 +36,9 @@ public static partial class TypedAstEvaluator
             var baseDisplayName = member.IsPrivate ? member.Name : propertyName;
             var displayName = member.Kind switch
             {
-                ClassMemberKind.Getter => $"get {ObjectExpression.BuildFunctionNameDisplay(baseDisplayName)}",
-                ClassMemberKind.Setter => $"set {ObjectExpression.BuildFunctionNameDisplay(baseDisplayName)}",
-                _ => ObjectExpression.BuildFunctionNameDisplay(baseDisplayName)
+                ClassMemberKind.Getter => $"get {baseDisplayName.BuildFunctionNameDisplay()}",
+                ClassMemberKind.Setter => $"set {baseDisplayName.BuildFunctionNameDisplay()}",
+                _ => baseDisplayName.BuildFunctionNameDisplay()
             };
 
             if (member.IsStatic &&

--- a/src/Asynkron.JsEngine/Ast/IteratorDriverPlanExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/IteratorDriverPlanExtensions.cs
@@ -70,7 +70,7 @@ public static partial class TypedAstEvaluator
             throw new ThrowSignal(context.FlowValue);
         }
 
-        IteratorDriverPlan.SyncIterationSlots(plan, reusableIterationEnvironment, context);
+        plan.SyncIterationSlots(reusableIterationEnvironment, context);
         letConstFirstIterationDone = true;
     }
 
@@ -219,7 +219,7 @@ public static partial class TypedAstEvaluator
                             throw new ThrowSignal(context.FlowValue);
                         }
 
-                        IteratorDriverPlan.SyncIterationSlots(plan, iterationEnvironment, context);
+                        plan.SyncIterationSlots(iterationEnvironment, context);
                     }
 
                     // Check if yield/await happened during binding (e.g., yield in destructuring default)
@@ -334,7 +334,7 @@ public static partial class TypedAstEvaluator
                                 throw new ThrowSignal(context.FlowValue);
                             }
 
-                            IteratorDriverPlan.SyncIterationSlots(plan, iterationEnvironment, context);
+                            plan.SyncIterationSlots(iterationEnvironment, context);
                         }
 
                         // Check if yield/await happened during binding (e.g., yield in destructuring default)
@@ -423,7 +423,7 @@ public static partial class TypedAstEvaluator
                                             throw new ThrowSignal(context.FlowValue);
                                         }
 
-                                        IteratorDriverPlan.SyncIterationSlots(plan, iterationEnvironment, context);
+                                        plan.SyncIterationSlots(iterationEnvironment, context);
                                     }
 
                                     break;
@@ -642,49 +642,46 @@ public static partial class TypedAstEvaluator
         }
     }
 
-    extension(IteratorDriverPlan plan)
+    private static void SyncIterationSlots(this IteratorDriverPlan driverPlan, JsEnvironment iterationEnvironment,
+        EvaluationContext context)
     {
-        private static void SyncIterationSlots(IteratorDriverPlan driverPlan, JsEnvironment iterationEnvironment,
-            EvaluationContext context)
+        if (driverPlan.IterationSlotCount < 0 ||
+            driverPlan.IterationScopeId < 0 ||
+            driverPlan.PerIterationSlotIndices.IsDefaultOrEmpty ||
+            driverPlan.PerIterationBindings.IsDefaultOrEmpty)
         {
-            if (driverPlan.IterationSlotCount < 0 ||
-                driverPlan.IterationScopeId < 0 ||
-                driverPlan.PerIterationSlotIndices.IsDefaultOrEmpty ||
-                driverPlan.PerIterationBindings.IsDefaultOrEmpty)
+            return;
+        }
+
+        if (iterationEnvironment.ScopeId != driverPlan.IterationScopeId)
+        {
+            return;
+        }
+
+        if (!iterationEnvironment.HasSlots)
+        {
+            return;
+        }
+
+        var slotIndices = driverPlan.PerIterationSlotIndices;
+        var bindingNames = driverPlan.PerIterationBindings;
+        var count = Math.Min(slotIndices.Length, bindingNames.Length);
+
+        for (var i = 0; i < count; i++)
+        {
+            var slotIndex = slotIndices[i];
+            if (slotIndex < 0)
             {
-                return;
+                continue;
             }
 
-            if (iterationEnvironment.ScopeId != driverPlan.IterationScopeId)
+            var binding = bindingNames[i];
+            if (!iterationEnvironment.TryGetIdentifierJsValue(binding, context, out var value))
             {
-                return;
+                continue;
             }
 
-            if (!iterationEnvironment.HasSlots)
-            {
-                return;
-            }
-
-            var slotIndices = driverPlan.PerIterationSlotIndices;
-            var bindingNames = driverPlan.PerIterationBindings;
-            var count = Math.Min(slotIndices.Length, bindingNames.Length);
-
-            for (var i = 0; i < count; i++)
-            {
-                var slotIndex = slotIndices[i];
-                if (slotIndex < 0)
-                {
-                    continue;
-                }
-
-                var binding = bindingNames[i];
-                if (!iterationEnvironment.TryGetIdentifierJsValue(binding, context, out var value))
-                {
-                    continue;
-                }
-
-                iterationEnvironment.SetSlotDirect(slotIndex, value);
-            }
+            iterationEnvironment.SetSlotDirect(slotIndex, value);
         }
     }
 

--- a/src/Asynkron.JsEngine/Ast/LoopPlanExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/LoopPlanExtensions.cs
@@ -535,9 +535,9 @@ public static partial class TypedAstEvaluator
             return true;
         }
 
-        if (LoopPlan.StatementsContainDynamicScope(plan.LeadingStatements) ||
-            LoopPlan.StatementsContainDynamicScope(plan.ConditionPrologue) ||
-            LoopPlan.StatementsContainDynamicScope(plan.PostIteration))
+        if (plan.StatementsContainDynamicScope(plan.LeadingStatements) ||
+            plan.StatementsContainDynamicScope(plan.ConditionPrologue) ||
+            plan.StatementsContainDynamicScope(plan.PostIteration))
         {
             return true;
         }
@@ -695,13 +695,13 @@ public static partial class TypedAstEvaluator
             return false;
         }
 
-        if (!LoopPlan.TryExtractAccumulatorPattern(assignExpr, loopVarId, out var accumName,
+        if (!plan.TryExtractAccumulatorPattern(assignExpr, loopVarId, out var accumName,
                 out var accumScopeId, out var accumSlotIndex, out var operation))
         {
             return false;
         }
 
-        return LoopPlan.ExecuteFastNumericLoop(loopVarId, accumName, limit, comparison, isIncrement,
+        return plan.ExecuteFastNumericLoop(loopVarId, accumName, limit, comparison, isIncrement,
             accumScopeId, accumSlotIndex, operation, plan.ConditionAfterBody, environment, out result);
     }
 
@@ -736,7 +736,7 @@ public static partial class TypedAstEvaluator
             return false;
         }
 
-        if (!LoopPlan.TryExtractAccumulatorPattern(assignExpr, loopVarId, out var accumName,
+        if (!plan.TryExtractAccumulatorPattern(assignExpr, loopVarId, out var accumName,
                 out var accumScopeId, out var accumSlotIndex, out var operation))
         {
             return false;
@@ -763,38 +763,36 @@ public static partial class TypedAstEvaluator
             return false;
         }
 
-        return LoopPlan.ExecuteFastNumericLoop(loopVarId, accumName, limit, comparison, isIncrement,
+        return plan.ExecuteFastNumericLoop(loopVarId, accumName, limit, comparison, isIncrement,
             accumScopeId, accumSlotIndex, operation, plan.ConditionAfterBody, environment, out result);
     }
 
-    extension(LoopPlan plan)
+    private static bool StatementsContainDynamicScope(this LoopPlan _, ImmutableArray<StatementNode> statements)
     {
-        private static bool StatementsContainDynamicScope(ImmutableArray<StatementNode> statements)
+        if (statements.IsDefaultOrEmpty)
         {
-            if (statements.IsDefaultOrEmpty)
-            {
-                return false;
-            }
-
-            var synthetic = new BlockStatement(null, statements, false);
-            return DynamicScopeDetector.ContainsWithOrDirectEval(synthetic);
+            return false;
         }
+
+        var synthetic = new BlockStatement(null, statements, false);
+        return DynamicScopeDetector.ContainsWithOrDirectEval(synthetic);
+    }
 
         /// <summary>
         /// Extracts accumulator slot info from a compound assignment expression (s += i, s -= i, s *= i).
         /// </summary>
-        private static bool TryExtractAccumulatorPattern(
-            AssignmentExpression assignExpr,
-            IdentifierExpression loopVarId,
-            out Symbol accumulatorName,
-            out int accumScopeId,
-            out int accumSlotIndex,
-            out FastLoopOperation operation)
-        {
-            accumulatorName = null!;
-            accumScopeId = -1;
-            accumSlotIndex = -1;
-            operation = default;
+    private static bool TryExtractAccumulatorPattern(this LoopPlan _,
+        AssignmentExpression assignExpr,
+        IdentifierExpression loopVarId,
+        out Symbol accumulatorName,
+        out int accumScopeId,
+        out int accumSlotIndex,
+        out FastLoopOperation operation)
+    {
+        accumulatorName = null!;
+        accumScopeId = -1;
+        accumSlotIndex = -1;
+        operation = default;
 
             // Must be compound assignment
             if (!assignExpr.IsCompoundAssignment)
@@ -845,27 +843,27 @@ public static partial class TypedAstEvaluator
             accumulatorName = assignExpr.Target;
             accumScopeId = assignExpr.ScopeId;
             accumSlotIndex = assignExpr.SlotIndex;
-            return true;
-        }
+        return true;
+    }
 
         /// <summary>
         /// Executes the tight numeric loop with pre-resolved slot references.
         /// Supports all comparison operators, increment/decrement, and arithmetic operations.
         /// </summary>
-        private static bool ExecuteFastNumericLoop(
-            IdentifierExpression loopVarId,
-            Symbol accumulatorName,
-            double limit,
-            FastLoopComparison comparison,
-            bool isIncrement,
-            int accumScopeId,
-            int accumSlotIndex,
-            FastLoopOperation operation,
-            bool conditionAfterBody,
-            JsEnvironment environment,
-            out JsValue result)
-        {
-            result = JsValue.Undefined;
+    private static bool ExecuteFastNumericLoop(this LoopPlan _,
+        IdentifierExpression loopVarId,
+        Symbol accumulatorName,
+        double limit,
+        FastLoopComparison comparison,
+        bool isIncrement,
+        int accumScopeId,
+        int accumSlotIndex,
+        FastLoopOperation operation,
+        bool conditionAfterBody,
+        JsEnvironment environment,
+        out JsValue result)
+    {
+        result = JsValue.Undefined;
 
             // Pre-resolve slots
             if (!environment.TryResolveSlot(loopVarId.Name, loopVarId.ScopeId, loopVarId.SlotIndex,
@@ -906,12 +904,12 @@ public static partial class TypedAstEvaluator
                     accumRef = new JsValue(newAccum);
                     lastValue = accumRef;
                     loopVarRef = new JsValue(isIncrement ? i + 1 : i - 1);
-                } while (LoopPlan.CheckCondition(loopVarRef.NumberValue, limit, comparison));
+                } while (CheckCondition(loopVarRef.NumberValue, limit, comparison));
             }
             else
             {
                 // while/for: check condition first
-                while (LoopPlan.CheckCondition(loopVarRef.NumberValue, limit, comparison))
+                while (CheckCondition(loopVarRef.NumberValue, limit, comparison))
                 {
                     var i = loopVarRef.NumberValue;
                     var s = accumRef.NumberValue;
@@ -932,19 +930,18 @@ public static partial class TypedAstEvaluator
 
             result = lastValue;
             return true;
-        }
+    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool CheckCondition(double loopVar, double limit, FastLoopComparison comparison)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool CheckCondition(double loopVar, double limit, FastLoopComparison comparison)
+    {
+        return comparison switch
         {
-            return comparison switch
-            {
-                FastLoopComparison.LessThan => loopVar < limit,
-                FastLoopComparison.LessThanOrEqual => loopVar <= limit,
-                FastLoopComparison.GreaterThan => loopVar > limit,
-                FastLoopComparison.GreaterThanOrEqual => loopVar >= limit,
-                _ => false
-            };
-        }
+            FastLoopComparison.LessThan => loopVar < limit,
+            FastLoopComparison.LessThanOrEqual => loopVar <= limit,
+            FastLoopComparison.GreaterThan => loopVar > limit,
+            FastLoopComparison.GreaterThanOrEqual => loopVar >= limit,
+            _ => false
+        };
     }
 }

--- a/src/Asynkron.JsEngine/Ast/ObjectExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ObjectExpressionExtensions.cs
@@ -56,7 +56,7 @@ public static partial class TypedAstEvaluator
                         if (valueJs.ObjectValue is IFunctionNameTarget nameTarget &&
                             member.Value is FunctionExpression { Name: null } or ClassExpression { Name: null })
                         {
-                            var displayName = ObjectExpression.BuildFunctionNameDisplay(name);
+                            var displayName = name.BuildFunctionNameDisplay();
                             nameTarget.EnsureHasName(displayName);
                         }
 
@@ -98,7 +98,7 @@ public static partial class TypedAstEvaluator
 
                         if (callable is IFunctionNameTarget nameTarget)
                         {
-                            var displayName = ObjectExpression.BuildFunctionNameDisplay(name);
+                            var displayName = name.BuildFunctionNameDisplay();
                             nameTarget.EnsureHasName(displayName);
                         }
 
@@ -127,7 +127,7 @@ public static partial class TypedAstEvaluator
                             return JsValue.Undefined;
                         }
 
-                        getter.EnsureHasName($"get {ObjectExpression.BuildFunctionNameDisplay(name)}");
+                        getter.EnsureHasName($"get {name.BuildFunctionNameDisplay()}");
 
                         obj.DefineAccessorProperty(name, getter, null);
                         break;
@@ -147,7 +147,7 @@ public static partial class TypedAstEvaluator
                             return JsValue.Undefined;
                         }
 
-                        setter.EnsureHasName($"set {ObjectExpression.BuildFunctionNameDisplay(name)}");
+                        setter.EnsureHasName($"set {name.BuildFunctionNameDisplay()}");
 
                         obj.DefineAccessorProperty(name, null, setter);
                         break;
@@ -239,16 +239,13 @@ public static partial class TypedAstEvaluator
         return new JsValue(obj);
     }
 
-    extension(ObjectExpression expression)
+    private static string BuildFunctionNameDisplay(this string propertyName)
     {
-        private static string BuildFunctionNameDisplay(string propertyName)
+        if (JsSymbol.TryGetByInternalKey(propertyName, out var symbol))
         {
-            if (JsSymbol.TryGetByInternalKey(propertyName, out var symbol))
-            {
-                return symbol!.Description is null ? string.Empty : $"[{symbol.Description}]";
-            }
-
-            return propertyName;
+            return symbol!.Description is null ? string.Empty : $"[{symbol.Description}]";
         }
+
+        return propertyName;
     }
 }

--- a/src/Asynkron.JsEngine/Ast/SwitchStatementExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/SwitchStatementExtensions.cs
@@ -31,7 +31,7 @@ public static partial class TypedAstEvaluator
         using var scopeHandle = context.PushScope(ScopeKind.Block, scopeMode);
 
         // Hoist lexical declarations from all case bodies
-        SwitchStatement.InstantiateSwitchLexicalDeclarations(instantiationPlan, switchEnv, context);
+        statement.InstantiateSwitchLexicalDeclarations(instantiationPlan, switchEnv, context);
 
         // V = undefined (spec step 1)
         var completionValue = JsValue.Undefined;
@@ -79,7 +79,7 @@ public static partial class TypedAstEvaluator
             // Evaluate the case clause body statements in the switch environment
             // We evaluate the statements directly without creating a new block environment
             var (caseCompletionJs, hasCaseJs) =
-                SwitchStatement.EvaluateCaseClauseBodyJsValue(switchCase.Body, switchEnv, context);
+                statement.EvaluateCaseClauseBodyJsValue(switchCase.Body, switchEnv, context);
 
             // If R.[[value]] is not empty, let V = R.[[value]] (spec step 4.b.ii)
             // UpdateEmpty semantics: only update V if the completion is not empty
@@ -104,109 +104,108 @@ public static partial class TypedAstEvaluator
         return completionValue;
     }
 
-    extension(SwitchStatement statement)
+    private static void InstantiateSwitchLexicalDeclarations(this SwitchStatement _,
+        SwitchInstantiationPlan plan,
+        JsEnvironment switchEnv,
+        EvaluationContext context)
     {
-        private static void InstantiateSwitchLexicalDeclarations(SwitchInstantiationPlan plan,
-            JsEnvironment switchEnv,
-            EvaluationContext context)
+        foreach (var binding in plan.LexicalBindings)
         {
-            foreach (var binding in plan.LexicalBindings)
-            {
-                binding.Target.CreateUninitializedLexicalBindings(switchEnv, binding.IsConst);
-            }
+            binding.Target.CreateUninitializedLexicalBindings(switchEnv, binding.IsConst);
+        }
 
-            foreach (var funcBinding in plan.FunctionBindings)
+        foreach (var funcBinding in plan.FunctionBindings)
+        {
+            if (!funcBinding.InitializeNow)
             {
-                if (!funcBinding.InitializeNow)
-                {
-                    switchEnv.DefineJsValue(
-                        funcBinding.Name,
-                        JsValue.Uninitialized,
-                        true,
-                        isLexicalBinding: true,
-                        blocksFunctionScopeOverride: true);
-                    continue;
-                }
-
-                var functionValue = funcBinding.Function.CreateFunctionValue(switchEnv, context,
-                    skipInternalNameBinding: true);
                 switchEnv.DefineJsValue(
                     funcBinding.Name,
-                    JsValue.FromObjectUnsafe(functionValue),
+                    JsValue.Uninitialized,
                     true,
                     isLexicalBinding: true,
                     blocksFunctionScopeOverride: true);
+                continue;
             }
 
-            foreach (var className in plan.ClassBindings)
-            {
-                switchEnv.DefineJsValue(
-                    className,
-                    JsValue.Undefined,
-                    true,
-                    isLexicalBinding: true,
-                    blocksFunctionScopeOverride: false);
-            }
+            var functionValue = funcBinding.Function.CreateFunctionValue(switchEnv, context,
+                skipInternalNameBinding: true);
+            switchEnv.DefineJsValue(
+                funcBinding.Name,
+                JsValue.FromObjectUnsafe(functionValue),
+                true,
+                isLexicalBinding: true,
+                blocksFunctionScopeOverride: true);
         }
 
-        /// <summary>
-        /// Evaluates a case clause body and returns a tuple with the value and whether it produced a value.
-        /// </summary>
-        private static (JsValue result, bool hasResult) EvaluateCaseClauseBodyJsValue(BlockStatement body,
-            JsEnvironment switchEnv,
-            EvaluationContext context)
+        foreach (var className in plan.ClassBindings)
         {
-            // Evaluate statements in the case clause body without creating a new environment
-            // The statements are evaluated in the shared switch environment
-            var hasResult = false;
-            var result = JsValue.Undefined;
+            switchEnv.DefineJsValue(
+                className,
+                JsValue.Undefined,
+                true,
+                isLexicalBinding: true,
+                blocksFunctionScopeOverride: false);
+        }
+    }
 
-            foreach (var stmt in body.Statements)
+    /// <summary>
+    /// Evaluates a case clause body and returns a tuple with the value and whether it produced a value.
+    /// </summary>
+    private static (JsValue result, bool hasResult) EvaluateCaseClauseBodyJsValue(this SwitchStatement _,
+        BlockStatement body,
+        JsEnvironment switchEnv,
+        EvaluationContext context)
+    {
+        // Evaluate statements in the case clause body without creating a new environment
+        // The statements are evaluated in the shared switch environment
+        var hasResult = false;
+        var result = JsValue.Undefined;
+
+        foreach (var stmt in body.Statements)
+        {
+            context.ThrowIfCancellationRequested();
+
+            // Special handling for async/generator function declarations
+            // They need to be initialized when evaluated (not during instantiation)
+            if (stmt is FunctionDeclaration funcDecl &&
+                (funcDecl.Function.IsAsync || funcDecl.Function.WasAsync || funcDecl.Function.IsGenerator))
             {
-                context.ThrowIfCancellationRequested();
-
-                // Special handling for async/generator function declarations
-                // They need to be initialized when evaluated (not during instantiation)
-                if (stmt is FunctionDeclaration funcDecl &&
-                    (funcDecl.Function.IsAsync || funcDecl.Function.WasAsync || funcDecl.Function.IsGenerator))
-                {
-                    // Pass skipInternalNameBinding: true so the function doesn't create an internal
-                    // const binding for its name (the binding was already defined during instantiation).
-                    var functionValue = funcDecl.Function.CreateFunctionValue(switchEnv, context,
-                        skipInternalNameBinding: true);
-                    switchEnv.AssignJsValue(funcDecl.Name, JsValue.FromObjectUnsafe(functionValue));
-                    // Function declarations have empty completion
-                    continue;
-                }
-
-                var completion = stmt.EvaluateStatementJsValue(switchEnv, context);
-                var shouldStop = context.ShouldStopEvaluation;
-                // Apply UpdateEmpty semantics: only update result if completion is not empty (Unit)
-                // This preserves the previous value when break/continue have empty completion
-                var shouldCapture =
-                    !completion.IsUnit &&
-                    (!shouldStop ||
-                     context.IsReturn ||
-                     context.IsThrow ||
-                     context.IsYield ||
-                     context.IsBreak ||
-                     context.IsContinue);
-
-                if (shouldCapture)
-                {
-                    result = completion;
-                    hasResult = true;
-                }
-
-                if (shouldStop)
-                {
-                    break;
-                }
+                // Pass skipInternalNameBinding: true so the function doesn't create an internal
+                // const binding for its name (the binding was already defined during instantiation).
+                var functionValue = funcDecl.Function.CreateFunctionValue(switchEnv, context,
+                    skipInternalNameBinding: true);
+                switchEnv.AssignJsValue(funcDecl.Name, JsValue.FromObjectUnsafe(functionValue));
+                // Function declarations have empty completion
+                continue;
             }
 
-            return (result, hasResult);
+            var completion = stmt.EvaluateStatementJsValue(switchEnv, context);
+            var shouldStop = context.ShouldStopEvaluation;
+            // Apply UpdateEmpty semantics: only update result if completion is not empty (Unit)
+            // This preserves the previous value when break/continue have empty completion
+            var shouldCapture =
+                !completion.IsUnit &&
+                (!shouldStop ||
+                 context.IsReturn ||
+                 context.IsThrow ||
+                 context.IsYield ||
+                 context.IsBreak ||
+                 context.IsContinue);
+
+            if (shouldCapture)
+            {
+                result = completion;
+                hasResult = true;
+            }
+
+            if (shouldStop)
+            {
+                break;
+            }
         }
 
-        // Strictness is precomputed in the instantiation plan.
+        return (result, hasResult);
     }
+
+    // Strictness is precomputed in the instantiation plan.
 }

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Declarations.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Declarations.cs
@@ -90,7 +90,7 @@ public static partial class TypedAstEvaluator
         {
             var instruction = Unsafe.As<SimpleVariableDeclarationInstruction>(instr);
             var isAnonymousFunctionDefinition = instruction.Initializer is not null &&
-                ExpressionNode.IsAnonymousFunctionDefinitionNode(instruction.Initializer);
+                instruction.Initializer.IsAnonymousFunctionDefinitionNode();
 
             using var functionNameHint = isAnonymousFunctionDefinition
                 ? context.EnterFunctionNameHint(instruction.TargetSymbol)

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -1715,7 +1715,7 @@ public static partial class TypedAstEvaluator
                         typedFunction.SetSuperBinding(fieldSuperBinding.Constructor, fieldSuperBinding.Prototype);
                     }
 
-                    if (ExpressionNode.IsAnonymousFunctionDefinitionNode(field.Initializer))
+                    if (field.Initializer.IsAnonymousFunctionDefinitionNode())
                     {
                         var displayName = field.IsComputed ? propertyName : field.Name;
                         var atIndex = displayName.IndexOf('@', StringComparison.Ordinal);

--- a/src/Asynkron.JsEngine/Ast/UnaryExpressionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/UnaryExpressionExtensions.cs
@@ -202,7 +202,7 @@ public static partial class TypedAstEvaluator
         catch (InvalidOperationException ex) when (ex.Message.StartsWith("ReferenceError:",
                                                        StringComparison.Ordinal))
         {
-            return UnaryExpression.HandleReferenceErrorUnary(ex, environment, context);
+            return expression.HandleReferenceErrorUnary(ex, environment, context);
         }
     }
 
@@ -276,31 +276,28 @@ public static partial class TypedAstEvaluator
         };
     }
 
-    extension(UnaryExpression expression)
+    /// <summary>
+    /// Handles ReferenceError exceptions from unary operations.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static JsValue HandleReferenceErrorUnary(this UnaryExpression _, InvalidOperationException ex, JsEnvironment environment,
+        EvaluationContext context)
     {
-        /// <summary>
-        /// Handles ReferenceError exceptions from unary operations.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static JsValue HandleReferenceErrorUnary(InvalidOperationException ex, JsEnvironment environment,
-            EvaluationContext context)
+        var errorValue = new JsValue(ex.Message);
+
+        if (environment.TryGetObject<IJsCallable>(Symbol.ReferenceErrorIdentifier, out var callable))
         {
-            var errorValue = new JsValue(ex.Message);
-
-            if (environment.TryGetObject<IJsCallable>(Symbol.ReferenceErrorIdentifier, out var callable))
+            try
             {
-                try
-                {
-                    errorValue = callable.Invoke(new SingleValueArgs(new JsValue(ex.Message)), JsValue.Undefined);
-                }
-                catch (ThrowSignal signal)
-                {
-                    errorValue = signal.ThrownValue;
-                }
+                errorValue = callable.Invoke(new SingleValueArgs(new JsValue(ex.Message)), JsValue.Undefined);
             }
-
-            context.SetThrow(errorValue);
-            return errorValue;
+            catch (ThrowSignal signal)
+            {
+                errorValue = signal.ThrownValue;
+            }
         }
+
+        context.SetThrow(errorValue);
+        return errorValue;
     }
 }

--- a/src/Asynkron.JsEngine/Ast/VariableKindExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/VariableKindExtensions.cs
@@ -41,7 +41,7 @@ public static partial class TypedAstEvaluator
         // then perform SetFunctionName(value, bindingId).
         using var functionNameHint = targetIdentifier is not null &&
                                      declarator.Initializer is not null &&
-                                     ExpressionNode.IsAnonymousFunctionDefinitionNode(declarator.Initializer)
+                                     declarator.Initializer.IsAnonymousFunctionDefinitionNode()
             ? context.EnterFunctionNameHint(targetIdentifier.Name)
             : null;
 
@@ -106,7 +106,7 @@ public static partial class TypedAstEvaluator
 
         // Per ES spec 13.3.1.4: Name inference only applies if IsAnonymousFunctionDefinition(Initializer) is true
         var allowNameInference = declarator.Initializer is not null &&
-                                 ExpressionNode.IsAnonymousFunctionDefinitionNode(declarator.Initializer);
+                                 declarator.Initializer.IsAnonymousFunctionDefinitionNode();
         declarator.Target.ApplyBindingTarget(valueJs, environment, context, mode,
             declarator.Initializer is not null, allowNameInference);
     }


### PR DESCRIPTION
## Summary
- replace C# 14 extension blocks with classic extension methods/helpers
- update call sites to use instance extensions and local helpers
- keep Map/Set fast-path helpers calling local methods

## Testing
- dotnet build

Closes #446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal code structure across the evaluation framework for improved maintainability and consistency. No changes to functionality or user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->