### PR TITLE
Fix Reflect.set/has proxy semantics for Array.reverse

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Mutators.cs
+++ b/src/Asynkron.JsEngine/StdLib/Array/ArrayPrototype.Mutators.cs
@@ -1,5 +1,6 @@
 #region
 
+using System.Collections.Generic;
 using Asynkron.JsEngine.Runtime;
 using Asynkron.JsEngine.Runtime.Prototypes;
 using static Asynkron.JsEngine.StdLib.StandardLibrary;
@@ -10,6 +11,9 @@ namespace Asynkron.JsEngine.StdLib;
 
 public sealed partial class ArrayPrototype
 {
+    private readonly HashSet<IJsPropertyAccessor> _reverseInProgress =
+        new(ReferenceEqualityComparer<IJsPropertyAccessor>.Instance);
+
     [JsHostMethod("push", Length = 1d)]
     public JsValue Push(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
@@ -377,8 +381,7 @@ public sealed partial class ArrayPrototype
         var accessor = EnsureArrayLikeReceiver(thisValue, MethodName, Realm);
 
         // Re-entrancy guard: prevent infinite recursion when length getter calls reverse
-        const string ReentrancyKey = "__inReverse__";
-        if (accessor.TryGetProperty(ReentrancyKey, out var inReverseFlag) && !inReverseFlag.IsUndefined)
+        if (!_reverseInProgress.Add(accessor))
         {
             // Already in reverse, return the array to break recursion
             return JsValue.FromObjectUnsafe(accessor);
@@ -386,7 +389,6 @@ public sealed partial class ArrayPrototype
 
         try
         {
-            accessor.SetProperty(ReentrancyKey, true);
             var objectLike = accessor as IJsObjectLike;
             var evalContext = Realm?.CreateContext();
             var lengthValue = accessor.TryGetProperty("length", out var lenVal) ? lenVal : JsValue.FromDouble(0d);
@@ -413,14 +415,14 @@ public sealed partial class ArrayPrototype
 
                 if (lowerExists && upperExists)
                 {
-                    accessor.SetProperty(lowerKey, upperValue);
-                    accessor.SetProperty(upperKey, lowerValue);
+                    SetPropertyOrThrow(accessor, lowerKey, upperValue, Realm, MethodName);
+                    SetPropertyOrThrow(accessor, upperKey, lowerValue, Realm, MethodName);
                     continue;
                 }
 
                 if (!lowerExists && upperExists)
                 {
-                    accessor.SetProperty(lowerKey, upperValue);
+                    SetPropertyOrThrow(accessor, lowerKey, upperValue, Realm, MethodName);
                     DeletePropertyOrThrow(objectLike, upperKey, upperExists, MethodName, Realm);
                     continue;
                 }
@@ -428,19 +430,16 @@ public sealed partial class ArrayPrototype
                 if (lowerExists && !upperExists)
                 {
                     DeletePropertyOrThrow(objectLike, lowerKey, lowerExists, MethodName, Realm);
-                    accessor.SetProperty(upperKey, lowerValue);
+                    SetPropertyOrThrow(accessor, upperKey, lowerValue, Realm, MethodName);
                     continue;
                 }
-
-                DeletePropertyOrThrow(objectLike, lowerKey, lowerExists, MethodName, Realm);
-                DeletePropertyOrThrow(objectLike, upperKey, upperExists, MethodName, Realm);
             }
 
             return JsValue.FromObjectUnsafe(accessor);
         }
         finally
         {
-            accessor.SetProperty(ReentrancyKey, JsValue.Undefined);
+            _reverseInProgress.Remove(accessor);
         }
     }
 

--- a/src/Asynkron.JsEngine/StdLib/Reflect/ReflectHelper.cs
+++ b/src/Asynkron.JsEngine/StdLib/Reflect/ReflectHelper.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Asynkron.JsEngine.Ast;
 using Asynkron.JsEngine.Runtime;
 using static Asynkron.JsEngine.StdLib.ObjectHelper;
+using static Asynkron.JsEngine.StdLib.StandardLibrary;
 
 #endregion
 
@@ -217,14 +218,7 @@ public static class ReflectHelper
         }
 
         var propertyKey = args.Count > 1 ? JsOps.ToPropertyName(args[1]) ?? string.Empty : string.Empty;
