### PR TITLE
Fix Intl.DateTimeFormat: 162 Test262 tests fixed

### DIFF
--- a/src/Asynkron.JsEngine/StdLib/Date/DateHelper.cs
+++ b/src/Asynkron.JsEngine/StdLib/Date/DateHelper.cs
@@ -668,8 +668,7 @@ public static class DateHelper
         }
 
         var index = 0;
-        var year = 0;
-
+        int year;
         if (value[index] is '+' or '-')
         {
             var sign = value[index++];
@@ -703,8 +702,6 @@ public static class DateHelper
             index += 4;
         }
 
-        var month = 1;
-        var day = 1;
         var hasTime = false;
 
         if (index == value.Length)
@@ -720,6 +717,8 @@ public static class DateHelper
         }
 
         index++;
+
+        int month;
         if (index + 2 > value.Length || !TryParseTwoDigits(value.Slice(index, 2), out month))
         {
             timeValue = double.NaN;
@@ -741,6 +740,7 @@ public static class DateHelper
         }
 
         index++;
+        int day;
         if (index + 2 > value.Length || !TryParseTwoDigits(value.Slice(index, 2), out day))
         {
             timeValue = double.NaN;
@@ -1191,16 +1191,11 @@ public static class DateHelper
         JsValue localesArg,
         JsValue optionsArg,
         RealmState realm,
-        Func<JsObject>? defaultOptionsFactory)
+        string required = "any",
+        string defaults = "all")
     {
         var dateObj = RequireDateObject(dateThis, realm);
-        var effectiveOptionsArg = optionsArg;
-        if (defaultOptionsFactory is not null &&
-            optionsArg.IsSymbol &&
-            ReferenceEquals(optionsArg.AsSymbol(), Symbol.Undefined))
-        {
-            effectiveOptionsArg = new JsValue(defaultOptionsFactory());
-        }
+        var effectiveOptionsArg = ToDateTimeOptions(optionsArg, required, defaults, realm);
 
         if (realm.Engine?.GlobalObject is not { } global ||
             !global.TryGetProperty("Intl", out var intlVal) || !intlVal.TryGetObject<JsObject>(out var intlObj) ||
@@ -1279,5 +1274,102 @@ public static class DateHelper
         opts.SetProperty("minute", "numeric");
         opts.SetProperty("second", "numeric");
         return opts;
+    }
+
+    private static readonly string[] DateComponents =
+        ["weekday", "year", "month", "day"];
+
+    private static readonly string[] TimeComponents =
+        ["dayPeriod", "hour", "minute", "second", "fractionalSecondDigits"];
+
+    /// <summary>
+    /// ECMA-402 ToDateTimeOptions(options, required, defaults).
+    /// Merges default date/time components into options when the relevant components are missing.
+    /// </summary>
+    internal static JsValue ToDateTimeOptions(JsValue optionsArg, string required, string defaults, RealmState realm)
+    {
+        JsObject options;
+        if (optionsArg.IsUndefined)
+        {
+            options = new JsObject(realm.ObjectPrototype);
+        }
+        else if (optionsArg.TryGetObject<JsObject>(out var obj))
+        {
+            // Copy properties to a new object to avoid mutating the caller's object
+            options = new JsObject(realm.ObjectPrototype);
+            foreach (var key in obj.GetOwnPropertyKeysInOrder(includeSymbols: false))
+            {
+                if (obj.TryGetProperty(key, out var val))
+                {
+                    options.SetProperty(key, val);
+                }
+            }
+        }
+        else
+        {
+            options = new JsObject(realm.ObjectPrototype);
+        }
+
+        var needDefaults = true;
+
+        // If required is "date" or "any", check for date components
+        if (required is "date" or "any")
+        {
+            foreach (var comp in DateComponents)
+            {
+                if (options.TryGetProperty(comp, out var v) && !v.IsUndefined)
+                {
+                    needDefaults = false;
+                    break;
+                }
+            }
+        }
+
+        // If still need defaults and required is "time" or "any", check for time components
+        if (needDefaults && required is "time" or "any")
+        {
+            foreach (var comp in TimeComponents)
+            {
+                if (options.TryGetProperty(comp, out var v) && !v.IsUndefined)
+                {
+                    needDefaults = false;
+                    break;
+                }
+            }
+        }
+
+        // Check for dateStyle/timeStyle
+        if (needDefaults)
+        {
+            if ((required is "date" or "any") && options.TryGetProperty("dateStyle", out var ds) && !ds.IsUndefined)
+            {
+                needDefaults = false;
+            }
+
+            if (needDefaults && (required is "time" or "any") && options.TryGetProperty("timeStyle", out var ts) && !ts.IsUndefined)
+            {
+                needDefaults = false;
+            }
+        }
+
+        // Apply defaults
+        if (needDefaults)
+        {
+            if (defaults is "date" or "all")
+            {
+                options.SetProperty("year", "numeric");
+                options.SetProperty("month", "numeric");
+                options.SetProperty("day", "numeric");
+            }
+
+            if (defaults is "time" or "all")
+            {
+                options.SetProperty("hour", "numeric");
+                options.SetProperty("minute", "numeric");
+                options.SetProperty("second", "numeric");
+            }
+        }
+
+        return new JsValue(options);
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/Date/DatePrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/Date/DatePrototype.cs
@@ -807,7 +807,7 @@ public sealed partial class DatePrototype
         }
 
         return FormatWithIntlDateTime(thisValue, args.GetArgument(0), args.GetArgument(1),
-            Realm, () => CreateDefaultDateTimeOptions(Realm));
+            Realm, required: "any", defaults: "all");
     }
 
     [JsHostMethod("toLocaleDateString", Length = 0d)]
@@ -820,7 +820,7 @@ public sealed partial class DatePrototype
         }
 
         return FormatWithIntlDateTime(thisValue, args.GetArgument(0), args.GetArgument(1),
-            Realm, () => CreateDefaultDateOptions(Realm));
+            Realm, required: "date", defaults: "date");
     }
 
     [JsHostMethod("toLocaleTimeString", Length = 0d)]
@@ -833,7 +833,7 @@ public sealed partial class DatePrototype
         }
 
         return FormatWithIntlDateTime(thisValue, args.GetArgument(0), args.GetArgument(1),
-            Realm, () => CreateDefaultTimeOptions(Realm));
+            Realm, required: "time", defaults: "time");
     }
 
     /* FLAKY */

--- a/src/Asynkron.JsEngine/StdLib/Intl/DateTimeFormatInternalSlots.cs
+++ b/src/Asynkron.JsEngine/StdLib/Intl/DateTimeFormatInternalSlots.cs
@@ -10,7 +10,8 @@ internal sealed class DateTimeFormatInternalSlots
 {
     public static readonly string[] ComponentNames =
     [
-        "weekday", "era", "year", "month", "day", "hour", "minute", "second", "timeZoneName"
+        "weekday", "era", "year", "month", "day", "dayPeriod", "hour", "minute", "second",
+        "fractionalSecondDigits", "timeZoneName"
     ];
 
     public string Locale { get; init; } = CultureInfo.CurrentCulture.Name;
@@ -18,9 +19,8 @@ internal sealed class DateTimeFormatInternalSlots
     public string Calendar { get; init; } = "gregory";
     public string NumberingSystem { get; init; } = "latn";
     public string HourCycle { get; init; } = "h23";
-    public string LocaleMatcher { get; init; } = "best fit";
-    public string FormatMatcher { get; init; } = "best fit";
+    public bool? Hour12 { get; init; }
     public string? DateStyle { get; init; }
     public string? TimeStyle { get; init; }
-    public Dictionary<string, string> Components { get; } = new();
+    public Dictionary<string, string> Components { get; init; } = new(StringComparer.Ordinal);
 }

--- a/src/Asynkron.JsEngine/StdLib/Intl/IntlDateTimeFormatConstructor.cs
+++ b/src/Asynkron.JsEngine/StdLib/Intl/IntlDateTimeFormatConstructor.cs
@@ -1,5 +1,6 @@
 #region
 
+using System.Globalization;
 using Asynkron.JsEngine.Runtime;
 using Asynkron.JsEngine.Runtime.Prototypes;
 using static Asynkron.JsEngine.StdLib.IntlHelper;
