### PR TITLE
Centralize hot JsValueKind predicates (IsNumberLike, IsHeapValue)

### DIFF
--- a/src/Asynkron.JsEngine/JsTypes/JsValue.cs
+++ b/src/Asynkron.JsEngine/JsTypes/JsValue.cs
@@ -348,6 +348,45 @@ public readonly struct JsValue : IEquatable<JsValue>
         get => Kind == JsValueKind.Unit;
     }
 
+    /// <summary>
+    /// True if this value stores its data in NumberValue (Boolean or Number).
+    /// Uses range check: (uint)(Kind - Boolean) &lt;= 1, which the JIT optimizes to a single comparison.
+    /// </summary>
+    public bool IsNumberLike
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => IsKindNumberLike(Kind);
+    }
+
+    /// <summary>
+    /// True if this value uses the heap-allocated ObjectValue field (String, Symbol, Object, Unit, Uninitialized).
+    /// Note: BigInt also uses ObjectValue but is not included in this check.
+    /// Uses range check: Kind >= String, which the JIT optimizes to a single comparison.
+    /// </summary>
+    public bool IsHeapValue
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => IsKindHeapValue(Kind);
+    }
+
+    /// <summary>
+    /// Static helper to check if a kind stores its data in NumberValue (Boolean or Number).
+    /// Uses range check: (uint)(kind - Boolean) &lt;= 1, which the JIT optimizes to a single comparison.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsKindNumberLike(JsValueKind kind)
+        => (uint)(kind - JsValueKind.Boolean) <= 1;
+
+    /// <summary>
+    /// Static helper to check if a kind uses the heap-allocated ObjectValue field.
+    /// Covers: String, Symbol, Object, Unit, Uninitialized.
+    /// Note: BigInt also uses ObjectValue but is not included in this check.
+    /// Uses range check: kind >= String, which the JIT optimizes to a single comparison.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsKindHeapValue(JsValueKind kind)
+        => kind >= JsValueKind.String;
+
     #endregion
 
     #region Value Accessors


### PR DESCRIPTION
## Summary
- Add `IsKindNumberLike(JsValueKind)` static helper - checks if kind is Boolean or Number (types that store data in NumberValue field)
- Add `IsKindHeapValue(JsValueKind)` static helper - checks if kind is String, Symbol, Object, Unit, or Uninitialized (types that use ObjectValue field)
- Add corresponding instance properties `IsNumberLike` and `IsHeapValue` on `JsValue`
- All methods use `[MethodImpl(MethodImplOptions.AggressiveInlining)]` for optimal JIT codegen

## Implementation Details
The helpers use range checks that the JIT optimizes to single comparisons:
- `IsKindNumberLike`: `(uint)(kind - JsValueKind.Boolean) <= 1`
- `IsKindHeapValue`: `kind >= JsValueKind.String`

Note: BigInt also uses ObjectValue but is not included in IsHeapValue (it falls between Number and String in the enum).

## Test plan
- [x] Build passes: `dotnet build src/Asynkron.JsEngine`
- [x] Tests pass: `dotnet test tests/Asynkron.JsEngine.Tests --filter "Category!=Test262"` (5 pre-existing failures unrelated to this change)

Fixes #460

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new type-checking properties and utility methods for JavaScript values, enabling efficient identification of numeric and heap-allocated value types at runtime. These additions expand the available APIs while maintaining full backward compatibility with existing code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->