-        var result = target switch
-        {
-            ModuleNamespace moduleNamespace => moduleNamespace.Delete(propertyKey),
-            JsArray jsArray when JsOps.TryResolveArrayIndex(propertyKey, out var index) => jsArray.DeleteElement(index),
-            JsArray jsArray => jsArray.DeleteProperty(propertyKey),
-            _ => target is JsObject jsObj && jsObj.Remove(propertyKey)
-        };
-        return result;
+        return target.Delete(propertyKey);
     }
 
     internal static JsValue ReflectGet(JsValue _, IReadOnlyList<JsValue> args, RealmState? realm)
@@ -301,7 +295,7 @@ public static class ReflectHelper
             return new JsValue(moduleNamespace.HasProperty(propertyKey));
         }
 
-        return new JsValue(target.TryGetProperty(propertyKey, out var _));
+        return new JsValue(HasProperty(target, propertyKey));
     }
 
     internal static JsValue ReflectIsExtensible(JsValue _, IReadOnlyList<JsValue> args, RealmState? realm)
@@ -393,26 +387,144 @@ public static class ReflectHelper
         var propertyKey = args.Count > 1 ? JsOps.ToPropertyName(args[1]) ?? string.Empty : string.Empty;
         var value = args.Count > 2 ? args[2] : JsValue.Undefined;
         var receiver = args.Count > 3 ? args[3] : JsValue.FromObjectUnsafe(target);
-        switch (target)
+        if (target is ModuleNamespace)
         {
-            case ModuleNamespace moduleNamespace:
-                try
-                {
-                    moduleNamespace.SetProperty(propertyKey, value, receiver);
-                }
-                catch (ThrowSignal)
-                {
-                    return new JsValue(false);
-                }
-
-                return new JsValue(false);
-            case JsArray jsArray when string.Equals(propertyKey, "length", StringComparison.Ordinal):
-                // Pass JsValue directly - ToNumericAsJsValue handles boxed JsValue efficiently
-                return jsArray.SetLength(value, null, false);
-            default:
-                target.SetProperty(propertyKey, value, receiver);
-                return new JsValue(true);
+            return new JsValue(false);
         }