@@ -14,6 +15,13 @@ namespace Asynkron.JsEngine.StdLib.Intl;
 public sealed partial class IntlDateTimeFormatConstructor(IJsObjectLike prototype, RealmState realm)
     : JsConstructor(prototype, realm)
 {
+    // Spec Table 7 component names in order (including dayPeriod and fractionalSecondDigits)
+    private static readonly string[] ComponentNamesInOrder =
+    [
+        "weekday", "era", "year", "month", "day", "dayPeriod", "hour", "minute", "second",
+        "fractionalSecondDigits", "timeZoneName"
+    ];
+
     protected override JsValue ConstructInstance(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
         var localesArg = args.GetArgument(0);
@@ -29,177 +37,316 @@ public sealed partial class IntlDateTimeFormatConstructor(IJsObjectLike prototyp
     {
         var (_, resolvedLocale) = ResolveIntlLocales(localesArg, Realm);
 
-        var options = NormalizeOptions(optionsArg);
-        var localeMatcher = ReadStringOption(
-            options,
-            "localeMatcher",
-            ["lookup", "best fit"],
-            "best fit");
+        // Per spec: Let options be ? ToObject(options) — use GetOptionsObject for proper ToObject
+        var options = IntlOptionHelpers.GetOptionsObject(optionsArg, Realm, "DateTimeFormat");
 
-        var formatMatcher = ReadStringOption(
-            options,
-            "formatMatcher",
-            ["basic", "best fit"],
-            "best fit");
+        // Step 4: localeMatcher
+        var localeMatcher = IntlOptionHelpers.GetStringOption(options, "localeMatcher", Realm,
+            "DateTimeFormat", ["lookup", "best fit"], "best fit");
 
-        var timeZoneValue = options is null ? JsValue.Undefined : GetOption(options, "timeZone");
-        var hourCycle = ReadStringOption(
-            options,
-            "hourCycle",
-            ["h11", "h12", "h23", "h24"],
-            "h23");
-        var calendar = ReadCalendarOption(options);
-        var numberingSystem = ReadNumberingSystem(options);
-        var dateStyle = ReadStyleOption(options, "dateStyle");
-        var timeStyle = ReadStyleOption(options, "timeStyle");
+        // Parse unicode extension keywords from locale for calendar, numberingSystem, hourCycle
+        var unicodeKeywords = IntlUtilities.ParseUnicodeExtensionKeywords(resolvedLocale);
+        var baseLocale = IntlUtilities.RemoveUnicodeExtensions(resolvedLocale);
 
-        var slots = new DateTimeFormatInternalSlots
+        // Calendar: option overrides unicode extension, option overrides locale
+        var calendarOption = ReadCalendarOption(options);
+        string calendar;
+        if (calendarOption is not null)
         {
-            Locale = resolvedLocale,
-            TimeZone = IntlUtilities.NormalizeTimeZone(timeZoneValue, Realm),
-            HourCycle = hourCycle,
-            Calendar = calendar,
-            NumberingSystem = numberingSystem,
-            LocaleMatcher = localeMatcher,
-            FormatMatcher = formatMatcher,
-            DateStyle = dateStyle,
-            TimeStyle = timeStyle
-        };
-
-        foreach (var component in DateTimeFormatInternalSlots.ComponentNames)
+            calendar = calendarOption;
+        }
+        else if (unicodeKeywords.TryGetValue("ca", out var caValues) && caValues.Count > 0)
         {
-            var value = ReadComponentOption(options, component);
-            if (value is not null)
+            var extCalendar = string.Join("-", caValues);
+            calendar = IntlUtilities.TryNormalizeCalendar(extCalendar, out var canonical) ? canonical : "gregory";
+        }
+        else
+        {
+            calendar = "gregory";
+        }
+
+        // NumberingSystem: option overrides unicode extension, option overrides locale
+        var numberingSystemOption = ReadNumberingSystemOption(options);
+        string numberingSystem;
+        if (numberingSystemOption is not null)
+        {
+            numberingSystem = numberingSystemOption;
+        }
+        else if (unicodeKeywords.TryGetValue("nu", out var nuValues) && nuValues.Count > 0)
+        {
+            var extNu = string.Join("-", nuValues);
+            numberingSystem = IntlUtilities.TryNormalizeNumberingSystem(extNu, out var canonical) &&
+                              !IsNumberingSystemAlias(canonical)
+                ? canonical
+                : "latn";
+        }
+        else
+        {
+            numberingSystem = "latn";
+        }
+
+        // Step 12: hour12
+        var hour12 = IntlOptionHelpers.GetBooleanOption(options, "hour12");
+
+        // Step 13: hourCycle
+        string? hourCycleOption = null;
+        if (options is not null && options.TryGetProperty("hourCycle", out var hcValue) && !hcValue.IsUndefined)
+        {
+            var hcString = JsValueToString(hcValue, Realm);
+            if (hcString is "h11" or "h12" or "h23" or "h24")
             {
-                slots.Components[component] = value;
+                hourCycleOption = hcString;
             }
         }
 
-        return slots;
-    }
-
-    private JsObject? NormalizeOptions(JsValue optionsArg)
-    {
-        if (optionsArg.IsNullOrUndefined)
+        // Resolve hourCycle: option overrides locale extension
+        string hourCycle;
+        if (hourCycleOption is not null)
         {
-            return null;
+            hourCycle = hourCycleOption;
+        }
+        else if (unicodeKeywords.TryGetValue("hc", out var hcValues) && hcValues.Count > 0)
+        {
+            var extHc = hcValues[0];
+            hourCycle = extHc is "h11" or "h12" or "h23" or "h24" ? extHc : GetDefaultHourCycle(baseLocale);
+        }
+        else
+        {
+            hourCycle = GetDefaultHourCycle(baseLocale);
         }
 
-        if (optionsArg.IsObject && optionsArg.AsObject() is { } jsObject)
+        // hour12 overrides hourCycle per spec
+        if (hour12 == true)
         {
-            return jsObject;
+            if (hourCycle is "h23" or "h24")
+            {
+                // Switch to locale-preferred 12-hour cycle
+                hourCycle = GetPreferred12HourCycle(baseLocale);
+            }
+        }
+        else if (hour12 == false)
+        {
+            if (hourCycle is "h11" or "h12")
+            {
+                hourCycle = "h23";
+            }
         }
 
-        throw ThrowTypeError("Intl.DateTimeFormat options must be an object", realm: Realm);
+        // Step 29: timeZone
+        var timeZoneValue = options is null ? JsValue.Undefined : GetOption(options, "timeZone");
+        var timeZone = IntlUtilities.NormalizeTimeZone(timeZoneValue, Realm);
+
+        // Step 36: Read components in table order
+        var components = new Dictionary<string, string>(StringComparer.Ordinal);
+        var hasExplicitFormatComponents = false;
+
+        foreach (var component in ComponentNamesInOrder)
+        {
+            if (string.Equals(component, "fractionalSecondDigits", StringComparison.Ordinal))
+            {
+                var fsd = ReadFractionalSecondDigits(options);
+                if (fsd is not null)
+                {
+                    components["fractionalSecondDigits"] = fsd.Value.ToString(CultureInfo.InvariantCulture);
+                    hasExplicitFormatComponents = true;
+                }
+            }
+            else if (string.Equals(component, "dayPeriod", StringComparison.Ordinal))
+            {
+                var dp = ReadDayPeriodOption(options);
+                if (dp is not null)
+                {
+                    components["dayPeriod"] = dp;
+                    hasExplicitFormatComponents = true;
+                }
+            }
+            else
+            {
+                var value = ReadComponentOption(options, component);
+                if (value is not null)
+                {
+                    components[component] = value;
+                    hasExplicitFormatComponents = true;
+                }
+            }
+        }
+
+        // Step 37: formatMatcher
+        var formatMatcher = IntlOptionHelpers.GetStringOption(options, "formatMatcher", Realm,
+            "DateTimeFormat", ["basic", "best fit"], "best fit");
+
+        // Step 38-39: dateStyle
+        var dateStyle = ReadStyleOption(options, "dateStyle");
+
+        // Step 40-41: timeStyle
+        var timeStyle = ReadStyleOption(options, "timeStyle");
+
+        // Step 43: If dateStyle or timeStyle is not undefined and hasExplicitFormatComponents, throw TypeError
+        if ((dateStyle is not null || timeStyle is not null) && hasExplicitFormatComponents)
+        {
+            throw ThrowTypeError(
+                "Intl.DateTimeFormat dateStyle/timeStyle options cannot be used with explicit format components",
+                realm: Realm);
+        }
+
+        // Per spec: If dateStyle and timeStyle are both undefined and no components are set,
+        // apply defaults. For "any"/"date" defaults, add year/month/day.
+        if (dateStyle is null && timeStyle is null && !hasExplicitFormatComponents)
+        {
+            components["year"] = "numeric";
+            components["month"] = "numeric";
+            components["day"] = "numeric";
+        }
+
+        // Build the resolved locale tag - strip all unicode extensions that aren't relevant
+        // DateTimeFormat only uses ca, hc, nu; all others must be stripped
+        // Per spec: hour12 option also suppresses hc extension in the resolved locale
+        var finalLocale = BuildResolvedLocale(baseLocale, unicodeKeywords, calendar, hourCycle,
+            numberingSystem, calendarOption, hourCycleOption, numberingSystemOption, hour12);
+
+        // Determine hour12 for resolved options
+        bool? resolvedHour12 = null;
+        if (components.ContainsKey("hour") || timeStyle is not null)
+        {
+            resolvedHour12 = hourCycle is "h11" or "h12";
+        }
+
+        return new DateTimeFormatInternalSlots
+        {
+            Locale = finalLocale,
+            TimeZone = timeZone,
+            HourCycle = hourCycle,
+            Calendar = calendar,
+            NumberingSystem = numberingSystem,
+            DateStyle = dateStyle,
+            TimeStyle = timeStyle,
+            Hour12 = resolvedHour12,
+            Components = components
+        };
     }
 
-    private static JsValue GetOption(JsObject options, string propertyName)
+    private static JsValue GetOption(IJsPropertyAccessor options, string propertyName)
     {
         return options.TryGetProperty(propertyName, out var value) ? value : JsValue.Undefined;
     }
 
-    private string ReadStringOption(JsObject? options, string propertyName, IReadOnlyList<string> allowed,
-        string defaultValue)
+    private string? ReadCalendarOption(IJsPropertyAccessor? options)
     {
-        if (options is null || !options.TryGetProperty(propertyName, out var rawValue) ||
-            rawValue.IsUndefined)
-        {
-            return defaultValue;
-        }
-
-        if (!rawValue.TryGetString(out var strValue))
-        {
-            throw ThrowTypeError(
-                $"Intl.DateTimeFormat {propertyName} option must be a string", realm: Realm);
-        }
-
-        if (!allowed.Contains(strValue, StringComparer.Ordinal))
-        {
-            throw ThrowRangeError(
-                $"Intl.DateTimeFormat {propertyName} option '{strValue}' is not supported", realm: Realm);
-        }
-
-        return strValue;
-    }
-
-    private string ReadCalendarOption(JsObject? options)
-    {
-        if (options is null || !options.TryGetProperty("calendar", out var value) ||
-            value.IsUndefined)
-        {
-            return "gregory";
-        }
-
-        if (!value.TryGetString(out var calendar))
-        {
-            throw ThrowTypeError("Intl.DateTimeFormat calendar option must be a string", realm: Realm);
-        }
-
-        if (!IntlUtilities.TryNormalizeCalendar(calendar, out var canonical))
-        {
-            throw ThrowRangeError($"Unsupported calendar '{calendar}'", realm: Realm);
-        }
-
-        return canonical;
-    }
-
-    private string ReadNumberingSystem(JsObject? options)
-    {
-        if (options is null || !options.TryGetProperty("numberingSystem", out var value) ||
-            value.IsUndefined)
-        {
-            return "latn";
-        }
-
-        if (!value.TryGetString(out var system))
-        {
-            throw ThrowTypeError(
-                "Intl.DateTimeFormat numberingSystem option must be a string", realm: Realm);
-        }
-
-        return IntlUtilities.TryNormalizeNumberingSystem(system, out var canonical)
-            ? canonical
-            : "latn";
-    }
-
-    private string? ReadStyleOption(JsObject? options, string propertyName)
-    {
-        if (options is null || !options.TryGetProperty(propertyName, out var value) ||
-            value.IsUndefined)
+        if (options is null || !options.TryGetProperty("calendar", out var value) || value.IsUndefined)
         {
             return null;
         }
 
-        if (!value.TryGetString(out var stringValue))
+        var calendar = JsValueToString(value, Realm);
+
+        // Per spec: only throw RangeError if the value doesn't match Unicode type nonterminal
+        if (!IsValidUnicodeTypeNonterminal(calendar))
         {
-            throw ThrowTypeError(
-                $"Intl.DateTimeFormat {propertyName} option must be a string", realm: Realm);
+            throw ThrowRangeError($"Invalid calendar value '{calendar}' for Intl.DateTimeFormat", realm: Realm);
+        }
+
+        // If it's structurally valid but not supported, return null (fall through to unicode ext/default)
+        return IntlUtilities.TryNormalizeCalendar(calendar, out var canonical) ? canonical : null;
+    }
+
+    private string? ReadNumberingSystemOption(IJsPropertyAccessor? options)
+    {
+        if (options is null || !options.TryGetProperty("numberingSystem", out var value) || value.IsUndefined)
+        {
+            return null;
+        }
+
+        var system = JsValueToString(value, Realm);
+
+        // Per spec: If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw RangeError
+        if (!IsValidUnicodeTypeNonterminal(system))
+        {
+            throw ThrowRangeError(
+                $"Invalid numberingSystem '{system}' for Intl.DateTimeFormat", realm: Realm);
+        }
+
+        // If structurally valid but not a recognized numbering system, return null (fall through)
+        return IntlUtilities.TryNormalizeNumberingSystem(system, out var canonical) ? canonical : null;
+    }
+
+    private string? ReadStyleOption(IJsPropertyAccessor? options, string propertyName)
+    {
+        if (options is null || !options.TryGetProperty(propertyName, out var value) || value.IsUndefined)
+        {
+            return null;
+        }
+
+        var stringValue = JsValueToString(value, Realm);
+
+        if (stringValue is not ("full" or "long" or "medium" or "short"))
+        {
+            throw ThrowRangeError(
+                $"Invalid value '{stringValue}' for option '{propertyName}' on Intl.DateTimeFormat", realm: Realm);
         }
 
         return stringValue;
     }
 
-    private string? ReadComponentOption(JsObject? options, string propertyName)
+    private string? ReadDayPeriodOption(IJsPropertyAccessor? options)
     {
-        if (options is null || !options.TryGetProperty(propertyName, out var value) ||
+        if (options is null || !options.TryGetProperty("dayPeriod", out var value) || value.IsUndefined)
+        {
+            return null;
+        }
+
+        var stringValue = JsValueToString(value, Realm);
+
+        if (stringValue is not ("narrow" or "short" or "long"))
+        {
+            throw ThrowRangeError(
+                $"Invalid value '{stringValue}' for option 'dayPeriod' on Intl.DateTimeFormat", realm: Realm);
+        }
+
+        return stringValue;
+    }
+
+    private int? ReadFractionalSecondDigits(IJsPropertyAccessor? options)
+    {
+        if (options is null || !options.TryGetProperty("fractionalSecondDigits", out var value) ||
             value.IsUndefined)
         {
             return null;
         }
 
-        if (!value.TryGetString(out var component))
+        var number = JsOps.ToNumber(value);
+        if (double.IsNaN(number) || number < 1 || number > 3)
         {
-            throw ThrowTypeError(
-                $"Intl.DateTimeFormat {propertyName} option must be a string", realm: Realm);
+            throw ThrowRangeError(
+                "Intl.DateTimeFormat fractionalSecondDigits must be 1, 2, or 3", realm: Realm);
         }
+
+        var intValue = (int)Math.Floor(number);
+        if (intValue < 1 || intValue > 3)
+        {
+            throw ThrowRangeError(
+                "Intl.DateTimeFormat fractionalSecondDigits must be 1, 2, or 3", realm: Realm);
+        }
+
+        return intValue;
+    }
+
+    private string? ReadComponentOption(IJsPropertyAccessor? options, string propertyName)
+    {
+        if (options is null || !options.TryGetProperty(propertyName, out var value) || value.IsUndefined)
+        {
+            return null;
+        }
+
+        var component = JsValueToString(value, Realm);
 
         var isAllowed = propertyName switch
         {
-            "month" => IsMonthAllowed(component),
+            "month" => component is "2-digit" or "numeric" or "narrow" or "short" or "long",
             "weekday" => component is "narrow" or "short" or "long",
             "era" => component is "narrow" or "short" or "long",
-            "timeZoneName" => component is "short" or "long",
-            _ => IsWidthAllowed(component)
+            "timeZoneName" => component is "short" or "long" or "shortOffset" or "longOffset" or "shortGeneric" or
+                "longGeneric",
+            _ => component is "2-digit" or "numeric"
         };
 
         if (!isAllowed)
@@ -209,16 +356,144 @@ public sealed partial class IntlDateTimeFormatConstructor(IJsObjectLike prototyp
         }
 
         return component;
+    }
 
-        bool IsWidthAllowed(string value)
+    /// <summary>
+    /// Returns the preferred 12-hour cycle for a locale.
+    /// Most locales use h12 (1-12), but some (like Japanese) use h11 (0-11).
+    /// </summary>
+    private static string GetPreferred12HourCycle(string locale)
+    {
+        // ICU data: Japanese locale uses h11 for 12-hour clock (K pattern letter, 0-11)
+        var lang = locale.Split('-')[0].ToLowerInvariant();
+        return lang is "ja" or "ko" ? "h11" : "h12";
+    }
+
+    private static string GetDefaultHourCycle(string locale)
+    {
+        // Determine default hour cycle from locale
+        try
         {
-            return value is "2-digit" or "numeric";
+            var culture = IntlUtilities.ResolveCulture(locale);
+            var pattern = culture.DateTimeFormat.ShortTimePattern;
+            if (pattern.Contains('h', StringComparison.Ordinal) ||
+                pattern.Contains("tt", StringComparison.Ordinal))
+            {
+                return "h12";
+            }
+
+            return "h23";
+        }
+        catch
+        {
+            return "h23";
+        }
+    }
+
+    /// <summary>
+    /// BCP 47 numbering system alias keywords that resolve to locale-specific numbering systems.
+    /// These are not valid concrete numbering system identifiers for DateTimeFormat.
+    /// </summary>
+    private static bool IsNumberingSystemAlias(string value)
+    {
+        return value is "native" or "traditio" or "finance";
+    }
+
+    /// <summary>
+    /// Validates that a string matches the Unicode Locale Identifier type nonterminal:
+    /// type = alphanum{3,8} ("-" alphanum{3,8})*
+    /// </summary>
+    private static bool IsValidUnicodeTypeNonterminal(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
         }
 
-        bool IsMonthAllowed(string value)
+        var parts = value.Split('-');
+        foreach (var part in parts)
         {
-            return value is "2-digit" or "numeric" or "narrow" or "short" or "long";
+            if (part.Length < 3 || part.Length > 8)
+            {
+                return false;
+            }
+
+            foreach (var ch in part)
+            {
+                if (!((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')))
+                {
+                    return false;
+                }
+            }
         }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Builds the resolved locale string, keeping only relevant unicode extension keys (ca, hc, nu)
+    /// and only when they came from the locale (not overridden by options).
+    /// </summary>
+    private static string BuildResolvedLocale(
+        string baseLocale,
+        IReadOnlyDictionary<string, List<string>> unicodeKeywords,
+        string calendar, string hourCycle, string numberingSystem,
+        string? calendarOption, string? hourCycleOption, string? numberingSystemOption,
+        bool? hour12)
+    {
+        // Start with base locale (no unicode extensions)
+        var extensions = new List<string>();
+
+        // Keep the ca extension only if:
+        // 1. The locale had a ca extension
+        // 2. The resolved calendar matches the normalized extension value
+        // 3. The calendar is not the default ("gregory")
+        // When an option explicitly overrides to a different value, the extension is dropped
+        if (unicodeKeywords.TryGetValue("ca", out var caExtValues) && caExtValues.Count > 0)
+        {
+            var extCalendar = string.Join("-", caExtValues);
+            if (IntlUtilities.TryNormalizeCalendar(extCalendar, out var normalizedExtCa) &&
+                string.Equals(normalizedExtCa, calendar, StringComparison.Ordinal))
+            {
+                extensions.Add("ca-" + calendar);
+            }
+        }
+
+        // Keep the hc extension only if:
+        // 1. The locale had an hc extension
+        // 2. hour12 option was NOT set (hour12 always suppresses hc extension)
+        // 3. If hourCycle option was set, it must match the extension value
+        if (hour12 is null && unicodeKeywords.TryGetValue("hc", out var hcExtValues) && hcExtValues.Count > 0)
+        {
+            var extHc = hcExtValues[0];
+            if (hourCycleOption is null ||
+                string.Equals(hourCycleOption, extHc, StringComparison.Ordinal))
+            {
+                extensions.Add("hc-" + hourCycle);
+            }
+        }
+
+        // Keep the nu extension only if:
+        // 1. The locale had a nu extension
+        // 2. The resolved numberingSystem matches the normalized extension value
+        // 3. The numberingSystem is not the default ("latn")
+        if (unicodeKeywords.TryGetValue("nu", out var nuExtValues) && nuExtValues.Count > 0)
+        {
+            var extNu = string.Join("-", nuExtValues);
+            if (IntlUtilities.TryNormalizeNumberingSystem(extNu, out var normalizedExtNu) &&
+                !IsNumberingSystemAlias(normalizedExtNu) &&
+                string.Equals(normalizedExtNu, numberingSystem, StringComparison.Ordinal))
+            {
+                extensions.Add("nu-" + numberingSystem);
+            }
+        }
+
+        if (extensions.Count == 0)
+        {
+            return baseLocale;
+        }
+
+        return baseLocale + "-u-" + string.Join("-", extensions);
     }
 
     protected override void ConfigureConstructor(HostFunction constructor)

--- a/src/Asynkron.JsEngine/StdLib/Intl/IntlDateTimeFormatPrototype.cs
+++ b/src/Asynkron.JsEngine/StdLib/Intl/IntlDateTimeFormatPrototype.cs
@@ -1,6 +1,7 @@
 #region
 
 using System.Globalization;
+using System.Text;
 using Asynkron.JsEngine.Runtime;
 using Asynkron.JsEngine.Runtime.Prototypes;
 using static Asynkron.JsEngine.StdLib.StandardLibrary;
@@ -25,19 +26,25 @@ public sealed partial class IntlDateTimeFormatPrototype
     private JsValue GetFormat(JsValue thisValue)
     {
         var slotData = ValidateReceiver(thisValue, out _);
-        return (JsValue)CreateBoundFormatFunction(value => FormatInternal(value, slotData));
+        var realm = Realm;
+        return (JsValue)CreateBoundFormatFunction(value => FormatChecked(value, slotData, realm));
     }
 
     [JsHostMethod("formatToParts", Length = 1d)]
     private JsValue FormatToParts(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
         var slotData = ValidateReceiver(thisValue, out _);
-        var formatted = FormatInternal(args.GetArgument(0), slotData);
-        var part = new JsObject();
-        part.SetProperty("type", new JsValue("literal"));
-        part.SetProperty("value", formatted);
-        var parts = new JsArray(Realm);
-        parts.Push(part);
+        var dateValue = args.GetArgument(0);
+        var epochMs = ToEpochMilliseconds(dateValue);
+        if (double.IsNaN(epochMs))
+        {
+            throw ThrowRangeError("Invalid time value", realm: Realm);
+        }
+
+        var dto = ToDateTimeOffset(epochMs, slotData.TimeZone);
+        var culture = IntlUtilities.ResolveCulture(slotData.Locale);
+        var parts = FormatToPartsInternal(dto, slotData, culture);
+        TranslatePartsDigits(parts, slotData.NumberingSystem);
         return JsValue.FromJsArray(parts);
     }
 
@@ -45,21 +52,165 @@ public sealed partial class IntlDateTimeFormatPrototype
     private JsValue FormatRange(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
         var slotData = ValidateReceiver(thisValue, out _);
-        var start = FormatInternal(args.GetArgument(0), slotData);
-        var end = FormatInternal(args.GetArgument(1), slotData);
-        return new JsValue($"{start.ObjectValue} – {end.ObjectValue}");
+
+        var startDate = args.GetArgument(0);
+        var endDate = args.GetArgument(1);
+
+        // Per spec: if startDate or endDate is undefined, throw TypeError
+        if (startDate.IsUndefined)
+        {
+            throw ThrowTypeError("startDate is undefined", realm: Realm);
+        }
+
+        if (endDate.IsUndefined)
+        {
+            throw ThrowTypeError("endDate is undefined", realm: Realm);
+        }
+
+        var startMs = ToEpochMilliseconds(startDate);
+        var endMs = ToEpochMilliseconds(endDate);
+
+        // Per spec: if either is NaN, throw RangeError
+        if (double.IsNaN(startMs))
+        {
+            throw ThrowRangeError("Invalid start date value", realm: Realm);
+        }
+
+        if (double.IsNaN(endMs))
+        {
+            throw ThrowRangeError("Invalid end date value", realm: Realm);
+        }
+
+        var startFormatted = FormatDateTimeOffset(startMs, slotData);
+        var endFormatted = FormatDateTimeOffset(endMs, slotData);
+
+        // If both format to the same string, return single formatted value (no range)
+        if (string.Equals(startFormatted, endFormatted, StringComparison.Ordinal))
+        {
+            return new JsValue(startFormatted);
+        }
+
+        // Try range collapsing for named month formats
+        if (ShouldCollapseRange(slotData))
+        {
+            var culture = IntlUtilities.ResolveCulture(slotData.Locale);
+            var startDto = ToDateTimeOffset(startMs, slotData.TimeZone);
+            var endDto = ToDateTimeOffset(endMs, slotData.TimeZone);
+            var startParts = FormatToPartsInternal(startDto, slotData, culture);
+            var endParts = FormatToPartsInternal(endDto, slotData, culture);
+
+            var collapsed = BuildCollapsedRangeString(startParts, endParts);
+            if (collapsed is not null)
+            {
+                return new JsValue(collapsed);
+            }
+        }
+
+        return new JsValue($"{startFormatted} \u2013 {endFormatted}");
     }
 
     [JsHostMethod("formatRangeToParts", Length = 2d)]
     private JsValue FormatRangeToParts(JsValue thisValue, IReadOnlyList<JsValue> args)
     {
         var slotData = ValidateReceiver(thisValue, out _);
-        var start = FormatInternal(args.GetArgument(0), slotData);
-        var end = FormatInternal(args.GetArgument(1), slotData);
+
+        var startDate = args.GetArgument(0);
+        var endDate = args.GetArgument(1);
+
+        // Per spec: if startDate or endDate is undefined, throw TypeError
+        if (startDate.IsUndefined)
+        {
+            throw ThrowTypeError("startDate is undefined", realm: Realm);
+        }
+
+        if (endDate.IsUndefined)
+        {
+            throw ThrowTypeError("endDate is undefined", realm: Realm);
+        }
+
+        var startMs = ToEpochMilliseconds(startDate);
+        var endMs = ToEpochMilliseconds(endDate);
+
+        // Per spec: if either is NaN, throw RangeError
+        if (double.IsNaN(startMs))
+        {
+            throw ThrowRangeError("Invalid start date value", realm: Realm);
+        }
+
+        if (double.IsNaN(endMs))
+        {
+            throw ThrowRangeError("Invalid end date value", realm: Realm);
+        }
+
+        var startFormatted = FormatDateTimeOffset(startMs, slotData);
+        var endFormatted = FormatDateTimeOffset(endMs, slotData);
+
+        var culture = IntlUtilities.ResolveCulture(slotData.Locale);
+
+        if (string.Equals(startFormatted, endFormatted, StringComparison.Ordinal))
+        {
+            // Same value — return typed parts from formatToParts with source="shared"
+            var dto = ToDateTimeOffset(startMs, slotData.TimeZone);
+            var typedParts = FormatToPartsInternal(dto, slotData, culture);
+
+            // Set source="shared" on all parts
+            var sharedParts = new JsArray(Realm);
+            for (var i = 0; i < typedParts.Length; i++)
+            {
+                var part = typedParts.Get(i);
+                if (part.TryGetObject<JsObject>(out var partObj))
+                {
+                    partObj.SetProperty("source", new JsValue("shared"));
+                }
+
+                sharedParts.Push(part);
+            }
+
+            return JsValue.FromJsArray(sharedParts);
+        }
+
         var parts = new JsArray(Realm);
-        parts.Push(CreateRangePart("startRange", (string)start.ObjectValue!));
-        parts.Push(CreateRangePart("separator", " – "));
-        parts.Push(CreateRangePart("endRange", (string)end.ObjectValue!));
+        var startDto = ToDateTimeOffset(startMs, slotData.TimeZone);
+        var endDto = ToDateTimeOffset(endMs, slotData.TimeZone);
+
+        var startParts = FormatToPartsInternal(startDto, slotData, culture);
+        var endParts = FormatToPartsInternal(endDto, slotData, culture);
+
+        // Try range collapsing for named month formats
+        if (ShouldCollapseRange(slotData))
+        {
+            var collapsed = BuildCollapsedRangeParts(Realm, startParts, endParts);
+            if (collapsed is not null)
+            {
+                return JsValue.FromJsArray(collapsed);
+            }
+        }
+
+        // No collapsing: full start + separator + full end
+        for (var i = 0; i < startParts.Length; i++)
+        {
+            var part = startParts.Get(i);
+            if (part.TryGetObject<JsObject>(out var partObj))
+            {
+                partObj.SetProperty("source", new JsValue("startRange"));
+            }
+
+            parts.Push(part);
+        }
+
+        parts.Push(CreateRangePart("literal", " \u2013 ", "shared"));
+
+        for (var i = 0; i < endParts.Length; i++)
+        {
+            var part = endParts.Get(i);
+            if (part.TryGetObject<JsObject>(out var partObj))
+            {
+                partObj.SetProperty("source", new JsValue("endRange"));
+            }
+
+            parts.Push(part);
+        }
+
         return JsValue.FromJsArray(parts);
     }
 
@@ -68,25 +219,122 @@ public sealed partial class IntlDateTimeFormatPrototype
     {
         var slots = ValidateReceiver(thisValue, out _);
         var obj = new JsObject(Realm.ObjectPrototype);
-        const string operation = "Intl.DateTimeFormat.prototype.resolvedOptions";
-        CreateDataPropertyOrThrowJsValue(obj, "locale", slots.Locale, Realm, operation);
-        CreateDataPropertyOrThrowJsValue(obj, "calendar", slots.Calendar, Realm, operation);
-        CreateDataPropertyOrThrowJsValue(obj, "numberingSystem", slots.NumberingSystem, Realm, operation);
-        CreateDataPropertyOrThrowJsValue(obj, "timeZone", slots.TimeZone, Realm, operation);
-        CreateDataPropertyOrThrowJsValue(obj, "hourCycle", slots.HourCycle, Realm, operation);
-        CreateDataPropertyOrThrowJsValue(obj, "localeMatcher", slots.LocaleMatcher, Realm, operation);
-        CreateDataPropertyOrThrowJsValue(obj, "formatMatcher", slots.FormatMatcher, Realm, operation);
-        CreateDataPropertyOrThrowJsValue(obj, "dateStyle", slots.DateStyle != null ? slots.DateStyle : JsValue.Undefined, Realm,
-            operation);
-        CreateDataPropertyOrThrowJsValue(obj, "timeStyle", slots.TimeStyle != null ? slots.TimeStyle : JsValue.Undefined, Realm,
-            operation);
-        foreach (var component in DateTimeFormatInternalSlots.ComponentNames)
+        const string op = "Intl.DateTimeFormat.prototype.resolvedOptions";
+
+        // Per spec order: locale, calendar, numberingSystem, timeZone, then conditionally
+        // hourCycle, hour12, then components in table order, then dateStyle, timeStyle
+        CreateDataPropertyOrThrowJsValue(obj, "locale", slots.Locale, Realm, op);
+        CreateDataPropertyOrThrowJsValue(obj, "calendar", slots.Calendar, Realm, op);
+        CreateDataPropertyOrThrowJsValue(obj, "numberingSystem", slots.NumberingSystem, Realm, op);
+        CreateDataPropertyOrThrowJsValue(obj, "timeZone", slots.TimeZone, Realm, op);
+
+        // hourCycle and hour12 are only output when hour component is present or timeStyle is used
+        var hasHour = slots.Components.ContainsKey("hour") || slots.TimeStyle is not null;
+        if (hasHour)
         {
-            CreateDataPropertyOrThrowJsValue(obj, component,
-                slots.Components.TryGetValue(component, out var value) ? value : JsValue.Undefined, Realm, operation);
+            CreateDataPropertyOrThrowJsValue(obj, "hourCycle", slots.HourCycle, Realm, op);
+            CreateDataPropertyOrThrowJsValue(obj, "hour12", slots.Hour12 ?? (slots.HourCycle is "h11" or "h12"),
+                Realm, op);
+        }
+
+        if (slots.DateStyle is not null || slots.TimeStyle is not null)
+        {
+            // When using styles, output the inferred components
+            OutputStyleComponents(obj, slots, op);
+        }
+        else
+        {
+            // Output only the components that were requested
+            foreach (var component in DateTimeFormatInternalSlots.ComponentNames)
+            {
+                if (slots.Components.TryGetValue(component, out var value))
+                {
+                    if (string.Equals(component, "fractionalSecondDigits", StringComparison.Ordinal))
+                    {
+                        CreateDataPropertyOrThrowJsValue(obj, component,
+                            int.TryParse(value, CultureInfo.InvariantCulture, out var fsd)
+                                ? (double)fsd
+                                : JsValue.Undefined, Realm, op);
+                    }
+                    else
+                    {
+                        CreateDataPropertyOrThrowJsValue(obj, component, value, Realm, op);
+                    }
+                }
+            }
+        }
+
+        // dateStyle and timeStyle
+        if (slots.DateStyle is not null)
+        {
+            CreateDataPropertyOrThrowJsValue(obj, "dateStyle", slots.DateStyle, Realm, op);
+        }
+
+        if (slots.TimeStyle is not null)
+        {
+            CreateDataPropertyOrThrowJsValue(obj, "timeStyle", slots.TimeStyle, Realm, op);
         }
 
         return new JsValue(obj);
+    }
+
+    private void OutputStyleComponents(JsObject obj, DateTimeFormatInternalSlots slots, string op)
+    {
+        var realm = Realm;
+
+        // dateStyle implies year, month, day (and possibly weekday, era)
+        if (slots.DateStyle is not null)
+        {
+            switch (slots.DateStyle)
+            {
+                case "full":
+                    CreateDataPropertyOrThrowJsValue(obj, "weekday", "long", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "year", "numeric", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "month", "long", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "day", "numeric", realm!, op);
+                    break;
+                case "long":
+                    CreateDataPropertyOrThrowJsValue(obj, "year", "numeric", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "month", "long", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "day", "numeric", realm!, op);
+                    break;
+                case "medium":
+                    CreateDataPropertyOrThrowJsValue(obj, "year", "numeric", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "month", "short", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "day", "numeric", realm!, op);
+                    break;
+                case "short":
+                    CreateDataPropertyOrThrowJsValue(obj, "year", "2-digit", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "month", "numeric", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "day", "numeric", realm!, op);
+                    break;
+            }
+        }
+
+        // timeStyle implies hour, minute (and possibly second)
+        if (slots.TimeStyle is not null)
+        {
+            switch (slots.TimeStyle)
+            {
+                case "full":
+                case "long":
+                    CreateDataPropertyOrThrowJsValue(obj, "hour", "numeric", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "minute", "2-digit", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "second", "2-digit", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "timeZoneName",
+                        slots.TimeStyle is "full" ? "long" : "short", realm!, op);
+                    break;
+                case "medium":
+                    CreateDataPropertyOrThrowJsValue(obj, "hour", "numeric", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "minute", "2-digit", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "second", "2-digit", realm!, op);
+                    break;
+                case "short":
+                    CreateDataPropertyOrThrowJsValue(obj, "hour", "numeric", realm!, op);
+                    CreateDataPropertyOrThrowJsValue(obj, "minute", "2-digit", realm!, op);
+                    break;
+            }
+        }
     }
 
     private DateTimeFormatInternalSlots ValidateReceiver(JsValue thisValue, out JsObject instance)
@@ -96,7 +344,7 @@ public sealed partial class IntlDateTimeFormatPrototype
         if (!obj.TryGetProperty(SlotsKey, out var slotValue) ||
             !slotValue.TryGetObject<DateTimeFormatInternalSlots>(out var slots))
         {
-            throw StandardLibrary.ThrowTypeError("Intl.DateTimeFormat method called on incompatible receiver",
+            throw ThrowTypeError("Intl.DateTimeFormat method called on incompatible receiver",
                 realm: Realm);
         }
 
@@ -104,12 +352,258 @@ public sealed partial class IntlDateTimeFormatPrototype
         return slots;
     }
 
-    private static JsObject CreateRangePart(string type, string value)
+    private static JsObject CreateRangePart(string type, string value, string? source = null)
     {
         var obj = new JsObject();
         obj.SetProperty("type", new JsValue(type));
         obj.SetProperty("value", new JsValue(value));
+        if (source is not null)
+        {
+            obj.SetProperty("source", new JsValue(source));
+        }
+
         return obj;
+    }
+
+    /// <summary>
+    /// Returns true when the format uses named months (short/long/narrow) and should attempt range collapsing.
+    /// Numeric dates are not collapsed per CLDR conventions.
+    /// </summary>
+    private static bool ShouldCollapseRange(DateTimeFormatInternalSlots slots)
+    {
+        // Only collapse when using component-based formatting (not style-based)
+        if (slots.DateStyle is not null || slots.TimeStyle is not null)
+        {
+            return false;
+        }
+
+        // Only collapse when month is named (short/long/narrow), not numeric
+        return slots.Components.TryGetValue("month", out var monthWidth)
+               && monthWidth is "long" or "short" or "narrow";
+    }
+
+    /// <summary>
+    /// Extract (type, value) from a typed part JsObject.
+    /// </summary>
+    private static (string type, string value) ExtractPartInfo(JsValue part)
+    {
+        if (!part.TryGetObject<JsObject>(out var obj))
+        {
+            return ("literal", "");
+        }
+
+        var type = obj.TryGetProperty("type", out var t) ? (string)t.ObjectValue! : "literal";
+        var value = obj.TryGetProperty("value", out var v) ? (string)v.ObjectValue! : "";
+        return (type, value);
+    }
+
+    /// <summary>
+    /// Build a collapsed range string by finding shared prefix/suffix parts.
+    /// Returns null if no collapsing is possible (all parts differ).
+    /// </summary>
+    private static string? BuildCollapsedRangeString(JsArray startParts, JsArray endParts)
+    {
+        var startCount = (int)startParts.Length;
+        var endCount = (int)endParts.Length;
+
+        if (startCount != endCount)
+        {
+            return null; // Different structure, can't collapse
+        }
+
+        // Find shared prefix length
+        var prefixLen = 0;
+        while (prefixLen < startCount)
+        {
+            var (st, sv) = ExtractPartInfo(startParts.Get(prefixLen));
+            var (et, ev) = ExtractPartInfo(endParts.Get(prefixLen));
+            if (st != et || sv != ev)
+            {
+                break;
+            }
+
+            prefixLen++;
+        }
+
+        // If all parts match, they're equal (shouldn't reach here)
+        if (prefixLen == startCount)
+        {
+            return null;
+        }
+
+        // Find shared suffix length (don't overlap with prefix)
+        var suffixLen = 0;
+        while (suffixLen < startCount - prefixLen)
+        {
+            var si = startCount - 1 - suffixLen;
+            var ei = endCount - 1 - suffixLen;
+            var (st, sv) = ExtractPartInfo(startParts.Get(si));
+            var (et, ev) = ExtractPartInfo(endParts.Get(ei));
+            if (st != et || sv != ev)
+            {
+                break;
+            }
+
+            suffixLen++;
+        }
+
+        // Per CLDR: only collapse when there's a shared suffix (year is shared).
+        // When the year (last significant component) differs, show full dates.
+        if (suffixLen == 0)
+        {
+            return null;
+        }
+
+        // Build collapsed string: prefix + start-middle + " – " + end-middle + suffix
+        var sb = new StringBuilder();
+
+        // Shared prefix
+        for (var i = 0; i < prefixLen; i++)
+        {
+            var (_, v) = ExtractPartInfo(startParts.Get(i));
+            sb.Append(v);
+        }
+
+        // Start-specific middle
+        for (var i = prefixLen; i < startCount - suffixLen; i++)
+        {
+            var (_, v) = ExtractPartInfo(startParts.Get(i));
+            sb.Append(v);
+        }
+
+        sb.Append(" \u2013 ");
+
+        // End-specific middle
+        for (var i = prefixLen; i < endCount - suffixLen; i++)
+        {
+            var (_, v) = ExtractPartInfo(endParts.Get(i));
+            sb.Append(v);
+        }
+
+        // Shared suffix
+        for (var i = startCount - suffixLen; i < startCount; i++)
+        {
+            var (_, v) = ExtractPartInfo(startParts.Get(i));
+            sb.Append(v);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Build collapsed range parts with source attributes.
+    /// Returns null if no collapsing is possible.
+    /// </summary>
+    private static JsArray? BuildCollapsedRangeParts(RealmState realm, JsArray startParts, JsArray endParts)
+    {
+        var startCount = (int)startParts.Length;
+        var endCount = (int)endParts.Length;
+
+        if (startCount != endCount)
+        {
+            return null;
+        }
+
+        // Find shared prefix length
+        var prefixLen = 0;
+        while (prefixLen < startCount)
+        {
+            var (st, sv) = ExtractPartInfo(startParts.Get(prefixLen));
+            var (et, ev) = ExtractPartInfo(endParts.Get(prefixLen));
+            if (st != et || sv != ev)
+            {
+                break;
+            }
+
+            prefixLen++;
+        }
+
+        if (prefixLen == startCount)
+        {
+            return null;
+        }
+
+        // Find shared suffix length
+        var suffixLen = 0;
+        while (suffixLen < startCount - prefixLen)
+        {
+            var si = startCount - 1 - suffixLen;
+            var ei = endCount - 1 - suffixLen;
+            var (st, sv) = ExtractPartInfo(startParts.Get(si));
+            var (et, ev) = ExtractPartInfo(endParts.Get(ei));
+            if (st != et || sv != ev)
+            {
+                break;
+            }
+
+            suffixLen++;
+        }
+
+        if (suffixLen == 0)
+        {
+            return null;
+        }
+
+        var result = new JsArray(realm);
+
+        // Shared prefix parts
+        for (var i = 0; i < prefixLen; i++)
+        {
+            var (type, value) = ExtractPartInfo(startParts.Get(i));
+            result.Push(CreateRangePart(type, value, "shared"));
+        }
+
+        // Start-specific middle
+        for (var i = prefixLen; i < startCount - suffixLen; i++)
+        {
+            var (type, value) = ExtractPartInfo(startParts.Get(i));
+            result.Push(CreateRangePart(type, value, "startRange"));
+        }
+
+        // Range separator
+        result.Push(CreateRangePart("literal", " \u2013 ", "shared"));
+
+        // End-specific middle
+        for (var i = prefixLen; i < endCount - suffixLen; i++)
+        {
+            var (type, value) = ExtractPartInfo(endParts.Get(i));
+            result.Push(CreateRangePart(type, value, "endRange"));
+        }
+
+        // Shared suffix parts
+        for (var i = startCount - suffixLen; i < startCount; i++)
+        {
+            var (type, value) = ExtractPartInfo(startParts.Get(i));
+            result.Push(CreateRangePart(type, value, "shared"));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Translate digits in all part values of a typed parts array.
+    /// </summary>
+    private static void TranslatePartsDigits(JsArray parts, string numberingSystem)
+    {
+        if (numberingSystem is "latn")
+        {
+            return;
+        }
+
+        for (var i = 0; i < parts.Length; i++)
+        {
+            var part = parts.Get(i);
+            if (part.TryGetObject<JsObject>(out var partObj) &&
+                partObj.TryGetProperty("value", out var val) &&
+                val.TryGetString(out var str))
+            {
+                var translated = IntlUtilities.TranslateDigits(str, numberingSystem);
+                if (!ReferenceEquals(translated, str))
+                {
+                    partObj.SetProperty("value", new JsValue(translated));
+                }
+            }
+        }
     }
 
     private HostFunction CreateBoundFormatFunction(Func<JsValue, JsValue> formatter)
@@ -127,27 +621,1031 @@ public sealed partial class IntlDateTimeFormatPrototype
             new PropertyDescriptor { Value = string.Empty, Writable = false, Enumerable = false, Configurable = true });
     }
 
-    private static JsValue FormatInternal(JsValue value, DateTimeFormatInternalSlots slots)
+    private static string FormatDateTimeOffset(double epochMs, DateTimeFormatInternalSlots slots)
+    {
+        return (string)FormatEpoch(epochMs, slots).ObjectValue!;
+    }
+
+    private static JsValue FormatChecked(JsValue value, DateTimeFormatInternalSlots slots, RealmState realm)
     {
         var epochMilliseconds = ToEpochMilliseconds(value);
         if (double.IsNaN(epochMilliseconds))
         {
-            return new JsValue("Invalid Date");
+            throw ThrowRangeError("Invalid time value", realm: realm);
         }
 
-        var truncated = Math.Truncate(epochMilliseconds);
+        return FormatEpoch(epochMilliseconds, slots);
+    }
+
+    private static JsValue FormatEpoch(double epochMilliseconds, DateTimeFormatInternalSlots slots)
+    {
+        var dto = ToDateTimeOffset(epochMilliseconds, slots.TimeZone);
+        var culture = IntlUtilities.ResolveCulture(slots.Locale);
+
+        string result;
+
+        // Style-based formatting
+        if (slots.DateStyle is not null || slots.TimeStyle is not null)
+        {
+            result = FormatWithStyles(dto, slots, culture);
+        }
+        // Component-based formatting
+        else if (slots.Components.Count > 0)
+        {
+            result = FormatWithComponents(dto, slots, culture);
+        }
+        else
+        {
+            // Default: year, month, day
+            result = FormatDefault(dto, culture);
+        }
+
+        // Apply numbering system digit translation
+        result = IntlUtilities.TranslateDigits(result, slots.NumberingSystem);
+
+        return new JsValue(result);
+    }
+
+    private static string FormatWithStyles(DateTimeOffset dto, DateTimeFormatInternalSlots slots, CultureInfo culture)
+    {
+        var datePart = slots.DateStyle switch
+        {
+            "full" => dto.ToString("dddd, MMMM d, yyyy", culture),
+            "long" => dto.ToString("MMMM d, yyyy", culture),
+            "medium" => dto.ToString("MMM d, yyyy", culture),
+            "short" => dto.ToString("M/d/yy", culture),
+            _ => null
+        };
+
+        var timePart = slots.TimeStyle switch
+        {
+            "full" or "long" => FormatTime(dto, slots, culture, includeSeconds: true, includeTimeZone: true,
+                longTimeZone: slots.TimeStyle is "full"),
+            "medium" => FormatTime(dto, slots, culture, includeSeconds: true, includeTimeZone: false,
+                longTimeZone: false),
+            "short" => FormatTime(dto, slots, culture, includeSeconds: false, includeTimeZone: false,
+                longTimeZone: false),
+            _ => null
+        };
+
+        if (datePart is not null && timePart is not null)
+        {
+            return $"{datePart}, {timePart}";
+        }
+
+        return datePart ?? timePart ?? dto.ToString("f", culture);
+    }
+
+    private static string FormatTime(DateTimeOffset dto, DateTimeFormatInternalSlots slots, CultureInfo culture,
+        bool includeSeconds, bool includeTimeZone, bool longTimeZone)
+    {
+        var sb = new StringBuilder();
+        var use12 = slots.HourCycle is "h11" or "h12";
+
+        int hour;
+        if (slots.HourCycle is "h11")
+        {
+            hour = dto.Hour % 12;
+        }
+        else if (slots.HourCycle is "h12")
+        {
+            hour = dto.Hour % 12;
+            if (hour == 0)
+            {
+                hour = 12;
+            }
+        }
+        else if (slots.HourCycle is "h24")
+        {
+            hour = dto.Hour == 0 ? 24 : dto.Hour;
+        }
+        else
+        {
+            hour = dto.Hour;
+        }
+
+        sb.Append(hour.ToString(CultureInfo.InvariantCulture));
+        sb.Append(':');
+        sb.Append(dto.Minute.ToString("D2", CultureInfo.InvariantCulture));
+
+        if (includeSeconds)
+        {
+            sb.Append(':');
+            sb.Append(dto.Second.ToString("D2", CultureInfo.InvariantCulture));
+        }
+
+        if (use12)
+        {
+            sb.Append(' ');
+            sb.Append(dto.Hour < 12 ? "AM" : "PM");
+        }
+
+        if (includeTimeZone)
+        {
+            sb.Append(' ');
+            sb.Append(GetTimeZoneDisplay(slots.TimeZone, dto, longTimeZone));
+        }
+
+        return sb.ToString();
+    }
+
+    private static string FormatWithComponents(DateTimeOffset dto, DateTimeFormatInternalSlots slots,
+        CultureInfo culture)
+    {
+        var sb = new StringBuilder();
+        var components = slots.Components;
+        var addedSomething = false;
+
+        // Weekday prefix
+        if (components.TryGetValue("weekday", out var weekday))
+        {
+            AppendSeparator(sb, ref addedSomething);
+            sb.Append(FormatWeekday(dto, weekday, culture));
+        }
+
+        if (components.TryGetValue("era", out var era))
+        {
+            AppendSeparator(sb, ref addedSomething);
+            sb.Append(FormatEra(dto, era));
+        }
+
+        // Date components (year/month/day) - locale-aware ordering and separators
+        var hasYear = components.TryGetValue("year", out var year);
+        var hasMonth = components.TryGetValue("month", out var month);
+        var hasDay = components.TryGetValue("day", out var day);
+
+        if (hasYear || hasMonth || hasDay)
+        {
+            var (order, numericSep) = ParseLocaleDateOrder(culture);
+            var dateStr = FormatLocaleDateString(dto, culture, order, numericSep,
+                hasYear, year, hasMonth, month, hasDay, day);
+            AppendSeparator(sb, ref addedSomething);
+            sb.Append(dateStr);
+        }
+
+        // dayPeriod only
+        if (components.TryGetValue("dayPeriod", out var dayPeriod) && !components.ContainsKey("hour"))
+        {
+            AppendSeparator(sb, ref addedSomething);
+            sb.Append(GetDayPeriod(dto, dayPeriod));
+        }
+
+        // Time components
+        string? pendingDayPeriod = null;
+        if (components.TryGetValue("hour", out var hour))
+        {
+            AppendSeparator(sb, ref addedSomething);
+            sb.Append(FormatHour(dto, hour, slots));
+
+            // Determine AM/PM but defer appending until after all time components
+            if (components.TryGetValue("dayPeriod", out var dp))
+            {
+                pendingDayPeriod = GetDayPeriod(dto, dp);
+            }
+            else if (slots.HourCycle is "h11" or "h12")
+            {
+                pendingDayPeriod = dto.Hour < 12 ? "AM" : "PM";
+            }
+        }
+
+        // Per ICU best-fit: when minute and second appear together (or with hour),
+        // they should always be 2-digit padded regardless of the "numeric" width setting
+        var forceMinSecPad = components.ContainsKey("minute") && components.ContainsKey("second");
+
+        if (components.TryGetValue("minute", out var minute))
+        {
+            if (components.ContainsKey("hour"))
+            {
+                sb.Append(':');
+            }
+            else
+            {
+                AppendSeparator(sb, ref addedSomething);
+            }
+
+            sb.Append(forceMinSecPad ? FormatMinute(dto, "2-digit") : FormatMinute(dto, minute));
+        }
+
+        if (components.TryGetValue("second", out var second))
+        {
+            if (components.ContainsKey("minute"))
+            {
+                sb.Append(':');
+            }
+            else
+            {
+                AppendSeparator(sb, ref addedSomething);
+            }
+
+            sb.Append(forceMinSecPad ? FormatSecond(dto, "2-digit") : FormatSecond(dto, second));
+        }
+
+        if (components.TryGetValue("fractionalSecondDigits", out var fsdStr) &&
+            int.TryParse(fsdStr, CultureInfo.InvariantCulture, out var fsd))
+        {
+            sb.Append(IntlUtilities.GetDecimalSeparator(slots.NumberingSystem));
+            var ms = dto.Millisecond;
+            var formatted = ms.ToString("D3", CultureInfo.InvariantCulture);
+            sb.Append(formatted[..fsd]);
+        }
+
+        // Append AM/PM after all time components
+        if (pendingDayPeriod is not null)
+        {
+            sb.Append(' ');
+            sb.Append(pendingDayPeriod);
+        }
+
+        if (components.TryGetValue("timeZoneName", out var tzName))
+        {
+            AppendSeparator(sb, ref addedSomething);
+            sb.Append(GetTimeZoneDisplay(slots.TimeZone, dto, tzName is "long"));
+        }
+
+        return sb.ToString();
+    }
+
+    private static string FormatDefault(DateTimeOffset dto, CultureInfo culture)
+    {
+        // When no components and no styles, use default: year, month, day with locale pattern
+        var (order, separator) = ParseLocaleDateOrder(culture);
+        return FormatLocaleDateString(dto, culture, order, separator,
+            true, "numeric", true, "numeric", true, "numeric");
+    }
+
+    private static void AppendSeparator(StringBuilder sb, ref bool addedSomething)
+    {
+        if (addedSomething)
+        {
+            sb.Append(", ");
+        }
+
+        addedSomething = true;
+    }
+
+    private enum DateOrder
+    {
+        MDY,
+        DMY,
+        YMD
+    }
+
+    private static (DateOrder order, string separator) ParseLocaleDateOrder(CultureInfo culture)
+    {
+        var pattern = culture.DateTimeFormat.ShortDatePattern;
+
+        var mPos = pattern.IndexOf('M');
+        var dPos = pattern.IndexOf('d');
+        var yPos = pattern.IndexOf('y');
+
+        if (mPos < 0)
+        {
+            mPos = int.MaxValue;
+        }
+
+        if (dPos < 0)
+        {
+            dPos = int.MaxValue;
+        }
+
+        if (yPos < 0)
+        {
+            yPos = int.MaxValue;
+        }
+
+        // Extract separator between first two date components
+        var separator = "/";
+        var positions = new (int pos, char ch)[] { (mPos, 'M'), (dPos, 'd'), (yPos, 'y') };
+        Array.Sort(positions, (a, b) => a.pos.CompareTo(b.pos));
+
+        if (positions.Length >= 2 && positions[0].pos != int.MaxValue && positions[1].pos != int.MaxValue)
+        {
+            // Find end of first component group
+            var endFirst = positions[0].pos;
+            while (endFirst < pattern.Length && pattern[endFirst] == positions[0].ch)
+            {
+                endFirst++;
+            }
+
+            // Find start of second component
+            var startSecond = positions[1].pos;
+
+            if (endFirst < startSecond)
+            {
+                separator = pattern[endFirst..startSecond];
+            }
+        }
+
+        DateOrder order;
+        if (mPos < dPos && mPos < yPos)
+        {
+            order = DateOrder.MDY;
+        }
+        else if (dPos < mPos && dPos < yPos)
+        {
+            order = DateOrder.DMY;
+        }
+        else
+        {
+            order = DateOrder.YMD;
+        }
+
+        return (order, separator);
+    }
+
+    private static char[] GetDateComponentChars(DateOrder order) => order switch
+    {
+        DateOrder.MDY => ['M', 'd', 'y'],
+        DateOrder.DMY => ['d', 'M', 'y'],
+        DateOrder.YMD => ['y', 'M', 'd'],
+        _ => ['M', 'd', 'y']
+    };
+
+    private static string FormatLocaleDateString(
+        DateTimeOffset dto, CultureInfo culture, DateOrder order, string numericSep,
+        bool hasYear, string? yearWidth,
+        bool hasMonth, string? monthWidth,
+        bool hasDay, string? dayWidth)
+    {
+        var namedMonth = monthWidth is "long" or "short" or "narrow";
+
+        var yearStr = hasYear ? FormatYear(dto, yearWidth) : null;
+        var monthStr = hasMonth ? FormatMonth(dto, monthWidth, culture) : null;
+        var dayStr = hasDay ? FormatDay(dto, dayWidth) : null;
+
+        // Build ordered list of present components
+        var parts = new List<(char ch, string value)>();
+        foreach (var c in GetDateComponentChars(order))
+        {
+            switch (c)
+            {
+                case 'M' when monthStr is not null:
+                    parts.Add(('M', monthStr));
+                    break;
+                case 'd' when dayStr is not null:
+                    parts.Add(('d', dayStr));
+                    break;
+                case 'y' when yearStr is not null:
+                    parts.Add(('y', yearStr));
+                    break;
+            }
+        }
+
+        if (parts.Count == 0)
+        {
+            return "";
+        }
+
+        if (parts.Count == 1)
+        {
+            return parts[0].value;
+        }
+
+        if (!namedMonth)
+        {
+            return string.Join(numericSep, parts.Select(p => p.value));
+        }
+
+        // Named month: use locale-aware separators
+        var sb = new StringBuilder();
+        for (var i = 0; i < parts.Count; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(GetNamedMonthSeparator(order, parts, i));
+            }
+
+            sb.Append(parts[i].value);
+        }
+
+        return sb.ToString();
+    }
+
+    private static string GetNamedMonthSeparator(DateOrder order, List<(char ch, string value)> parts, int index)
+    {
+        // MDY: "Jan 3, 2019" → " " between M-d, ", " between d-y
+        // DMY: "3 Jan 2019" → " " between all
+        // YMD: "2019 Jan 3" → " " between all
+        if (order == DateOrder.MDY && parts[index - 1].ch == 'd' && parts[index].ch == 'y')
+        {
+            return ", ";
+        }
+
+        if (order == DateOrder.DMY && parts[index - 1].ch == 'd' && parts[index].ch == 'M')
+        {
+            return " ";
+        }
+
+        return " ";
+    }
+
+    private static string FormatWeekday(DateTimeOffset dto, string width, CultureInfo culture)
+    {
+        return width switch
+        {
+            "long" => dto.ToString("dddd", culture),
+            "short" => dto.ToString("ddd", culture),
+            "narrow" => dto.ToString("dddd", culture)[..1],
+            _ => dto.ToString("dddd", culture)
+        };
+    }
+
+    private static string FormatEra(DateTimeOffset dto, string width)
+    {
+        var era = dto.Year > 0 ? "AD" : "BC";
+        return width switch
+        {
+            "long" => dto.Year > 0 ? "Anno Domini" : "Before Christ",
+            "short" => era,
+            "narrow" => era[..1],
+            _ => era
+        };
+    }
+
+    private static string FormatYear(DateTimeOffset dto, string width)
+    {
+        return width switch
+        {
+            "2-digit" => (dto.Year % 100).ToString("D2", CultureInfo.InvariantCulture),
+            _ => dto.Year.ToString(CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static string FormatMonth(DateTimeOffset dto, string width, CultureInfo culture)
+    {
+        return width switch
+        {
+            "long" => dto.ToString("MMMM", culture),
+            "short" => dto.ToString("MMM", culture),
+            "narrow" => dto.ToString("MMMM", culture)[..1],
+            "2-digit" => dto.Month.ToString("D2", CultureInfo.InvariantCulture),
+            _ => dto.Month.ToString(CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static string FormatDay(DateTimeOffset dto, string width)
+    {
+        return width switch
+        {
+            "2-digit" => dto.Day.ToString("D2", CultureInfo.InvariantCulture),
+            _ => dto.Day.ToString(CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static string FormatHour(DateTimeOffset dto, string width, DateTimeFormatInternalSlots slots)
+    {
+        int hour;
+        if (slots.HourCycle is "h11")
+        {
+            hour = dto.Hour % 12;
+        }
+        else if (slots.HourCycle is "h12")
+        {
+            hour = dto.Hour % 12;
+            if (hour == 0)
+            {
+                hour = 12;
+            }
+        }
+        else if (slots.HourCycle is "h24")
+        {
+            hour = dto.Hour == 0 ? 24 : dto.Hour;
+        }
+        else
+        {
+            hour = dto.Hour;
+        }
+
+        return width switch
+        {
+            "2-digit" => hour.ToString("D2", CultureInfo.InvariantCulture),
+            _ => hour.ToString(CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static string FormatMinute(DateTimeOffset dto, string width)
+    {
+        return width switch
+        {
+            "2-digit" => dto.Minute.ToString("D2", CultureInfo.InvariantCulture),
+            _ => dto.Minute.ToString(CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static string FormatSecond(DateTimeOffset dto, string width)
+    {
+        return width switch
+        {
+            "2-digit" => dto.Second.ToString("D2", CultureInfo.InvariantCulture),
+            _ => dto.Second.ToString(CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static string GetDayPeriod(DateTimeOffset dto, string width)
+    {
+        var hour = dto.Hour;
+
+        // Per CLDR day period rules for English
+        // midnight = 0, morning = 6-12, noon = 12, afternoon = 12-18, evening = 18-21, night = 21-6
+        return width switch
+        {
+            "narrow" => GetDayPeriodNarrow(hour),
+            "short" => GetDayPeriodShort(hour),
+            "long" => GetDayPeriodLong(hour),
+            _ => hour < 12 ? "AM" : "PM"
+        };
+    }
+
+    private static string GetDayPeriodNarrow(int hour)
+    {
+        if (hour == 0)
+        {
+            return "at night";
+        }
+
+        if (hour == 12)
+        {
+            return "n";
+        }
+
+        return hour switch
+        {
+            >= 1 and < 6 => "at night",
+            >= 6 and < 12 => "in the morning",
+            > 12 and < 18 => "in the afternoon",
+            >= 18 and < 21 => "in the evening",
+            _ => "at night"
+        };
+    }
+
+    private static string GetDayPeriodShort(int hour)
+    {
+        if (hour == 0)
+        {
+            return "at night";
+        }
+
+        if (hour == 12)
+        {
+            return "noon";
+        }
+
+        return hour switch
+        {
+            >= 1 and < 6 => "at night",
+            >= 6 and < 12 => "in the morning",
+            > 12 and < 18 => "in the afternoon",
+            >= 18 and < 21 => "in the evening",
+            _ => "at night"
+        };
+    }
+
+    private static string GetDayPeriodLong(int hour)
+    {
+        if (hour == 0)
+        {
+            return "at night";
+        }
+
+        if (hour == 12)
+        {
+            return "noon";
+        }
+
+        return hour switch
+        {
+            >= 1 and < 6 => "at night",
+            >= 6 and < 12 => "in the morning",
+            > 12 and < 18 => "in the afternoon",
+            >= 18 and < 21 => "in the evening",
+            _ => "at night"
+        };
+    }
+
+    private static string GetTimeZoneDisplay(string timeZoneId, DateTimeOffset dto, bool longForm)
+    {
+        if (string.Equals(timeZoneId, "UTC", StringComparison.OrdinalIgnoreCase))
+        {
+            return longForm ? "Coordinated Universal Time" : "UTC";
+        }
+
+        // Handle offset timezone IDs like +03:00, -07:00
+        if (timeZoneId.Length > 0 && (timeZoneId[0] == '+' || timeZoneId[0] == '-'))
+        {
+            if (TryParseTimeZoneOffset(timeZoneId, out var offset))
+            {
+                var sign = offset >= TimeSpan.Zero ? "+" : "";
+                return $"GMT{sign}{offset.Hours:D2}:{offset.Minutes:D2}";
+            }
+
+            return $"GMT{timeZoneId}";
+        }
+
         try
         {
-            var offset = DateTimeOffset.FromUnixTimeMilliseconds((long)truncated);
-            var culture = CultureInfo.GetCultureInfo(slots.Locale);
-            var format = slots.TimeStyle is "long" or "short" ? "G" : "f";
-            return new JsValue(offset.ToString(format, culture));
+            var tz = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            if (longForm)
+            {
+                return tz.IsDaylightSavingTime(dto) ? tz.DaylightName : tz.StandardName;
+            }
+
+            var offset = tz.GetUtcOffset(dto);
+            return $"GMT{(offset >= TimeSpan.Zero ? "+" : "")}{offset.Hours:D2}:{offset.Minutes:D2}";
         }
         catch
         {
-            return new JsValue(DateTimeOffset.FromUnixTimeMilliseconds((long)truncated)
-                .ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture));
+            return timeZoneId;
         }
+    }
+
+    private JsArray FormatToPartsInternal(DateTimeOffset dto, DateTimeFormatInternalSlots slots, CultureInfo culture)
+    {
+        var parts = new JsArray(Realm);
+        var components = slots.Components;
+
+        if (slots.DateStyle is not null || slots.TimeStyle is not null)
+        {
+            FormatStyleToParts(dto, slots, culture, parts);
+            return parts;
+        }
+
+        if (components.Count == 0)
+        {
+            var formatted = FormatDefault(dto, culture);
+            parts.Push(CreateTypedPart("literal", formatted));
+            return parts;
+        }
+
+        var addedSomething = false;
+
+        if (components.TryGetValue("weekday", out var weekday))
+        {
+            AddSeparatorPart(parts, ref addedSomething);
+            parts.Push(CreateTypedPart("weekday", FormatWeekday(dto, weekday, culture)));
+        }
+
+        if (components.TryGetValue("era", out var era))
+        {
+            AddSeparatorPart(parts, ref addedSomething);
+            parts.Push(CreateTypedPart("era", FormatEra(dto, era)));
+        }
+
+        // Date components (year/month/day) - locale-aware ordering and separators
+        var hasYear = components.TryGetValue("year", out var year);
+        var hasMonth = components.TryGetValue("month", out var month);
+        var hasDay = components.TryGetValue("day", out var day);
+
+        if (hasYear || hasMonth || hasDay)
+        {
+            AppendLocaleDateParts(parts, ref addedSomething, dto, culture,
+                hasYear, year, hasMonth, month, hasDay, day);
+        }
+
+        if (components.TryGetValue("dayPeriod", out var dayPeriod) && !components.ContainsKey("hour"))
+        {
+            AddSeparatorPart(parts, ref addedSomething);
+            parts.Push(CreateTypedPart("dayPeriod", GetDayPeriod(dto, dayPeriod)));
+        }
+
+        // Determine pending day period but defer until after time components
+        string? pendingDayPeriodParts = null;
+        if (components.TryGetValue("hour", out var hour))
+        {
+            AddSeparatorPart(parts, ref addedSomething);
+            parts.Push(CreateTypedPart("hour", FormatHour(dto, hour, slots)));
+
+            if (components.TryGetValue("dayPeriod", out var dp))
+            {
+                pendingDayPeriodParts = GetDayPeriod(dto, dp);
+            }
+            else if (slots.HourCycle is "h11" or "h12")
+            {
+                pendingDayPeriodParts = dto.Hour < 12 ? "AM" : "PM";
+            }
+        }
+
+        var forceMinSecPadParts = components.ContainsKey("minute") && components.ContainsKey("second");
+
+        if (components.TryGetValue("minute", out var minute))
+        {
+            if (components.ContainsKey("hour"))
+            {
+                parts.Push(CreateTypedPart("literal", ":"));
+            }
+            else
+            {
+                AddSeparatorPart(parts, ref addedSomething);
+            }
+
+            parts.Push(CreateTypedPart("minute",
+                forceMinSecPadParts ? FormatMinute(dto, "2-digit") : FormatMinute(dto, minute)));
+        }
+
+        if (components.TryGetValue("second", out var second))
+        {
+            if (components.ContainsKey("minute"))
+            {
+                parts.Push(CreateTypedPart("literal", ":"));
+            }
+            else
+            {
+                AddSeparatorPart(parts, ref addedSomething);
+            }
+
+            parts.Push(CreateTypedPart("second",
+                forceMinSecPadParts ? FormatSecond(dto, "2-digit") : FormatSecond(dto, second)));
+        }
+
+        if (components.TryGetValue("fractionalSecondDigits", out var fsdStr) &&
+            int.TryParse(fsdStr, CultureInfo.InvariantCulture, out var fsd))
+        {
+            parts.Push(CreateTypedPart("literal", IntlUtilities.GetDecimalSeparator(slots.NumberingSystem)));
+            var ms = dto.Millisecond;
+            var formatted = ms.ToString("D3", CultureInfo.InvariantCulture);
+            parts.Push(CreateTypedPart("fractionalSecond", formatted[..fsd]));
+        }
+
+        // Append AM/PM after all time components
+        if (pendingDayPeriodParts is not null)
+        {
+            parts.Push(CreateTypedPart("literal", " "));
+            parts.Push(CreateTypedPart("dayPeriod", pendingDayPeriodParts));
+        }
+
+        if (components.TryGetValue("timeZoneName", out var tzName))
+        {
+            AddSeparatorPart(parts, ref addedSomething);
+            parts.Push(CreateTypedPart("timeZoneName",
+                GetTimeZoneDisplay(slots.TimeZone, dto, tzName is "long")));
+        }
+
+        return parts;
+    }
+
+    private static void FormatStyleToParts(DateTimeOffset dto, DateTimeFormatInternalSlots slots, CultureInfo culture,
+        JsArray parts)
+    {
+        var use12 = slots.HourCycle is "h11" or "h12";
+        var addedSomething = false;
+
+        // Date parts
+        if (slots.DateStyle is not null)
+        {
+            if (slots.DateStyle is "full")
+            {
+                parts.Push(CreateTypedPart("weekday", dto.ToString("dddd", culture)));
+                parts.Push(CreateTypedPart("literal", ", "));
+            }
+
+            parts.Push(CreateTypedPart("month",
+                slots.DateStyle is "short"
+                    ? dto.Month.ToString(CultureInfo.InvariantCulture)
+                    : slots.DateStyle is "medium"
+                        ? dto.ToString("MMM", culture)
+                        : dto.ToString("MMMM", culture)));
+            parts.Push(CreateTypedPart("literal", " "));
+            parts.Push(CreateTypedPart("day", dto.Day.ToString(CultureInfo.InvariantCulture)));
+            parts.Push(CreateTypedPart("literal", ", "));
+            parts.Push(CreateTypedPart("year",
+                slots.DateStyle is "short"
+                    ? (dto.Year % 100).ToString("D2", CultureInfo.InvariantCulture)
+                    : dto.Year.ToString(CultureInfo.InvariantCulture)));
+            addedSomething = true;
+        }
+
+        // Time parts
+        if (slots.TimeStyle is not null)
+        {
+            if (addedSomething)
+            {
+                parts.Push(CreateTypedPart("literal", ", "));
+            }
+
+            int hour;
+            if (slots.HourCycle is "h11")
+            {
+                hour = dto.Hour % 12;
+            }
+            else if (slots.HourCycle is "h12")
+            {
+                hour = dto.Hour % 12;
+                if (hour == 0)
+                {
+                    hour = 12;
+                }
+            }
+            else if (slots.HourCycle is "h24")
+            {
+                hour = dto.Hour == 0 ? 24 : dto.Hour;
+            }
+            else
+            {
+                hour = dto.Hour;
+            }
+
+            parts.Push(CreateTypedPart("hour", hour.ToString(CultureInfo.InvariantCulture)));
+            parts.Push(CreateTypedPart("literal", ":"));
+            parts.Push(CreateTypedPart("minute",
+                dto.Minute.ToString("D2", CultureInfo.InvariantCulture)));
+
+            if (slots.TimeStyle is "full" or "long" or "medium")
+            {
+                parts.Push(CreateTypedPart("literal", ":"));
+                parts.Push(CreateTypedPart("second",
+                    dto.Second.ToString("D2", CultureInfo.InvariantCulture)));
+            }
+
+            if (use12)
+            {
+                parts.Push(CreateTypedPart("literal", " "));
+                parts.Push(CreateTypedPart("dayPeriod", dto.Hour < 12 ? "AM" : "PM"));
+            }
+
+            if (slots.TimeStyle is "full" or "long")
+            {
+                parts.Push(CreateTypedPart("literal", " "));
+                parts.Push(CreateTypedPart("timeZoneName",
+                    GetTimeZoneDisplay(slots.TimeZone, dto, slots.TimeStyle is "full")));
+            }
+        }
+    }
+
+    private static JsObject CreateTypedPart(string type, string value)
+    {
+        var obj = new JsObject();
+        obj.SetProperty("type", new JsValue(type));
+        obj.SetProperty("value", new JsValue(value));
+        return obj;
+    }
+
+    private static void AddSeparatorPart(JsArray parts, ref bool addedSomething)
+    {
+        if (addedSomething)
+        {
+            parts.Push(CreateTypedPart("literal", ", "));
+        }
+
+        addedSomething = true;
+    }
+
+    private static void AppendLocaleDateParts(
+        JsArray parts, ref bool addedSomething,
+        DateTimeOffset dto, CultureInfo culture,
+        bool hasYear, string? yearWidth,
+        bool hasMonth, string? monthWidth,
+        bool hasDay, string? dayWidth)
+    {
+        var (order, numericSep) = ParseLocaleDateOrder(culture);
+        var namedMonth = monthWidth is "long" or "short" or "narrow";
+
+        // Build ordered list of present components
+        var componentList = new List<(char ch, string type, string value)>();
+        foreach (var c in GetDateComponentChars(order))
+        {
+            switch (c)
+            {
+                case 'M' when hasMonth:
+                    componentList.Add(('M', "month", FormatMonth(dto, monthWidth, culture)));
+                    break;
+                case 'd' when hasDay:
+                    componentList.Add(('d', "day", FormatDay(dto, dayWidth)));
+                    break;
+                case 'y' when hasYear:
+                    componentList.Add(('y', "year", FormatYear(dto, yearWidth)));
+                    break;
+            }
+        }
+
+        for (var i = 0; i < componentList.Count; i++)
+        {
+            if (i == 0)
+            {
+                // Separator from previous non-date components (weekday, era)
+                if (addedSomething)
+                {
+                    parts.Push(CreateTypedPart("literal", ", "));
+                }
+            }
+            else
+            {
+                // Separator between date components
+                if (namedMonth)
+                {
+                    var sep = GetNamedMonthSeparator(order,
+                        componentList.ConvertAll(x => (x.ch, x.value)), i);
+                    parts.Push(CreateTypedPart("literal", sep));
+                }
+                else
+                {
+                    parts.Push(CreateTypedPart("literal", numericSep));
+                }
+            }
+
+            parts.Push(CreateTypedPart(componentList[i].type, componentList[i].value));
+            addedSomething = true;
+        }
+    }
+
+    private static DateTimeOffset ToDateTimeOffset(double epochMs, string timeZoneId)
+    {
+        var truncated = Math.Truncate(epochMs);
+        var longMs = (long)truncated;
+
+        // .NET DateTimeOffset range is narrower than ECMAScript time range
+        // Clamp to .NET's supported range
+        const long dotNetMinMs = -62135596800000L;
+        const long dotNetMaxMs = 253402300799999L;
+        longMs = Math.Clamp(longMs, dotNetMinMs, dotNetMaxMs);
+
+        var dto = DateTimeOffset.FromUnixTimeMilliseconds(longMs);
+
+        if (string.Equals(timeZoneId, "UTC", StringComparison.OrdinalIgnoreCase))
+        {
+            return dto;
+        }
+
+        // Handle offset timezones like +03:00, -07:00
+        if (timeZoneId.Length > 0 && (timeZoneId[0] == '+' || timeZoneId[0] == '-'))
+        {
+            if (TryParseTimeZoneOffset(timeZoneId, out var offset))
+            {
+                // .NET only supports ±14h offsets in DateTimeOffset.ToOffset
+                // For larger offsets, manually adjust the UTC time
+                var totalMinutes = (int)offset.TotalMinutes;
+                var utcTicks = dto.UtcTicks;
+                var adjustedTicks = utcTicks + TimeSpan.FromMinutes(totalMinutes).Ticks;
+
+                // Clamp to valid DateTimeOffset range
+                if (adjustedTicks < DateTime.MinValue.Ticks)
+                {
+                    adjustedTicks = DateTime.MinValue.Ticks;
+                }
+                else if (adjustedTicks > DateTime.MaxValue.Ticks)
+                {
+                    adjustedTicks = DateTime.MaxValue.Ticks;
+                }
+
+                // Use a safe offset for the DateTimeOffset constructor (clamp to ±14h)
+                var safeOffset = offset;
+                if (offset.TotalHours > 14 || offset.TotalHours < -14)
+                {
+                    safeOffset = TimeSpan.Zero;
+                }
+
+                try
+                {
+                    return new DateTimeOffset(new DateTime(adjustedTicks, DateTimeKind.Unspecified), safeOffset);
+                }
+                catch
+                {
+                    return dto;
+                }
+            }
+
+            return dto;
+        }
+
+        try
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            return TimeZoneInfo.ConvertTime(dto, tz);
+        }
+        catch
+        {
+            return dto;
+        }
+    }
+
+    private static bool TryParseTimeZoneOffset(string timeZoneId, out TimeSpan offset)
+    {
+        offset = TimeSpan.Zero;
+        if (string.IsNullOrEmpty(timeZoneId) || (timeZoneId[0] != '+' && timeZoneId[0] != '-'))
+        {
+            return false;
+        }
+
+        var sign = timeZoneId[0] == '+' ? 1 : -1;
+        var rest = timeZoneId.AsSpan(1);
+
+        int hours, minutes;
+        if (rest.Length == 5 && rest[2] == ':' &&
+            int.TryParse(rest[..2], System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture, out hours) &&
+            int.TryParse(rest[3..], System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture, out minutes))
+        {
+            offset = new TimeSpan(sign * hours, sign * minutes, 0);
+            return true;
+        }
+
+        if (rest.Length == 2 && int.TryParse(rest, System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture, out hours))
+        {
+            offset = new TimeSpan(sign * hours, 0, 0);
+            return true;
+        }
+
+        return false;
     }
 
     private static double ToEpochMilliseconds(JsValue value)
@@ -160,16 +1658,39 @@ public sealed partial class IntlDateTimeFormatPrototype
         if (value is { Kind: JsValueKind.Object, ObjectValue: JsObject jsObject } &&
             jsObject.TryGetProperty("_internalDate", out var stored) && stored.TryGetDouble(out var storedMs))
         {
-            return storedMs;
+            return TimeClip(storedMs);
         }
 
         try
         {
-            return JsOps.ToNumber(value);
+            var number = JsOps.ToNumber(value);
+            return TimeClip(number);
+        }
+        catch (ThrowSignal)
+        {
+            throw; // Propagate JS throw signals (valueOf/toString/Symbol.toPrimitive exceptions)
         }
         catch
         {
             return double.NaN;
         }
+    }
+
+    /// <summary>
+    /// ECMAScript TimeClip(time) - 20.4.1.15
+    /// </summary>
+    private static double TimeClip(double time)
+    {
+        if (!double.IsFinite(time))
+        {
+            return double.NaN;
+        }
+
+        if (Math.Abs(time) > 8.64e15)
+        {
+            return double.NaN;
+        }
+
+        return Math.Truncate(time);
     }
 }

--- a/src/Asynkron.JsEngine/StdLib/Intl/IntlOptionHelpers.cs
+++ b/src/Asynkron.JsEngine/StdLib/Intl/IntlOptionHelpers.cs
@@ -10,7 +10,7 @@ namespace Asynkron.JsEngine.StdLib.Intl;
 internal static class IntlOptionHelpers
 {
     /// <summary>
-    /// JsValue overload that avoids boxing. Per spec, uses ToObject on non-undefined values.
+    /// JsValue overload that avoids boxing.
     /// </summary>
     public static IJsPropertyAccessor? GetOptionsObject(JsValue optionsArg, RealmState realm, string typeName)
     {
@@ -24,14 +24,13 @@ internal static class IntlOptionHelpers
             throw StandardLibrary.ThrowTypeError($"Intl.{typeName} options must be an object", realm: realm);
         }
 
-        // Per spec: Let options be ? ToObject(options).
-        // ToObject wraps primitives (boolean, number, string, symbol) in their wrapper objects.
         if (optionsArg.TryGetObject<IJsPropertyAccessor>(out var accessor))
         {
             return accessor;
         }
 
-        // For primitive types (boolean, number, string, symbol), ToObject wraps them.
+        // Per spec: Let options be ? ToObject(options).
+        // ToObject wraps primitives (boolean, number, string, symbol) in their wrapper objects.
         return StandardLibrary.ToObjectPropertyAccessor(optionsArg, $"Intl.{typeName}", realm);
     }
 

--- a/src/Asynkron.JsEngine/StdLib/Intl/IntlUtilities.cs
+++ b/src/Asynkron.JsEngine/StdLib/Intl/IntlUtilities.cs
@@ -1207,6 +1207,128 @@ internal static partial class IntlUtilities
         public Dictionary<string, string> Lookup { get; } = lookup;
     }
 
+    /// <summary>
+    /// Maps numbering system IDs to the Unicode code point of their zero digit.
+    /// Most numbering systems have contiguous digit blocks (0-9 = zeroCodePoint + 0..9).
+    /// </summary>
+    private static readonly Dictionary<string, int> NumberingSystemZeroDigits = new(StringComparer.Ordinal)
+    {
+        ["arab"] = 0x0660,
+        ["arabext"] = 0x06F0,
+        ["bali"] = 0x1B50,
+        ["beng"] = 0x09E6,
+        ["cham"] = 0xAA50,
+        ["deva"] = 0x0966,
+        ["fullwide"] = 0xFF10,
+        ["gujr"] = 0x0AE6,
+        ["guru"] = 0x0A66,
+        ["java"] = 0xA9D0,
+        ["kali"] = 0xA900,
+        ["khmr"] = 0x17E0,
+        ["knda"] = 0x0CE6,
+        ["lana"] = 0x1A80,
+        ["lanatham"] = 0x1A90,
+        ["laoo"] = 0x0ED0,
+        ["lepc"] = 0x1C40,
+        ["limb"] = 0x1946,
+        ["mlym"] = 0x0D66,
+        ["mong"] = 0x1810,
+        ["mtei"] = 0xABF0,
+        ["mymr"] = 0x1040,
+        ["mymrshan"] = 0x1090,
+        ["nkoo"] = 0x07C0,
+        ["olck"] = 0x1C50,
+        ["orya"] = 0x0B66,
+        ["saur"] = 0xA8D0,
+        ["sund"] = 0x1BB0,
+        ["takr"] = 0x116C0,
+        ["talu"] = 0x19D0,
+        ["tamldec"] = 0x0BE6,
+        ["telu"] = 0x0C66,
+        ["thai"] = 0x0E50,
+        ["tibt"] = 0x0F20,
+        ["vaii"] = 0xA620,
+        ["wara"] = 0x118E0,
+        ["cakm"] = 0x11136,
+        ["modi"] = 0x11650,
+        ["mroo"] = 0x16A60,
+        ["osma"] = 0x104A0,
+        ["rohg"] = 0x10D30,
+        ["shrd"] = 0x111D0,
+        ["sind"] = 0x112F0,
+        ["sora"] = 0x110F0,
+        ["wcho"] = 0x1E2F0
+    };
+
+    /// <summary>
+    /// Translate Latin digits (0-9) in a string to the target numbering system's digits.
+    /// </summary>
+    internal static string TranslateDigits(string input, string numberingSystem)
+    {
+        if (numberingSystem is "latn" || string.IsNullOrEmpty(input))
+        {
+            return input;
+        }
+
+        if (numberingSystem is "hanidec")
+        {
+            return TranslateHanidecDigits(input);
+        }
+
+        if (!NumberingSystemZeroDigits.TryGetValue(numberingSystem, out var zeroCodePoint))
+        {
+            return input;
+        }
+
+        var sb = new System.Text.StringBuilder(input.Length * 2);
+        foreach (var ch in input)
+        {
+            if (ch >= '0' && ch <= '9')
+            {
+                var digit = ch - '0';
+                sb.Append(char.ConvertFromUtf32(zeroCodePoint + digit));
+            }
+            else
+            {
+                sb.Append(ch);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Translate Latin digits to Chinese numeral characters (hanidec system).
+    /// These are not contiguous in Unicode, so each must be mapped individually.
+    /// </summary>
+    private static string TranslateHanidecDigits(string input)
+    {
+        ReadOnlySpan<char> hanDigits = ['〇', '一', '二', '三', '四', '五', '六', '七', '八', '九'];
+        var sb = new System.Text.StringBuilder(input.Length);
+        foreach (var ch in input)
+        {
+            if (ch >= '0' && ch <= '9')
+            {
+                sb.Append(hanDigits[ch - '0']);
+            }
+            else
+            {
+                sb.Append(ch);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Returns the appropriate decimal separator for a given numbering system.
+    /// Arabic numbering systems use the Arabic decimal separator (U+066B).
+    /// </summary>
+    internal static string GetDecimalSeparator(string numberingSystem)
+    {
+        return numberingSystem is "arab" or "arabext" ? "\u066B" : ".";
+    }
+
     [GeneratedRegex(@"^(([a-z]{2,3}|[a-z]{5,8})(-([a-z]{4}))?(-([a-z]{2}|[0-9]{3}))?(-([a-z0-9]{5,8}|(?:[0-9][a-z0-9]{3})))*(-((u((-([a-z0-9][a-z](-[a-z0-9]{3,8})*))+|((-([a-z0-9]{3,8}))+(-([a-z0-9][a-z](-[a-z0-9]{3,8})*))*)))|(t((-(([a-z]{2,3}|[a-z]{5,8})(-([a-z]{4}))?(-([a-z]{2}|[0-9]{3}))?(-([a-z0-9]{5,8}|(?:[0-9][a-z0-9]{3})))*)(-([a-z][0-9](-[a-z0-9]{3,8})+))*)|(-([a-z][0-9](-[a-z0-9]{3,8})+))+))|(([0-9]|[a-sv-wy-z])(-[a-z0-9]{2,8})+)))*(-(x(-[a-z0-9]{1,8})+))?)$", RegexOptions.IgnoreCase | RegexOptions.Compiled, "sv-SE")]
     private static partial Regex MyRegex();
     [GeneratedRegex(@"-([0-9]|[a-wy-z])-(.*-)?\1(?![a-z0-9])", RegexOptions.IgnoreCase | RegexOptions.Compiled, "sv-SE")]


### PR DESCRIPTION
## Summary
- **Locale-aware date formatting**: Components ordered MDY/DMY/YMD based on CultureInfo.DateTimeFormat.ShortDatePattern
- **Range collapsing**: Named month date ranges properly collapse shared prefix/suffix ("Jan 3 – 5, 2019") per CLDR conventions
- **ToDateTimeOptions**: Implements ECMA-402 spec for Date.prototype.toLocaleString/toLocaleDateString/toLocaleTimeString default options
- **Digit translation**: Non-Latin numbering system support (Arabic, Devanagari, Chinese hanidec, etc.) with correct decimal separators
- **AM/PM placement**: Fixed to appear after all time components (minute, second, fractionalSecondDigits) not just after hour
- **Constructor improvements**: hourCycle resolution, dateStyle/timeStyle component defaults

## Test Results
- **Test262 DateTimeFormat**: 232 → 70 failures (162 tests fixed, 80 unique test files)
- **Internal tests**: 3184/3184 passing (zero regressions)
- **Remaining 70 failures**: 30 Temporal API (separate task), 28 pre-existing on main (timezone/taint/constructor), 12 calendar infrastructure (Chinese calendar, proleptic dates, allCalendars harness)

## Files Changed
- `IntlDateTimeFormatPrototype.cs` — Core formatting rewrite with locale-aware ordering, range collapsing, digit translation
- `IntlDateTimeFormatConstructor.cs` — Option resolution improvements
- `DateHelper.cs` — ToDateTimeOptions implementation
- `DatePrototype.cs` — Correct required/defaults params for toLocale* methods
- `IntlUtilities.cs` — TranslateDigits, GetDecimalSeparator utilities
- `IntlOptionHelpers.cs` — Option handling improvements
- `DateTimeFormatInternalSlots.cs` — Slot additions

## Test plan
- [x] Internal test suite passes (3184/3184)
- [x] Test262 DateTimeFormat improvements verified (232→70)
- [x] No regressions vs main baseline
- [x] Roslynator fix run
- [x] Code formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)