### PR TITLE
Enable eval for-of let/const regression tests (#485)

### DIFF
--- a/tests/Asynkron.JsEngine.Tests/CompletionValueDebugTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/CompletionValueDebugTests.cs
@@ -181,16 +181,28 @@ public sealed class CompletionValueDebugTests(ITestOutputHelper output)
             $"Expected undefined, got: {result}");
     }
 
-    [Fact(Skip = "Bug #485: for (let x of ...) inside eval() fails with TDZ error")]
+    [Fact(Timeout = 10000)]
     public async Task ForOfDecl_Break_ReturnsUndefined()
     {
         var logger = new TestLogger(output, "Test9", minLogLevel: LogLevel.Debug);
         await using var engine = new JsEngine(new JsEngineOptions { DebugMode = true, Logger = logger });
 
         // cptn-decl-abrupt-empty.js - for (let/const)
-        // Note: This test is blocked by a separate bug where for (let ... of ...) inside eval()
-        // fails with "a is not defined" because the loop binding isn't created properly.
         var result = await engine.Evaluate("eval('1; for (let a of [0]) { break; }')");
+        output.WriteLine($"Result: {result?.ToString() ?? "null"} (type: {result?.GetType().Name ?? "null"})");
+
+        Assert.True(result is null || ReferenceEquals(result, Asynkron.JsEngine.Ast.Symbol.Undefined),
+            $"Expected undefined, got: {result}");
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task ForOfConstDecl_Break_ReturnsUndefined()
+    {
+        var logger = new TestLogger(output, "Test9Const", minLogLevel: LogLevel.Debug);
+        await using var engine = new JsEngine(new JsEngineOptions { DebugMode = true, Logger = logger });
+
+        // cptn-decl-abrupt-empty.js - for (let/const)
+        var result = await engine.Evaluate("eval('1; for (const a of [0]) { break; }')");
         output.WriteLine($"Result: {result?.ToString() ?? "null"} (type: {result?.GetType().Name ?? "null"})");
 
         Assert.True(result is null || ReferenceEquals(result, Asynkron.JsEngine.Ast.Symbol.Undefined),


### PR DESCRIPTION
Fixes #485

## Context
Issue #485 reports `eval('1; for (let a of [0]) { break; }')` throwing a TDZ ReferenceError.

I can't reproduce this on current `main` (commit `b7163e8f`). The reproduction returns `undefined` in both Debug and Release.

## What changed
- Re-enabled `CompletionValueDebugTests.ForOfDecl_Break_ReturnsUndefined` (was skipped).
- Added `CompletionValueDebugTests.ForOfConstDecl_Break_ReturnsUndefined`.

## Verification
- `dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~CompletionValueDebugTests.ForOf"` (Debug + Release)
- `dotnet test tests/Asynkron.JsEngine.Tests`