+
+        return new JsValue(SetPropertyWithReceiver(target, propertyKey, value, receiver));
+    }
+
+    private static bool SetPropertyWithReceiver(IJsPropertyAccessor target, string propertyKey, JsValue value,
+        JsValue receiver)
+    {
+        if (target is JsProxy proxy)
+        {
+            try
+            {
+                proxy.SetProperty(propertyKey, value, receiver);
+                return true;
+            }
+            catch (ThrowSignal signal) when (IsProxySetTrapReturnFalse(signal))
+            {
+                return false;
+            }
+        }
+
+        if (target is IJsObjectLike objectLike)
+        {
+            return OrdinarySetWithReceiver(objectLike, propertyKey, value, receiver);
+        }
+
+        target.SetProperty(propertyKey, value, receiver);
+        return true;
+    }
+
+    private static bool OrdinarySetWithReceiver(IJsObjectLike target, string propertyKey, JsValue value,
+        JsValue receiver)
+    {
+        var ownDesc = target.GetOwnPropertyDescriptor(propertyKey);
+        if (ownDesc is null)
+        {
+            var parent = GetPrototypeAccessor(target);
+            if (parent is not null)
+            {
+                return SetPropertyWithReceiver(parent, propertyKey, value, receiver);
+            }
+
+            ownDesc = new PropertyDescriptor
+            {
+                JsValue = JsValue.Undefined,
+                Writable = true,
+                Enumerable = true,
+                Configurable = true
+            };
+        }
+
+        if (ownDesc.IsAccessorDescriptor)
+        {
+            if (ownDesc.Set is null)
+            {
+                return false;
+            }
+
+            ownDesc.Set.Invoke(new SingleValueArgs(value), receiver);
+            return true;
+        }
+
+        if (!ownDesc.Writable)
+        {
+            return false;
+        }
+
+        if (!receiver.TryGetObject<IJsObjectLike>(out var receiverObject))
+        {
+            return false;
+        }
+
+        var existingDesc = receiverObject.GetOwnPropertyDescriptor(propertyKey);
+        if (existingDesc is not null)
+        {
+            if (existingDesc.IsAccessorDescriptor || !existingDesc.Writable)
+            {
+                return false;
+            }
+
+            var valueDesc = new PropertyDescriptor { JsValue = value };
+            return TryDefineProperty(receiverObject, propertyKey, valueDesc);
+        }
+
+        if (receiverObject is IExtensibilityControl { IsExtensible: false })
+        {
+            return false;
+        }
+
+        var newDesc = new PropertyDescriptor
+        {
+            JsValue = value,
+            Writable = true,
+            Enumerable = true,
+            Configurable = true
+        };
+
+        return TryDefineProperty(receiverObject, propertyKey, newDesc);
+    }
+
+    private static IJsPropertyAccessor? GetPrototypeAccessor(IJsObjectLike target)
+    {
+        if (target.Prototype is not null)
+        {
+            return target.Prototype;
+        }
+
+        return target is IPrototypeAccessorProvider provider ? provider.PrototypeAccessor : null;
+    }
+
+    private static bool TryDefineProperty(IJsObjectLike target, string propertyKey, PropertyDescriptor descriptor)
+    {
+        if (target is IPropertyDefinitionHost host)
+        {
+            return host.TryDefineProperty(propertyKey, descriptor);
+        }
+
+        target.DefineProperty(propertyKey, descriptor);
+        return true;
+    }
+
+    private static bool IsProxySetTrapReturnFalse(ThrowSignal signal)
+    {
+        if (!signal.ThrownValue.TryGetObject<JsObject>(out var errorObj))
+        {
+            return false;
+        }
+
+        if (!errorObj.TryGetProperty("message", out var messageValue) ||
+            !messageValue.TryGetString(out var message))
+        {
+            return false;
+        }
+
+        return string.Equals(message, "Proxy 'set' trap returned a falsy value", StringComparison.Ordinal);
     }
 
     internal static JsValue ReflectSetPrototypeOf(JsValue _, IReadOnlyList<JsValue> args, RealmState? realm)

--- a/tests/Asynkron.JsEngine.Tests/ArrayBuiltinsSpecTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/ArrayBuiltinsSpecTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Asynkron.JsEngine.JsTypes;
 using Xunit.Abstractions;
 
