### PR TITLE
Stabilize flaky Test262 dynamic import hang (#455)

### DIFF
--- a/src/Asynkron.JsEngine/JsEngine.cs
+++ b/src/Asynkron.JsEngine/JsEngine.cs
@@ -1993,7 +1993,7 @@ public sealed class JsEngine : IAsyncDisposable
             // If enqueue fails (queue closed), decrement immediately.
             Interlocked.Decrement(ref _pendingTaskCount);
             TrySignalDrainComplete();
-        }, TaskScheduler.Default);
+        }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
     }
 
     /// <summary>
@@ -2048,7 +2048,7 @@ public sealed class JsEngine : IAsyncDisposable
             // If enqueue fails (queue closed), decrement immediately.
             Interlocked.Decrement(ref _pendingTaskCount);
             TrySignalDrainComplete();
-        }, TaskScheduler.Default);
+        }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
     }
 
     /// <summary>
@@ -2060,6 +2060,28 @@ public sealed class JsEngine : IAsyncDisposable
     /// <param name="task">The async task to track.</param>
     private void TrackPendingAsyncWork(Task task)
     {
+        if (task.IsCompleted)
+        {
+            // If the task failed, log the error
+            if (task.IsFaulted)
+            {
+                var ex = task.Exception?.GetBaseException() ?? task.Exception;
+                if (ex is not null)
+                {
+                    RealmState.Logger?.LogError(ex,
+                        "[TrackPendingAsyncWork] Tracked task faulted: {ErrorType}: {ErrorMessage}",
+                        ex.GetType().Name,
+                        ex.Message);
+                }
+            }
+            else if (task.IsCanceled)
+            {
+                RealmState.Logger?.LogWarning("[TrackPendingAsyncWork] Tracked task was canceled");
+            }
+
+            return;
+        }
+
         StartEventLoop();
 
         // Increment immediately to track pending work
@@ -2088,7 +2110,7 @@ public sealed class JsEngine : IAsyncDisposable
             // The task's internal ScheduleTask calls will have their own increment/decrement cycle
             Interlocked.Decrement(ref _pendingTaskCount);
             TrySignalDrainComplete();
-        }, TaskScheduler.Default);
+        }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
     }
 
     /// <summary>

--- a/tests/Asynkron.JsEngine.Tests/PendingAsyncWorkTrackingTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/PendingAsyncWorkTrackingTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+
+namespace Asynkron.JsEngine.Tests;
+
+[Category(TestCategories.AsyncRuntime)]
+[Category(TestCategories.Regression)]
+public sealed class PendingAsyncWorkTrackingTests
+{
+    [Fact(Timeout = 10000)]
+    public async Task TrackPendingAsyncWork_CompletedTask_DoesNotStartEventLoopOrIncrementPendingCount()
+    {
+        await using var engine = new JsEngine();
+
+        var engineType = typeof(JsEngine);
+        var eventQueueField = engineType.GetField("_eventQueue", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(eventQueueField);
+
+        var pendingTaskCountField = engineType.GetField("_pendingTaskCount", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(pendingTaskCountField);
+
+        var trackMethod = engineType.GetMethod("TrackPendingAsyncWork", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(trackMethod);
+
+        Assert.Null(eventQueueField.GetValue(engine));
+        Assert.Equal(0, (int)pendingTaskCountField.GetValue(engine)!);
+
+        trackMethod.Invoke(engine, new object[] { Task.CompletedTask });
+
+        Assert.Null(eventQueueField.GetValue(engine));
+        Assert.Equal(0, (int)pendingTaskCountField.GetValue(engine)!);
+    }
+}


### PR DESCRIPTION
Fixes #455

### What changed
- TrackPendingAsyncWork returns early for already-completed tasks (avoids incrementing _pendingTaskCount for sync dynamic imports).
- ScheduleAfterTask/TrackPendingAsyncWork continuations use TaskContinuationOptions.ExecuteSynchronously to reduce thread-pool dependency under heavy parallel test load.
- Added regression test PendingAsyncWorkTrackingTests to lock in the completed-task behavior.

### Why
DynamicImport frequently completes synchronously for cached/sync modules. Previously we still tracked the task, which incremented _pendingTaskCount and relied on a thread-pool continuation to decrement it. Under concurrent Test262 runs that decrement could be delayed, leaving the event loop drain waiting indefinitely and hanging Expressions_dynamicImport_usage(...).

### Tests
- dotnet test tests/Asynkron.JsEngine.Tests -c Release
- dotnet test tests/Asynkron.JsEngine.Tests.Test262 -c Release --filter "FullyQualifiedName~Expressions_dynamicImport_usage"
- dotnet test tests/Asynkron.JsEngine.Tests.Test262 -c Release --filter "FullyQualifiedName~nested-arrow-import-then-eval-script-code-host-resolves-module-code"
