### PR TITLE
Apply hot/cold path separation to remaining handlers

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.ControlFlow.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.ControlFlow.cs
@@ -134,6 +134,7 @@ public static partial class TypedAstEvaluator
             return InstructionResult.Continue;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static InstructionResult HandleReturn(
             ExecutionPlanRunner runner,
             ExecutionInstruction instr,
@@ -152,20 +153,7 @@ public static partial class TypedAstEvaluator
 
             if (context.IsThrow)
             {
-                var pendingThrow = context.FlowValue;
-                context.Clear();
-                if (runner.HandleAbruptCompletion(AbruptKind.Throw, pendingThrow))
-                {
-                    if (runner._programCounter == runner._currentInstructionIndex)
-                    {
-                        runner._programCounter = instruction.Next;
-                    }
-                    returnValue = default;
-                    return InstructionResult.Continue;
-                }
-
-                runner.TryCatchStateRef.TryStack.Clear();
-                throw new ThrowSignal(pendingThrow);
+                return HandleReturnThrowSlow(runner, instruction, context, out returnValue);
             }
 
             if (context.IsReturn)
@@ -197,6 +185,29 @@ public static partial class TypedAstEvaluator
             return InstructionResult.Return;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleReturnThrowSlow(
+            ExecutionPlanRunner runner,
+            ReturnInstruction instruction,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var pendingThrow = context.FlowValue;
+            context.Clear();
+            if (runner.HandleAbruptCompletion(AbruptKind.Throw, pendingThrow))
+            {
+                if (runner._programCounter == runner._currentInstructionIndex)
+                {
+                    runner._programCounter = instruction.Next;
+                }
+                returnValue = default;
+                return InstructionResult.Continue;
+            }
+
+            runner.TryCatchStateRef.TryStack.Clear();
+            throw new ThrowSignal(pendingThrow);
+        }
+
 #if NO_INLINING
         [MethodImpl(MethodImplOptions.NoInlining)]
 #else
@@ -214,6 +225,7 @@ public static partial class TypedAstEvaluator
             return InstructionResult.Continue;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static InstructionResult HandleBranch(
             ExecutionPlanRunner runner,
             ExecutionInstruction instr,
@@ -232,21 +244,30 @@ public static partial class TypedAstEvaluator
 
             if (context.IsThrow)
             {
-                var thrownValue = context.FlowValue;
-                context.Clear();
-                if (runner.HandleAbruptCompletion(AbruptKind.Throw, thrownValue))
-                {
-                    returnValue = default;
-                    return InstructionResult.Continue;
-                }
-
-                runner.TryCatchStateRef.TryStack.Clear();
-                throw new ThrowSignal(thrownValue);
+                return HandleBranchThrowSlow(runner, context, out returnValue);
             }
 
             runner._programCounter = testValue.IsTruthy ? instruction.ConsequentIndex : instruction.AlternateIndex;
             returnValue = default;
             return InstructionResult.Continue;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleBranchThrowSlow(
+            ExecutionPlanRunner runner,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var thrownValue = context.FlowValue;
+            context.Clear();
+            if (runner.HandleAbruptCompletion(AbruptKind.Throw, thrownValue))
+            {
+                returnValue = default;
+                return InstructionResult.Continue;
+            }
+
+            runner.TryCatchStateRef.TryStack.Clear();
+            throw new ThrowSignal(thrownValue);
         }
     }
 }

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Declarations.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Declarations.cs
@@ -42,6 +42,7 @@ public static partial class TypedAstEvaluator
             return InstructionResult.Continue;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static InstructionResult HandleClassDeclaration(
             ExecutionPlanRunner runner,
             ExecutionInstruction instr,
@@ -61,16 +62,7 @@ public static partial class TypedAstEvaluator
 
             if (context.IsThrow)
             {
-                var classThrown = context.FlowValue;
-                context.Clear();
-                if (runner.HandleAbruptCompletion(AbruptKind.Throw, classThrown))
-                {
-                    returnValue = default;
-                    return InstructionResult.Continue;
-                }
-
-                runner.TryCatchStateRef.TryStack.Clear();
-                throw new ThrowSignal(classThrown);
+                return HandleClassDeclarationThrowSlow(runner, context, out returnValue);
             }
 
             environment.DefineJsValue(instruction.Declaration.Name, classValue,
@@ -81,6 +73,25 @@ public static partial class TypedAstEvaluator
             return InstructionResult.Continue;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleClassDeclarationThrowSlow(
+            ExecutionPlanRunner runner,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var classThrown = context.FlowValue;
+            context.Clear();
+            if (runner.HandleAbruptCompletion(AbruptKind.Throw, classThrown))
+            {
+                returnValue = default;
+                return InstructionResult.Continue;
+            }
+
+            runner.TryCatchStateRef.TryStack.Clear();
+            throw new ThrowSignal(classThrown);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static InstructionResult HandleSimpleVariableDeclaration(
             ExecutionPlanRunner runner,
             ExecutionInstruction instr,
@@ -106,51 +117,17 @@ public static partial class TypedAstEvaluator
 
             if (context.IsThrow)
             {
-                var varThrown = context.FlowValue;
-                context.Clear();
-                if (runner.HandleAbruptCompletion(AbruptKind.Throw, varThrown))
-                {
-                    if (runner._programCounter == runner._currentInstructionIndex)
-                    {
-                        runner._programCounter = instruction.Next;
-                    }
-                    returnValue = default;
-                    return InstructionResult.Continue;
-                }
-
-                runner.TryCatchStateRef.TryStack.Clear();
-                throw new ThrowSignal(varThrown);
+                return HandleSimpleVariableDeclarationThrowSlow(runner, instruction, context, out returnValue);
             }
 
             if (context.IsReturn)
             {
-                var varReturnValue = context.FlowValue;
-                context.ClearReturn();
-                if (!runner.HandleAbruptCompletion(AbruptKind.Return, varReturnValue))
-                {
-                    returnValue = runner.CompleteReturn(varReturnValue);
-                    return InstructionResult.Return;
-                }
-
-                if (runner._programCounter == runner._currentInstructionIndex)
-                {
-                    runner._programCounter = instruction.Next;
-                }
-                returnValue = default;
-                return InstructionResult.Continue;
+                return HandleSimpleVariableDeclarationReturnSlow(runner, instruction, context, out returnValue);
             }
 
             if (context.IsYield)
             {
-                var varYieldedValue = context.FlowValue;
-                var varIteratorResultObject = (context.CurrentSignal as YieldCompletionSignal)?.IteratorResultObject;
-                runner.RecordYield(context, environment);
-                context.Clear();
-                runner._state = GeneratorState.Suspended;
-                returnValue = varIteratorResultObject is not null
-                    ? JsValue.FromObjectUnsafe(varIteratorResultObject)
-                    : CreateIteratorResult(varYieldedValue, false);
-                return InstructionResult.Return;
+                return HandleSimpleVariableDeclarationYieldSlow(runner, ref environment, context, out returnValue);
             }
 
             if (instruction.VarKind == VariableKind.Var)
@@ -190,6 +167,71 @@ public static partial class TypedAstEvaluator
             return InstructionResult.Continue;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleSimpleVariableDeclarationThrowSlow(
+            ExecutionPlanRunner runner,
+            SimpleVariableDeclarationInstruction instruction,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var varThrown = context.FlowValue;
+            context.Clear();
+            if (runner.HandleAbruptCompletion(AbruptKind.Throw, varThrown))
+            {
+                if (runner._programCounter == runner._currentInstructionIndex)
+                {
+                    runner._programCounter = instruction.Next;
+                }
+                returnValue = default;
+                return InstructionResult.Continue;
+            }
+
+            runner.TryCatchStateRef.TryStack.Clear();
+            throw new ThrowSignal(varThrown);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleSimpleVariableDeclarationReturnSlow(
+            ExecutionPlanRunner runner,
+            SimpleVariableDeclarationInstruction instruction,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var varReturnValue = context.FlowValue;
+            context.ClearReturn();
+            if (!runner.HandleAbruptCompletion(AbruptKind.Return, varReturnValue))
+            {
+                returnValue = runner.CompleteReturn(varReturnValue);
+                return InstructionResult.Return;
+            }
+
+            if (runner._programCounter == runner._currentInstructionIndex)
+            {
+                runner._programCounter = instruction.Next;
+            }
+            returnValue = default;
+            return InstructionResult.Continue;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleSimpleVariableDeclarationYieldSlow(
+            ExecutionPlanRunner runner,
+            ref JsEnvironment environment,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var varYieldedValue = context.FlowValue;
+            var varIteratorResultObject = (context.CurrentSignal as YieldCompletionSignal)?.IteratorResultObject;
+            runner.RecordYield(context, environment);
+            context.Clear();
+            runner._state = GeneratorState.Suspended;
+            returnValue = varIteratorResultObject is not null
+                ? JsValue.FromObjectUnsafe(varIteratorResultObject)
+                : CreateIteratorResult(varYieldedValue, false);
+            return InstructionResult.Return;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static InstructionResult HandleComplexVariableDeclaration(
             ExecutionPlanRunner runner,
             ExecutionInstruction instr,
@@ -211,32 +253,35 @@ public static partial class TypedAstEvaluator
 
             if (context.IsThrow)
             {
-                var thrown = context.FlowValue;
-                context.Clear();
-                if (runner.HandleAbruptCompletion(AbruptKind.Throw, thrown))
-                {
-                    if (runner._programCounter == runner._currentInstructionIndex)
-                    {
-                        runner._programCounter = instruction.Next;
-                    }
-                    returnValue = default;
-                    return InstructionResult.Continue;
-                }
-
-                runner.TryCatchStateRef.TryStack.Clear();
-                throw new ThrowSignal(thrown);
+                return HandleComplexVariableDeclarationThrowSlow(runner, instruction, context, out returnValue);
             }
 
             if (context.IsReturn)
             {
-                var returnVal = context.FlowValue;
-                context.ClearReturn();
-                if (!runner.HandleAbruptCompletion(AbruptKind.Return, returnVal))
-                {
-                    returnValue = runner.CompleteReturn(returnVal);
-                    return InstructionResult.Return;
-                }
+                return HandleComplexVariableDeclarationReturnSlow(runner, instruction, context, out returnValue);
+            }
 
+            if (context.IsYield)
+            {
+                return HandleComplexVariableDeclarationYieldSlow(runner, ref environment, context, out returnValue);
+            }
+
+            runner._programCounter = instruction.Next;
+            returnValue = default;
+            return InstructionResult.Continue;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleComplexVariableDeclarationThrowSlow(
+            ExecutionPlanRunner runner,
+            ComplexVariableDeclarationInstruction instruction,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var thrown = context.FlowValue;
+            context.Clear();
+            if (runner.HandleAbruptCompletion(AbruptKind.Throw, thrown))
+            {
                 if (runner._programCounter == runner._currentInstructionIndex)
                 {
                     runner._programCounter = instruction.Next;
@@ -245,22 +290,49 @@ public static partial class TypedAstEvaluator
                 return InstructionResult.Continue;
             }
 
-            if (context.IsYield)
+            runner.TryCatchStateRef.TryStack.Clear();
+            throw new ThrowSignal(thrown);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleComplexVariableDeclarationReturnSlow(
+            ExecutionPlanRunner runner,
+            ComplexVariableDeclarationInstruction instruction,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var returnVal = context.FlowValue;
+            context.ClearReturn();
+            if (!runner.HandleAbruptCompletion(AbruptKind.Return, returnVal))
             {
-                var yieldedValue = context.FlowValue;
-                var iteratorResultObject = (context.CurrentSignal as YieldCompletionSignal)?.IteratorResultObject;
-                runner.RecordYield(context, environment);
-                context.Clear();
-                runner._state = GeneratorState.Suspended;
-                returnValue = iteratorResultObject is not null
-                    ? JsValue.FromObjectUnsafe(iteratorResultObject)
-                    : CreateIteratorResult(yieldedValue, false);
+                returnValue = runner.CompleteReturn(returnVal);
                 return InstructionResult.Return;
             }
 
-            runner._programCounter = instruction.Next;
+            if (runner._programCounter == runner._currentInstructionIndex)
+            {
+                runner._programCounter = instruction.Next;
+            }
             returnValue = default;
             return InstructionResult.Continue;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleComplexVariableDeclarationYieldSlow(
+            ExecutionPlanRunner runner,
+            ref JsEnvironment environment,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var yieldedValue = context.FlowValue;
+            var iteratorResultObject = (context.CurrentSignal as YieldCompletionSignal)?.IteratorResultObject;
+            runner.RecordYield(context, environment);
+            context.Clear();
+            runner._state = GeneratorState.Suspended;
+            returnValue = iteratorResultObject is not null
+                ? JsValue.FromObjectUnsafe(iteratorResultObject)
+                : CreateIteratorResult(yieldedValue, false);
+            return InstructionResult.Return;
         }
     }
 }

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Generators.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Generators.cs
@@ -38,30 +38,12 @@ public static partial class TypedAstEvaluator
 
                 if (context.IsThrow)
                 {
-                    var thrown = context.FlowValue;
-                    context.Clear();
-                    if (runner.HandleAbruptCompletion(AbruptKind.Throw, thrown))
-                    {
-                        returnValue = default;
-                        return InstructionResult.Continue;
-                    }
-
-                    runner.TryCatchStateRef.TryStack.Clear();
-                    throw new ThrowSignal(thrown);
+                    return HandleYieldThrowSlow(runner, context, out returnValue);
                 }
 
                 if (context.IsYield)
                 {
-                    yieldedValue = context.FlowValue;
-                    var nestedIteratorResult = (context.CurrentSignal as YieldCompletionSignal)?.IteratorResultObject;
-                    context.Clear();
-                    runner._programCounter = runner._currentInstructionIndex;
-                    runner.RecordYield(context, environment);
-                    runner._state = GeneratorState.Suspended;
-                    returnValue = nestedIteratorResult is not null
-                        ? JsValue.FromObjectUnsafe(nestedIteratorResult)
-                        : CreateIteratorResult(yieldedValue, false);
-                    return InstructionResult.Return;
+                    return HandleYieldNestedSlow(runner, ref environment, context, out returnValue);
                 }
             }
 
@@ -69,6 +51,43 @@ public static partial class TypedAstEvaluator
             runner.RecordYield(context, environment);
             runner._state = GeneratorState.Suspended;
             returnValue = CreateIteratorResult(yieldedValue, false);
+            return InstructionResult.Return;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleYieldThrowSlow(
+            ExecutionPlanRunner runner,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var thrown = context.FlowValue;
+            context.Clear();
+            if (runner.HandleAbruptCompletion(AbruptKind.Throw, thrown))
+            {
+                returnValue = default;
+                return InstructionResult.Continue;
+            }
+
+            runner.TryCatchStateRef.TryStack.Clear();
+            throw new ThrowSignal(thrown);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleYieldNestedSlow(
+            ExecutionPlanRunner runner,
+            ref JsEnvironment environment,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var yieldedValue = context.FlowValue;
+            var nestedIteratorResult = (context.CurrentSignal as YieldCompletionSignal)?.IteratorResultObject;
+            context.Clear();
+            runner._programCounter = runner._currentInstructionIndex;
+            runner.RecordYield(context, environment);
+            runner._state = GeneratorState.Suspended;
+            returnValue = nestedIteratorResult is not null
+                ? JsValue.FromObjectUnsafe(nestedIteratorResult)
+                : CreateIteratorResult(yieldedValue, false);
             return InstructionResult.Return;
         }
 

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Iterators.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Iterators.cs
@@ -106,16 +106,7 @@ public static partial class TypedAstEvaluator
 
             if (context.IsThrow)
             {
-                var initThrown = context.FlowValue;
-                context.Clear();
-                if (runner.HandleAbruptCompletion(AbruptKind.Throw, initThrown))
-                {
-                    returnValue = default;
-                    return InstructionResult.Continue;
-                }
-
-                runner.TryCatchStateRef.TryStack.Clear();
-                throw new ThrowSignal(initThrown);
+                return HandleIteratorInitThrowSlow(runner, context, out returnValue);
             }
 
             var iteratorState = CreateIteratorDriverState(iterableValue, instruction.IteratorKind, context);
@@ -155,6 +146,24 @@ public static partial class TypedAstEvaluator
             runner._programCounter = instruction.Next;
             returnValue = default;
             return InstructionResult.Continue;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleIteratorInitThrowSlow(
+            ExecutionPlanRunner runner,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var initThrown = context.FlowValue;
+            context.Clear();
+            if (runner.HandleAbruptCompletion(AbruptKind.Throw, initThrown))
+            {
+                returnValue = default;
+                return InstructionResult.Continue;
+            }
+
+            runner.TryCatchStateRef.TryStack.Clear();
+            throw new ThrowSignal(initThrown);
         }
 
 #if NO_INLINING

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Operators.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Operators.cs
@@ -13,6 +13,7 @@ public static partial class TypedAstEvaluator
 {
     private sealed partial class ExecutionPlanRunner
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static InstructionResult HandleBinaryOp(
             ExecutionPlanRunner runner,
             ExecutionInstruction instr,
@@ -24,49 +25,103 @@ public static partial class TypedAstEvaluator
             var binLeft = instruction.Left.EvaluateExpression(environment, context);
             if (context.ShouldStopEvaluation)
             {
-                if (runner._isAsync && runner.TryHandlePendingAwait(context, out var pendingBinLeftResult, environment))
-                {
-                    returnValue = pendingBinLeftResult;
-                    return InstructionResult.Return;
-                }
-
-                if (context.IsThrow)
-                {
-                    var binThrown = context.FlowValue;
-                    context.Clear();
-                    if (runner.HandleAbruptCompletion(AbruptKind.Throw, binThrown))
-                    {
-                        returnValue = default;
-                        return InstructionResult.Continue;
-                    }
-
-                    runner.TryCatchStateRef.TryStack.Clear();
-                    throw new ThrowSignal(binThrown);
-                }
+                return HandleBinaryOpLeftSlow(runner, instruction, binLeft, ref environment, context, out returnValue);
             }
 
             var binRight = instruction.Right.EvaluateExpression(environment, context);
             if (context.ShouldStopEvaluation)
             {
-                if (runner._isAsync && runner.TryHandlePendingAwait(context, out var pendingBinRightResult, environment))
+                return HandleBinaryOpRightSlow(runner, instruction, binLeft, binRight, ref environment, context, out returnValue);
+            }
+
+            var binResult = ApplyBinaryOperator(instruction.Operator, binLeft, binRight, context);
+
+            if (instruction.ResultSlot is not null)
+            {
+                environment.AssignJsValue(instruction.ResultSlot, binResult);
+            }
+
+            runner._programCounter = instruction.Next;
+            returnValue = default;
+            return InstructionResult.Continue;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleBinaryOpLeftSlow(
+            ExecutionPlanRunner runner,
+            BinaryOpInstruction instruction,
+            JsValue binLeft,
+            ref JsEnvironment environment,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            if (runner._isAsync && runner.TryHandlePendingAwait(context, out var pendingBinLeftResult, environment))
+            {
+                returnValue = pendingBinLeftResult;
+                return InstructionResult.Return;
+            }
+
+            if (context.IsThrow)
+            {
+                var binThrown = context.FlowValue;
+                context.Clear();
+                if (runner.HandleAbruptCompletion(AbruptKind.Throw, binThrown))
                 {
-                    returnValue = pendingBinRightResult;
-                    return InstructionResult.Return;
+                    returnValue = default;
+                    return InstructionResult.Continue;
                 }
 
-                if (context.IsThrow)
-                {
-                    var binThrown = context.FlowValue;
-                    context.Clear();
-                    if (runner.HandleAbruptCompletion(AbruptKind.Throw, binThrown))
-                    {
-                        returnValue = default;
-                        return InstructionResult.Continue;
-                    }
+                runner.TryCatchStateRef.TryStack.Clear();
+                throw new ThrowSignal(binThrown);
+            }
 
-                    runner.TryCatchStateRef.TryStack.Clear();
-                    throw new ThrowSignal(binThrown);
+            // Continue evaluation of right operand after handling left operand signals
+            var binRight = instruction.Right.EvaluateExpression(environment, context);
+            if (context.ShouldStopEvaluation)
+            {
+                return HandleBinaryOpRightSlow(runner, instruction, binLeft, binRight, ref environment, context, out returnValue);
+            }
+
+            var binResult = ApplyBinaryOperator(instruction.Operator, binLeft, binRight, context);
+
+            if (instruction.ResultSlot is not null)
+            {
+                environment.AssignJsValue(instruction.ResultSlot, binResult);
+            }
+
+            runner._programCounter = instruction.Next;
+            returnValue = default;
+            return InstructionResult.Continue;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleBinaryOpRightSlow(
+            ExecutionPlanRunner runner,
+            BinaryOpInstruction instruction,
+            JsValue binLeft,
+            JsValue binRight,
+            ref JsEnvironment environment,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            if (runner._isAsync && runner.TryHandlePendingAwait(context, out var pendingBinRightResult, environment))
+            {
+                returnValue = pendingBinRightResult;
+                return InstructionResult.Return;
+            }
+
+            if (context.IsThrow)
+            {
+                var binThrown = context.FlowValue;
+                context.Clear();
+                if (runner.HandleAbruptCompletion(AbruptKind.Throw, binThrown))
+                {
+                    returnValue = default;
+                    return InstructionResult.Continue;
                 }
+
+                runner.TryCatchStateRef.TryStack.Clear();
+                throw new ThrowSignal(binThrown);
             }
 
             var binResult = ApplyBinaryOperator(instruction.Operator, binLeft, binRight, context);

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Scope.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Scope.cs
@@ -13,6 +13,7 @@ public static partial class TypedAstEvaluator
     private sealed partial class ExecutionPlanRunner
     {
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static InstructionResult HandleEnterWith(
             ExecutionPlanRunner runner,
             ExecutionInstruction instr,
@@ -31,16 +32,7 @@ public static partial class TypedAstEvaluator
 
             if (context.IsThrow)
             {
-                var thrownWith = context.FlowValue;
-                context.Clear();
-                if (runner.HandleAbruptCompletion(AbruptKind.Throw, thrownWith))
-                {
-                    returnValue = default;
-                    return InstructionResult.Continue;
-                }
-
-                runner.TryCatchStateRef.TryStack.Clear();
-                throw new ThrowSignal(thrownWith);
+                return HandleEnterWithThrowSlow(runner, context, out returnValue);
             }
 
             if (TryConvertToWithBindingObject(objValueJs, context, out var withObject))
@@ -55,6 +47,24 @@ public static partial class TypedAstEvaluator
             runner._programCounter = instruction.Next;
             returnValue = default;
             return InstructionResult.Continue;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleEnterWithThrowSlow(
+            ExecutionPlanRunner runner,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var thrownWith = context.FlowValue;
+            context.Clear();
+            if (runner.HandleAbruptCompletion(AbruptKind.Throw, thrownWith))
+            {
+                returnValue = default;
+                return InstructionResult.Continue;
+            }
+
+            runner.TryCatchStateRef.TryStack.Clear();
+            throw new ThrowSignal(thrownWith);
         }
 
         private static InstructionResult HandleLeaveWith(

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.TryCatch.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.TryCatch.cs
@@ -11,6 +11,7 @@ public static partial class TypedAstEvaluator
 {
     private sealed partial class ExecutionPlanRunner
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static InstructionResult HandleThrow(
             ExecutionPlanRunner runner,
             ExecutionInstruction instr,
@@ -29,31 +30,49 @@ public static partial class TypedAstEvaluator
 
             if (context.IsThrow)
             {
-                var existingThrown = context.FlowValue;
-                context.Clear();
-                if (runner.HandleAbruptCompletion(AbruptKind.Throw, existingThrown))
+                return HandleThrowExistingSlow(runner, context, out returnValue);
+            }
+
+            return HandleThrowNewSlow(runner, throwValue, out returnValue);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleThrowExistingSlow(
+            ExecutionPlanRunner runner,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var existingThrown = context.FlowValue;
+            context.Clear();
+            if (runner.HandleAbruptCompletion(AbruptKind.Throw, existingThrown))
+            {
+                if (runner._programCounter != runner._currentInstructionIndex)
                 {
-                    if (runner._programCounter != runner._currentInstructionIndex)
+                    returnValue = default;
+                    return InstructionResult.Continue;
+                }
+
+                if (runner.TryCatchStateRef.TryStack.Count > 0)
+                {
+                    runner.TryCatchStateRef.TryStack.Pop();
+                    if (runner.HandleAbruptCompletion(AbruptKind.Throw, existingThrown))
                     {
                         returnValue = default;
                         return InstructionResult.Continue;
                     }
-
-                    if (runner.TryCatchStateRef.TryStack.Count > 0)
-                    {
-                        runner.TryCatchStateRef.TryStack.Pop();
-                        if (runner.HandleAbruptCompletion(AbruptKind.Throw, existingThrown))
-                        {
-                            returnValue = default;
-                            return InstructionResult.Continue;
-                        }
-                    }
                 }
-
-                runner.TryCatchStateRef.TryStack.Clear();
-                throw new ThrowSignal(existingThrown);
             }
 
+            runner.TryCatchStateRef.TryStack.Clear();
+            throw new ThrowSignal(existingThrown);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleThrowNewSlow(
+            ExecutionPlanRunner runner,
+            JsValue throwValue,
+            out JsValue returnValue)
+        {
             if (runner.HandleAbruptCompletion(AbruptKind.Throw, throwValue))
             {
                 if (runner._programCounter != runner._currentInstructionIndex)
@@ -128,6 +147,7 @@ public static partial class TypedAstEvaluator
             return InstructionResult.Continue;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static InstructionResult HandleEnterCatchWithDestructuring(
             ExecutionPlanRunner runner,
             ExecutionInstruction instr,
@@ -147,16 +167,7 @@ public static partial class TypedAstEvaluator
             {
                 if (context.IsThrow)
                 {
-                    var exception = context.FlowValue;
-                    context.Clear();
-                    if (runner.HandleAbruptCompletion(AbruptKind.Throw, exception))
-                    {
-                        returnValue = default;
-                        return InstructionResult.Continue;
-                    }
-
-                    runner.TryCatchStateRef.TryStack.Clear();
-                    throw new ThrowSignal(exception);
+                    return HandleEnterCatchWithDestructuringThrowSlow(runner, context, out returnValue);
                 }
             }
 
@@ -164,6 +175,24 @@ public static partial class TypedAstEvaluator
             runner._programCounter = instruction.Next;
             returnValue = default;
             return InstructionResult.Continue;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InstructionResult HandleEnterCatchWithDestructuringThrowSlow(
+            ExecutionPlanRunner runner,
+            EvaluationContext context,
+            out JsValue returnValue)
+        {
+            var exception = context.FlowValue;
+            context.Clear();
+            if (runner.HandleAbruptCompletion(AbruptKind.Throw, exception))
+            {
+                returnValue = default;
+                return InstructionResult.Continue;
+            }
+
+            runner.TryCatchStateRef.TryStack.Clear();
+            throw new ThrowSignal(exception);
         }
 
         private static JsValue PrepareCatchEnvironment(


### PR DESCRIPTION
## Summary
- Extract slow/cold paths from instruction handlers to separate `[NoInlining]` methods
- Apply `[AggressiveInlining]` to hot path handler methods  
- This follows the established pattern from `HandleIncrementSlot` and `HandleCompoundAssignmentSlot`
- The JIT can now inline the hot paths into the main execution loop while keeping cold paths (error handling, async/throw handling) separate

## Handlers Updated

| Handler | Extracted Methods |
|---------|-------------------|
| HandleBinaryOp | HandleBinaryOpLeftSlow, HandleBinaryOpRightSlow |
| HandleReturn | HandleReturnThrowSlow |
| HandleBranch | HandleBranchThrowSlow |
| HandleClassDeclaration | HandleClassDeclarationThrowSlow |
| HandleSimpleVariableDeclaration | *ThrowSlow, *ReturnSlow, *YieldSlow |
| HandleComplexVariableDeclaration | *ThrowSlow, *ReturnSlow, *YieldSlow |
| HandleYield | HandleYieldThrowSlow, HandleYieldNestedSlow |
| HandleIteratorInit | HandleIteratorInitThrowSlow |
| HandleEnterWith | HandleEnterWithThrowSlow |
| HandleThrow | HandleThrowExistingSlow, HandleThrowNewSlow |
| HandleEnterCatchWithDestructuring | HandleEnterCatchWithDestructuringThrowSlow |

## Pattern Applied

```csharp
// BEFORE: slow path inline
if (context.IsThrow)
{
    var thrown = context.FlowValue;
    context.Clear();
    if (runner.HandleAbruptCompletion(AbruptKind.Throw, thrown))
    {
        returnValue = default;
        return InstructionResult.Continue;
    }
    runner.TryCatchStateRef.TryStack.Clear();
    throw new ThrowSignal(thrown);
}

// AFTER: slow path extracted
if (context.IsThrow)
{
    return HandleSomethingThrowSlow(runner, context, out returnValue);
}

[MethodImpl(MethodImplOptions.NoInlining)]
private static InstructionResult HandleSomethingThrowSlow(...)
{
    // slow path code here...
}
```

## Test plan
- [x] Build succeeds: `dotnet build src/Asynkron.JsEngine`
- [x] Tests pass: `dotnet test tests/Asynkron.JsEngine.Tests --filter "Category!=Test262"` 
  - Note: 6 pre-existing test failures unrelated to this change (also fail on main)

Fixes #463

:robot: Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized JavaScript engine execution performance by restructuring error and completion handling paths to improve inlining efficiency across control flow, declarations, generators, iterators, operators, scope, and try-catch handlers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->