@@ -807,6 +808,131 @@ public sealed class ArrayBuiltinsSpecTests(ITestOutputHelper output) : InternalT
         """);
         Output.WriteLine($"Result = {result}");
         Assert.Equal("[object Object]", result);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Array_reverse_ProxyTrapsMatchSpec_WhenLengthExceedsIntegerLimit()
+    {
+        // Test262: length-exceeding-integer-limit-with-proxy.js
+        await using var engine = CreateEngine();
+
+        var result = await engine.Evaluate("""
+            function StopReverse() {}
+
+            var arrayLike = {
+              0: "zero",
+              2: "two",
+              get 4() {
+                throw new StopReverse();
+              },
+              9007199254740987: "2**53-5",
+              9007199254740990: "2**53-2",
+              length: 2 ** 53 + 2,
+            };
+
+            var traps = [];
+
+            var proxy = new Proxy(arrayLike, {
+              getOwnPropertyDescriptor(t, pk) {
+                traps.push(`GetOwnPropertyDescriptor:${String(pk)}`);
+                return Reflect.getOwnPropertyDescriptor(t, pk);
+              },
+              defineProperty(t, pk, desc) {
+                traps.push(`DefineProperty:${String(pk)}`);
+                return Reflect.defineProperty(t, pk, desc);
+              },
+              has(t, pk) {
+                traps.push(`Has:${String(pk)}`);
+                return Reflect.has(t, pk);
+              },
+              get(t, pk, r) {
+                traps.push(`Get:${String(pk)}`);
+                return Reflect.get(t, pk, r);
+              },
+              set(t, pk, v, r) {
+                traps.push(`Set:${String(pk)}`);
+                return Reflect.set(t, pk, v, r);
+              },
+              deleteProperty(t, pk) {
+                traps.push(`Delete:${String(pk)}`);
+                return Reflect.deleteProperty(t, pk);
+              },
+            });
+
+            var threw = false;
+            try {
+              Array.prototype.reverse.call(proxy);
+            } catch (e) {
+              threw = e instanceof StopReverse;
+            }
+
+            ({
+              threw,
+              traps,
+              length: arrayLike.length,
+              zero: arrayLike[0],
+              oneIn: 1 in arrayLike,
+              twoIn: 2 in arrayLike,
+              three: arrayLike[3],
+              bigIn: 9007199254740987 in arrayLike,
+              bigVal: arrayLike[9007199254740988],
+              bigIn2: 9007199254740989 in arrayLike,
+              bigVal2: arrayLike[9007199254740990],
+            });
+        """);
+
+        var record = Assert.IsType<JsObject>(result);
+        Assert.Equal(true, record["threw"]);
+
+        var trapsArray = Assert.IsType<JsArray>(record["traps"]);
+        var actualTraps = trapsArray.Items
+            .Select(static item => item.ToObject()?.ToString() ?? string.Empty)
+            .ToArray();
+
+        var expectedTraps = new[]
+        {
+            "Get:length",
+            "Has:0",
+            "Get:0",
+            "Has:9007199254740990",
+            "Get:9007199254740990",
+            "Set:0",
+            "GetOwnPropertyDescriptor:0",
+            "DefineProperty:0",
+            "Set:9007199254740990",
+            "GetOwnPropertyDescriptor:9007199254740990",
+            "DefineProperty:9007199254740990",
+            "Has:1",
+            "Has:9007199254740989",
+            "Has:2",
+            "Get:2",
+            "Has:9007199254740988",
+            "Delete:2",
+            "Set:9007199254740988",
+            "GetOwnPropertyDescriptor:9007199254740988",
+            "DefineProperty:9007199254740988",
+            "Has:3",
+            "Has:9007199254740987",
+            "Get:9007199254740987",
+            "Set:3",
+            "GetOwnPropertyDescriptor:3",
+            "DefineProperty:3",
+            "Delete:9007199254740987",
+            "Has:4",
+            "Get:4"
+        };
+
+        Assert.Equal(expectedTraps, actualTraps);
+
+        Assert.Equal(9007199254740994d, record["length"]);
+        Assert.Equal("2**53-2", record["zero"]);
+        Assert.Equal(false, record["oneIn"]);
+        Assert.Equal(false, record["twoIn"]);
+        Assert.Equal("2**53-5", record["three"]);
+        Assert.Equal(false, record["bigIn"]);
+        Assert.Equal("two", record["bigVal"]);
+        Assert.Equal(false, record["bigIn2"]);
+        Assert.Equal("zero", record["bigVal2"]);
     }
 
     [Fact(Timeout = 5000)]


### PR DESCRIPTION
## Summary\n- avoid proxy-visible reverse re-entrancy guards and use SetPropertyOrThrow for swaps\n- implement Reflect.has/Reflect.set receiver semantics and proper delete behavior\n- add Test262 coverage for reverse proxy trap ordering\n\n## Testing\n- dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj -v:m --filter "FullyQualifiedName~Array_reverse_ProxyTrapsMatchSpec_WhenLengthExceedsIntegerLimit" -- xUnit.MaxParallelThreads=1 -timeout 20000\n\nFixes #584