### PR TITLE
Add regression test for for-await-of resume after loop (#473)

### DIFF
--- a/tests/Asynkron.JsEngine.Tests/ForAwaitOfScopeResumeTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/ForAwaitOfScopeResumeTests.cs
@@ -1,0 +1,91 @@
+using Xunit.Abstractions;
+
+namespace Asynkron.JsEngine.Tests;
+
+[Category(TestCategories.AsyncRuntime)]
+[Category(TestCategories.IteratorRuntime)]
+[Category(TestCategories.Regression)]
+public sealed class ForAwaitOfScopeResumeTests(ITestOutputHelper output) : InternalTestBase(output)
+{
+    [Fact(Timeout = 5000)]
+    public async Task ForAwaitOf_LocalIterable_ResumesAfterLoop()
+    {
+        await using var engine = CreateEngine(() => new JsEngineOptions { DebugMode = true });
+
+        var afterLoop = await engine.EvaluateAndAwait("""
+            let after = '';
+
+            async function test() {
+                let localIterable = {
+                    [Symbol.iterator]() {
+                        let values = ['x', 'y', 'z'];
+                        let index = 0;
+                        return {
+                            next() {
+                                if (index < values.length) {
+                                    return { value: values[index++], done: false };
+                                }
+                                return { done: true };
+                            }
+                        };
+                    }
+                };
+
+                let result = '';
+                for await (let item of localIterable) {
+                    result = result + item;
+                }
+
+                after = result;
+                return result;
+            }
+
+            test();
+            after;
+            """);
+
+        Assert.Equal("xyz", afterLoop);
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ForAwaitOf_GlobalIterable_ResumesAfterLoop()
+    {
+        await using var engine = CreateEngine(() => new JsEngineOptions { DebugMode = true });
+
+        await engine.Evaluate("""
+            let after = '';
+
+            let globalIterable = {
+                [Symbol.iterator]() {
+                    let values = ['x', 'y', 'z'];
+                    let index = 0;
+                    return {
+                        next() {
+                            if (index < values.length) {
+                                return { value: values[index++], done: false };
+                            }
+                            return { done: true };
+                        }
+                    };
+                }
+            };
+
+            async function test() {
+                let result = '';
+                for await (let item of globalIterable) {
+                    result = result + item;
+                }
+
+                after = result;
+                return result;
+            }
+            """);
+
+        var afterLoop = await engine.EvaluateAndAwait("""
+            test();
+            after;
+            """);
+
+        Assert.Equal("xyz", afterLoop);
+    }
+}


### PR DESCRIPTION
Fixes #473

I could not reproduce the reported behavior on current `main`, but #473 is still open.

This PR adds a focused regression test that asserts a `for await...of` loop resumes and executes statements after the loop when the iterable lives in global scope (and also covers the local-scope control case).

Tests:
- `dotnet test tests/Asynkron.JsEngine.Tests/Asynkron.JsEngine.Tests.csproj -c Release`
