### PR TITLE
Fix #579: Annex B.3.5 catch parameter conflict hoisting

### DIFF
--- a/src/Asynkron.JsEngine/Ast/Legacy/BlockStatementExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/Legacy/BlockStatementExtensions.cs
@@ -231,21 +231,12 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
             effectiveLexicalNames.UnionWith(block.CollectLexicalNames());
         }
 
-        var effectiveCatchNames = catchParameterNames is null
-            ? block.CollectCatchParameterNames()
-            : [.. catchParameterNames];
-        if (catchParameterNames is not null)
-        {
-            effectiveCatchNames.UnionWith(block.CollectCatchParameterNames());
-        }
-
-        var effectiveSimpleCatchNames = simpleCatchParameterNames is null
-            ? block.CollectSimpleCatchParameterNames()
-            : [.. simpleCatchParameterNames];
-        if (simpleCatchParameterNames is not null)
-        {
-            effectiveSimpleCatchNames.UnionWith(block.CollectSimpleCatchParameterNames());
-        }
+        // Catch parameter names are tracked as *active* names from enclosing catch clauses.
+        // They are added when recursing into a catch body (see HoistFromStatement TryStatement case).
+        var effectiveCatchNames = catchParameterNames ??
+                                  new HashSet<Symbol>(ReferenceEqualityComparer<Symbol>.Instance);
+        var effectiveSimpleCatchNames = simpleCatchParameterNames ??
+                                        new HashSet<Symbol>(ReferenceEqualityComparer<Symbol>.Instance);
 
         block.HoistVarDeclarationsPass(environment,
             context,
@@ -317,16 +308,18 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
 
     private static HashSet<Symbol> MergeCatchNames(this BlockStatement block, HashSet<Symbol> catchParameterNames)
     {
-        var merged = new HashSet<Symbol>(catchParameterNames);
-        merged.UnionWith(block.CollectCatchParameterNames());
-        return merged;
+        // Catch parameter names are tracked as active names from enclosing catch clauses.
+        // Entering a normal block does not add new catch parameter names.
+        _ = block;
+        return catchParameterNames;
     }
 
     private static HashSet<Symbol> MergeSimpleCatchNames(this BlockStatement block, HashSet<Symbol> simpleCatchParameterNames)
     {
-        var merged = new HashSet<Symbol>(simpleCatchParameterNames);
-        merged.UnionWith(block.CollectSimpleCatchParameterNames());
-        return merged;
+        // Simple catch parameter names are tracked as active names from enclosing catch clauses.
+        // Entering a normal block does not add new catch parameter names.
+        _ = block;
+        return simpleCatchParameterNames;
     }
 
     private static HashSet<Symbol> CollectLexicalNames(this BlockStatement block)

--- a/src/Asynkron.JsEngine/Ast/Legacy/StatementNodeExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/Legacy/StatementNodeExtensions.cs
@@ -225,10 +225,28 @@ public static partial class TypedAstEvaluator
                         functionHoistDedupe);
                     if (tryStatement.Catch is { } catchClause)
                     {
+                        // Track *active* catch parameter names for Annex B.3.5/B.3.3.3 checks while
+                        // hoisting inside the catch body.
+                        var catchParameterNamesForBody = catchParameterNames;
+                        var simpleCatchParameterNamesForBody = simpleCatchParameterNames;
+                        if (catchClause.Binding is { } catchBinding)
+                        {
+                            catchParameterNamesForBody =
+                                new HashSet<Symbol>(catchParameterNames, catchParameterNames.Comparer);
+                            catchBinding.CollectSymbolsFromBinding(catchParameterNamesForBody);
+
+                            if (catchBinding is IdentifierBinding identifierBinding)
+                            {
+                                simpleCatchParameterNamesForBody =
+                                    new HashSet<Symbol>(simpleCatchParameterNames, simpleCatchParameterNames.Comparer);
+                                simpleCatchParameterNamesForBody.Add(identifierBinding.Name);
+                            }
+                        }
+
                         catchClause.Body.HoistVarDeclarationsPass(environment, context, hoistFunctionValues,
                             catchClause.Body.MergeLexicalNames(lexicalNames),
-                            catchClause.Body.MergeCatchNames(catchParameterNames),
-                            catchClause.Body.MergeSimpleCatchNames(simpleCatchParameterNames),
+                            catchClause.Body.MergeCatchNames(catchParameterNamesForBody),
+                            catchClause.Body.MergeSimpleCatchNames(simpleCatchParameterNamesForBody),
                             pass,
                             true,
                             reverseFunctionHoist,
@@ -342,6 +360,16 @@ public static partial class TypedAstEvaluator
                             // This check only applies to eval code (B.3.3.3), not regular scripts (B.3.3.1).
                             if (context.ExecutionKind == ExecutionKind.Eval &&
                                 lexicalNames.Contains(functionDeclaration.Name))
+                            {
+                                break;
+                            }
+
+                            // Annex B.3.5: If the catch parameter is not a simple identifier (e.g. destructuring),
+                            // any var binding with the same name in the catch body would be an early error.
+                            // Per B.3.3.3, skip AnnexB var-style function hoisting in direct eval in that case.
+                            if (context.ExecutionKind == ExecutionKind.Eval &&
+                                catchParameterNames.Contains(functionDeclaration.Name) &&
+                                !simpleCatchParameterNames.Contains(functionDeclaration.Name))
                             {
                                 break;
                             }

--- a/src/Asynkron.JsEngine/Ast/ProgramNodeExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ProgramNodeExtensions.cs
@@ -329,8 +329,6 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
         var programBlock = new BlockStatement(program.Source, program.Body, program.IsStrict);
         var lexicalNames = programBlock.CollectLexicalNames();
         var topLevelLexicalNames = CollectTopLevelLexicalNames(program.Body);
-        var catchParameterNames = programBlock.CollectCatchParameterNames();
-        var simpleCatchParameterNames = programBlock.CollectSimpleCatchParameterNames();
         // For bodyLexicalNames used in global/var conflict checks, we only use TOP-LEVEL names.
         // Per ES spec GlobalDeclarationInstantiation, var declarations only conflict with
         // top-level lexical declarations, not with block-scoped let/const in nested blocks.
@@ -533,8 +531,6 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
         programBlock.HoistVarDeclarations(executionEnvironment,
             context,
             lexicalNames: lexicalNames,
-            catchParameterNames: catchParameterNames,
-            simpleCatchParameterNames: simpleCatchParameterNames,
             reverseFunctionHoist: reverseFunctionHoist,
             functionHoistDedupe: functionHoistDedupe);
 

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Environment.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Environment.cs
@@ -25,10 +25,8 @@ public static partial class TypedAstEvaluator
             var lexicalNames = lexicalNamesRaw.Count == 0
                 ? new HashSet<Symbol>(ReferenceEqualityComparer<Symbol>.Instance)
                 : new HashSet<Symbol>(lexicalNamesRaw, ReferenceEqualityComparer<Symbol>.Instance);
-            var catchParameterNamesRaw = hoistPlan.CatchParameterNames;
-            var catchParameterNames = catchParameterNamesRaw.Count == 0
-                ? new HashSet<Symbol>(ReferenceEqualityComparer<Symbol>.Instance)
-                : new HashSet<Symbol>(catchParameterNamesRaw, ReferenceEqualityComparer<Symbol>.Instance);
+            // Track active catch parameters while hoisting (Annex B.3.5/B.3.3.3); start empty.
+            var catchParameterNames = new HashSet<Symbol>(ReferenceEqualityComparer<Symbol>.Instance);
             var simpleCatchParameterNamesRaw = hoistPlan.SimpleCatchParameterNames;
             var simpleCatchParameterNames = simpleCatchParameterNamesRaw.Count == 0
                 ? new HashSet<Symbol>(ReferenceEqualityComparer<Symbol>.Instance)
@@ -214,6 +212,7 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
 
             SyncParameterSlotsToPlan(executionEnvironment, parameterEnvironment, parameterNames);
 
+            simpleCatchParameterNames.Clear();
             _function.Body.HoistVarDeclarations(executionEnvironment, generatorContext,
                 lexicalNames: lexicalNames,
                 catchParameterNames: catchParameterNames,

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -821,12 +821,15 @@ public static partial class TypedAstEvaluator
             }
 
             var lexicalNames = RentSymbolSet(_lexicalTemplate);
-            var catchParameterNames = RentSymbolSet(_catchParameterTemplate);
+            // Used to compute body-lexical blocking; cleared and reused as an "active catch" set for hoisting.
             var simpleCatchParameterNames = RentSymbolSet(_simpleCatchParameterTemplate);
+            // Track active catch parameters while hoisting (Annex B.3.5/B.3.3.3); start empty.
+            var catchParameterNames = RentSymbolSet();
             var bodyLexicalNames = lexicalNames.Count == 0
                 ? lexicalNames
                 : RentSymbolSet(_bodyLexicalTemplate);
             bodyLexicalNames.ExceptWith(simpleCatchParameterNames);
+            simpleCatchParameterNames.Clear();
 
             var functionMode = _isStrict ? ScopeMode.Strict : ScopeMode.Sloppy;
             using var functionScopeFrame = context.PushScope(ScopeKind.Function, functionMode);

--- a/tests/Asynkron.JsEngine.Tests/AnnexBCatchParameterConflictTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/AnnexBCatchParameterConflictTests.cs
@@ -1,0 +1,33 @@
+namespace Asynkron.JsEngine.Tests;
+
+[Category(TestCategories.ScopeAnalysis)]
+public sealed class AnnexBCatchParameterConflictTests
+{
+    [Fact]
+    public async Task SloppyMode_DirectEval_CatchDestructuringNameConflict_DisablesAnnexBHoisting()
+    {
+        await using var engine = new JsEngine();
+        var result = await engine.Evaluate(@"
+            (function() {
+              eval('try { throw {}; } catch ({ f }) { if (true) function f() {} else function _f() {} }');
+              try { f; return 'no error'; } catch (e) { return e.name; }
+            }())
+        ");
+
+        Assert.Equal("ReferenceError", result);
+    }
+
+    [Fact]
+    public async Task SloppyMode_DirectEval_DestructuringCatchElsewhere_DoesNotDisableHoisting()
+    {
+        await using var engine = new JsEngine();
+        var result = await engine.Evaluate(@"
+            (function() {
+              eval('try { throw {}; } catch ({ f }) { } if (true) function f() {}');
+              try { f; return typeof f; } catch (e) { return e.name; }
+            }())
+        ");
+
+        Assert.Equal("function", result);
+    }
+}


### PR DESCRIPTION
Fixes #579.

**What**
- Implements the Annex B.3.3.3 early-error guard for Annex B.3.5 catch-parameter conflicts during non-strict direct eval.
- Tracks *active* catch parameter names while hoisting inside catch bodies, so we only suppress hoisting when the function declaration is actually within a conflicting catch.

**Why**
Test262 `annexB/language/eval-code/direct/func-if-decl-else-decl-a-eval-func-skip-early-err-try.js` requires that when a catch parameter is a destructuring pattern and a block function declaration would introduce a var binding with the same name, AnnexB hoisting is skipped (no function-scope binding created).

**How**
- `StatementNodeExtensions.HoistFromStatement`: when descending into a `catch` body, extend the active catch-name sets with the catch binding.
- For block-scoped function declarations in sloppy direct eval, skip creating the function-scope var binding when the name conflicts with an active *non-simple* catch parameter (destructuring).

**Tests**
- `dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~AnnexBCatchParameterConflictTests"`
- `dotnet test tests/Asynkron.JsEngine.Tests.Test262 -c Release --filter "FullyQualifiedName~AnnexBTests&FullyQualifiedName~Language_evalCode_direct&FullyQualifiedName~func-if-decl-else-decl-a-eval-func-skip-early-err-try"`
