### PR TITLE
Remove StatementInstruction fallbacks

### DIFF
--- a/src/Asynkron.JsEngine/Execution/Emitters/DeclarationEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/DeclarationEmitter.cs
@@ -52,7 +52,7 @@ internal static class DeclarationEmitter
 
     /// <summary>
     /// Try to emit IR for a variable declaration.
-    /// Handles yield initializers, binding target defaults, and falls back to StatementInstruction when needed.
+    /// Handles yield initializers, binding target defaults, and falls back to ComplexVariableDeclarationInstruction when needed.
     /// </summary>
     public static bool TryEmitVariableDeclaration(
         EmitContext ctx,
@@ -68,13 +68,13 @@ internal static class DeclarationEmitter
 
         // Check for variable declarations with yields in binding target default values.
         // These cannot be safely lowered because defaults are only evaluated when
-        // the value is undefined. Wrap them as StatementInstruction.
+        // the value is undefined. Use the complex declaration instruction (AST eval).
         if (DeclarationContainsYieldInBindingTargetDefaults(declaration))
         {
             // AST fallback: var decl with yield in binding target defaults
             // Reason: Conditional yield semantics in destructuring defaults
             // Tracking: #398, #416 (IR-only execution epic)
-            entryIndex = ctx.Append(new StatementInstruction(nextIndex, declaration));
+            entryIndex = ctx.Append(new ComplexVariableDeclarationInstruction(nextIndex, declaration));
             return true;
         }
 

--- a/src/Asynkron.JsEngine/Execution/Emitters/ExpressionStatementEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/ExpressionStatementEmitter.cs
@@ -41,13 +41,17 @@ internal static class ExpressionStatementEmitter
         // extracted. This includes:
         // - Yields in default values (only evaluated when element is undefined)
         // - Yields in assignment target expressions (e.g., [ {}[ yield ] ] = x)
-        // Wrap them as StatementInstruction to use AST evaluation's state-saving.
         if (EmitContext.ExpressionContainsDestructuringWithYieldAnywhere(expressionStatement.Expression))
         {
             // AST fallback: expression statement with yield in destructuring
             // Reason: Conditional yield semantics in destructuring defaults/targets
             // Tracking: #398, #416 (IR-only execution epic)
-            entryIndex = ctx.Append(new StatementInstruction(nextIndex, expressionStatement));
+            var suppressCompletionFallback =
+                ctx.SuppressCompletionValue || expressionStatement.SuppressCompletionValue;
+            entryIndex = ctx.Append(new EvaluateAndDiscardInstruction(
+                nextIndex,
+                expressionStatement.Expression,
+                suppressCompletionFallback));
             return true;
         }
 

--- a/src/Asynkron.JsEngine/Execution/Emitters/StatementEmitter.cs
+++ b/src/Asynkron.JsEngine/Execution/Emitters/StatementEmitter.cs
@@ -221,20 +221,6 @@ internal static class StatementEmitter
         Symbol? activeLabel,
         out int entryIndex)
     {
-        // If binding target has yields anywhere (defaults or assignment target expressions),
-        // wrap as StatementInstruction. The AST evaluator handles yield state-saving correctly.
-        // This handles patterns like: for ([ {}[ yield ] ] of iterable) { }
-        if (EmitContext.BindingTargetContainsYieldAnywhere(forEachStatement.Target) &&
-            !AstShapeAnalyzer.StatementContainsYield(forEachStatement.Body) &&
-            !AstShapeAnalyzer.ContainsYield(forEachStatement.Iterable))
-        {
-            // AST fallback: for-of with yield in binding target
-            // Reason: Conditional yield semantics in destructuring defaults
-            // Tracking: #398, #416 (IR-only execution epic)
-            entryIndex = ctx.Append(new StatementInstruction(nextIndex, forEachStatement));
-            return true;
-        }
-
         return ForOfEmitter.TryEmit(ctx, forEachStatement, nextIndex, activeLabel, out entryIndex);
     }
 
@@ -249,18 +235,6 @@ internal static class StatementEmitter
         Symbol? activeLabel,
         out int entryIndex)
     {
-        // If binding target has yields anywhere (defaults or assignment target expressions),
-        // we cannot emit IR - fall back to StatementInstruction.
-        if (EmitContext.BindingTargetContainsYieldAnywhere(forInStatement.Target) &&
-            !AstShapeAnalyzer.StatementContainsYield(forInStatement.Body) &&
-            !AstShapeAnalyzer.ContainsYield(forInStatement.Iterable))
-        {
-            // AST fallback: for-in with yield in binding target
-            // Reason: Conditional yield semantics in destructuring defaults
-            entryIndex = ctx.Append(new StatementInstruction(nextIndex, forInStatement));
-            return true;
-        }
-
         return ForInEmitter.TryEmit(ctx, forInStatement, nextIndex, activeLabel, out entryIndex);
     }
 


### PR DESCRIPTION
## Summary\n- route destructuring yield defaults through ComplexVariableDeclarationInstruction instead of StatementInstruction\n- use EvaluateAndDiscardInstruction for destructuring assignment yields\n- rely on ForOfEmitter/ForInEmitter without StatementInstruction fallback\n\n## Testing\n- dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~Yield"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimizations to improve code execution efficiency and control flow handling in complex scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->