### PR TITLE
Fix: stabilize for-of typedarray RAB tests (#448)

### DIFF
--- a/src/Asynkron.JsEngine/Ast/IteratorDriverPlanExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/IteratorDriverPlanExtensions.cs
@@ -529,6 +529,9 @@ public static partial class TypedAstEvaluator
                         break;
                     }
 
+                    iterationEnvironment = plan.EnsureIterationEnvironmentChain(iterationEnvironment, outerEnvironment,
+                        nextJsValue, context, useIterationSlots, logger);
+
                     // Per ES spec 14.7.5.7 ForIn/OfBodyEvaluation step 5.k-l:
                     // Only update V (completion value) if result.[[Value]] is not empty
                     var bodyResult2 = plan.Body.EvaluateStatementJsValue(iterationEnvironment, context, loopLabel);

--- a/tests/Asynkron.JsEngine.Tests/ForOfIteratorDriverEnvChainTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/ForOfIteratorDriverEnvChainTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using Asynkron.JsEngine.Ast;
+using Asynkron.JsEngine.Execution;
+using Asynkron.JsEngine.JsTypes;
+using Xunit.Abstractions;
+
+namespace Asynkron.JsEngine.Tests;
+
+[Category(TestCategories.IteratorRuntime)]
+[Category(TestCategories.Regression)]
+public sealed class ForOfIteratorDriverEnvChainTests(ITestOutputHelper output) : InternalTestBase(output)
+{
+    [Fact]
+    public async Task EnumeratorFallbackPathRepairsIterationEnvironmentChain()
+    {
+        await using var engine = CreateEngine();
+
+        Assert.NotNull(CurrentLogger);
+
+        var arrayValuesSymbol = Symbol.Intern("__test_arrayValues_448");
+        const int outerScopeId = 1_234_567_890;
+
+        var outerSlotMap = ImmutableDictionary.CreateBuilder<Symbol, int>(ReferenceEqualityComparer<Symbol>.Instance);
+        outerSlotMap[arrayValuesSymbol] = 0;
+
+        var outerEnvironment = JsEnvironment.CreateInstance(engine.GlobalEnvironment, isFunctionScope: true,
+            description: "outer");
+        outerEnvironment.Initialize(outerScopeId, outerSlotMap.ToImmutable());
+        outerEnvironment.SetSlotDirect(0, JsValue.True);
+
+        var loopEnvironment = JsEnvironment.CreateInstance(engine.GlobalEnvironment, description: "loop");
+
+        var body = new BlockStatement(
+            null,
+            ImmutableArray.Create<StatementNode>(
+                new ExpressionStatement(null, new IdentifierExpression(null, arrayValuesSymbol)),
+                new BreakStatement(null, null)),
+            IsStrict: true);
+
+        var plan = new IteratorDriverPlan(
+            IteratorDriverKind.Sync,
+            new LiteralExpression(null, JsValue.Undefined),
+            new IdentifierBinding(null, Symbol.Intern("__unused")),
+            VariableKind.Let,
+            body);
+
+        var context = engine.RealmState.CreateContext();
+
+        var execute = typeof(TypedAstEvaluator).GetMethod(
+            "ExecuteIteratorDriverJsValue",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(execute);
+
+        InvokeAndUnwrap(execute, null, plan, null, null, loopEnvironment, outerEnvironment, context, null, false);
+
+        Assert.Contains(CurrentLogger.Collector.Snapshot(),
+            record => record.Message.Contains("ForOf iteration env chain repaired", StringComparison.Ordinal));
+    }
+
+    private static void InvokeAndUnwrap(MethodInfo method, object? instance, params object?[] args)
+    {
+        try
+        {
+            method.Invoke(instance, args);
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            throw ex.InnerException;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #448

### What
- Adds the missing `EnsureIterationEnvironmentChain` call in the for-of iterator driver *enumerator fallback* path, matching the other two execution paths.
- Adds a regression test that forces the fallback path and asserts the env-chain repair happens (prevents `ReferenceError: ... is not defined` when the outer scope isn’t reachable from the iteration env).

### Why
The Test262 `typedarray-backed-by-resizable-buffer*` tests intermittently fail under parallel execution with `ReferenceError: arrayValues is not defined`, consistent with the loop body sometimes running with a broken environment chain.

### Tests
- `dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~ForOfIteratorDriverEnvChainTests"`
- `dotnet test tests/Asynkron.JsEngine.Tests.Test262 -c Release --filter "typedarray-backed-by-resizable-buffer"` (5x)
- `dotnet test tests/Asynkron.JsEngine.Tests.Test262 -c Release --filter "Statements_forOf"`
