### PR TITLE
Fix #482: Use consistent error message for destructuring non-iterable values

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Destructuring.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Destructuring.cs
@@ -121,7 +121,7 @@ public static partial class TypedAstEvaluator
                     throw new ThrowSignal(thrown);
                 }
 
-                var typeError = StandardLibrary.CreateTypeError("Value is not iterable.", context, context.RealmState);
+                var typeError = StandardLibrary.CreateTypeError($"Cannot destructure non-iterable value.{context.GetSourceInfo()}", context, context.RealmState);
                 if (runner.HandleAbruptCompletion(AbruptKind.Throw, typeError))
                 {
                     returnValue = default;

--- a/tests/Asynkron.JsEngine.Tests/SourceReferenceInExceptionsTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/SourceReferenceInExceptionsTests.cs
@@ -11,7 +11,7 @@ public sealed class SourceReferenceInExceptionsTests(ITestOutputHelper output) :
     // NOTE: This test may timeout when run in parallel with other tests due to event queue processing delays.
     // The feature is implemented correctly and the test passes when run individually.
 
-    [Fact(Timeout = 2000, Skip = "Bug #482: Missing error message 'Cannot destructure non-iterable value'")]
+    [Fact(Timeout = 2000)]
     public async Task Exception_DestructuringNonArray_IncludesSourceReference()
     {
         var source = @"


### PR DESCRIPTION
## Summary
- Fixed inconsistent error messages between IR execution path and AST walking path for destructuring non-iterable values
- Updated `TypedAstEvaluator.ExecutionPlanRunner.Handlers.Destructuring.cs` to use "Cannot destructure non-iterable value" message with source info
- Re-enabled the previously skipped test `Exception_DestructuringNonArray_IncludesSourceReference`

## Test plan
- [x] Verified `SourceReferenceInExceptionsTests.Exception_DestructuringNonArray_IncludesSourceReference` passes
- [x] Full test suite passes (3085 passed, 0 failed, 16 skipped - pre-existing)
- [x] Roslynator fix applied
- [x] Code formatted
- [x] No new code duplications

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message for destructuring non-iterable values to be more specific and include source location information.

* **Tests**
  * Enabled a previously skipped test for destructuring error handling with source reference tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->