### PR TITLE
fix: reject with-scoped class IR seeds

### DIFF
--- a/src/Asynkron.JsEngine/Ast/ClassDefinitionExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ClassDefinitionExtensions.cs
@@ -255,7 +255,11 @@ public static partial class TypedAstEvaluator
             context,
             isConstructorFunction: true,
             skipInternalNameBinding: true,
-            planSeed: definition.Constructor.PlanSeed);
+            planSeed: GetRuntimePlanSeedForClassCallable(
+                definition.Constructor.PlanSeed,
+                definition.Constructor.Function,
+                "class constructor",
+                evaluationEnvironment));
         var constructorJsValue = JsValue.FromObjectUnsafe(constructorCallable);
         if (context.ShouldStopEvaluation)
         {
@@ -384,6 +388,25 @@ public static partial class TypedAstEvaluator
         }
 
         return constructorJsValue;
+    }
+
+    private static FunctionExecutionPlanSeed GetRuntimePlanSeedForClassCallable(
+        FunctionExecutionPlanSeed cachedPlanSeed,
+        FunctionExpression function,
+        string callableDescription,
+        JsEnvironment closure)
+    {
+        if (!function.IsGenerator &&
+            !function.IsAsync &&
+            cachedPlanSeed.Plan is not null &&
+            closure.HasWithObjectInChain())
+        {
+            return FunctionExecutionPlanSeed.Reject(
+                ExecutionPlanFailureCode.AstReentryDetected,
+                $"Cached IR plan for {callableDescription} cannot execute when the closure chain contains with.");
+        }
+
+        return cachedPlanSeed;
     }
 
     private static PrivateNameScope? CreatePrivateNameScope(this LoweredClassDefinition definition, RealmState realm)

--- a/src/Asynkron.JsEngine/Ast/ImmutableArrayClassMemberExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/ImmutableArrayClassMemberExtensions.cs
@@ -64,7 +64,11 @@ public static partial class TypedAstEvaluator
                 context,
                 false,
                 false,
-                member.Callable.PlanSeed));
+                GetRuntimePlanSeedForClassCallable(
+                    member.Callable.PlanSeed,
+                    member.Callable.Function,
+                    $"class member '{displayName}'",
+                    environment)));
             if (context.ShouldStopEvaluation)
             {
                 return;

--- a/src/Asynkron.JsEngine/Execution/ExecutionPlanBuildResult.cs
+++ b/src/Asynkron.JsEngine/Execution/ExecutionPlanBuildResult.cs
@@ -72,6 +72,16 @@ internal readonly record struct FunctionExecutionPlanSeed(
     {
         return new FunctionExecutionPlanSeed(result.Plan, result.Failure);
     }
+
+    public static FunctionExecutionPlanSeed Reject(
+        ExecutionPlanFailureCode code,
+        string detail,
+        ExpressionProgramFailureCode? expressionFailureCode = null)
+    {
+        return new FunctionExecutionPlanSeed(
+            null,
+            new ExecutionPlanBuildFailure(code, detail, expressionFailureCode));
+    }
 }
 
 public readonly record struct ExecutionPlanDiagnosticCounters(int Attempts, int Succeeded, int Failed);

--- a/tests/Asynkron.JsEngine.Tests/AstFreeExecutionAssertionTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/AstFreeExecutionAssertionTests.cs
@@ -2625,6 +2625,41 @@ public sealed class AstFreeExecutionAssertionTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task AssertNoAstEvaluation_Enabled_ClassMethodWithCapturedDynamicScope_ThrowsPlanFailureInsteadOfAstFallback()
+    {
+        var originalValue = EvaluationContext.AssertNoAstEvaluation;
+
+        try
+        {
+            var program = _engine.ParseProgram("""
+                function makeBox(scopeObj) {
+                    with (scopeObj) {
+                        return class Box {
+                            read() {
+                                return answer;
+                            }
+                        };
+                    }
+                }
+
+                const Box = makeBox({ answer: 42 });
+                """);
+
+            await _engine.Evaluate(program);
+            EvaluationContext.AssertNoAstEvaluation = true;
+
+            var exception = await Assert.ThrowsAsync<NotSupportedException>(async () =>
+                await _engine.Evaluate("Box.prototype.read.call({});"));
+
+            Assert.Contains("with", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            EvaluationContext.AssertNoAstEvaluation = originalValue;
+        }
+    }
+
+    [Fact]
     public async Task AssertNoAstEvaluation_Enabled_AllowsFieldInitializerNewTargetUndefinedExecution()
     {
         var originalValue = EvaluationContext.AssertNoAstEvaluation;

--- a/tests/Asynkron.JsEngine.Tests/ClassStatementTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/ClassStatementTests.cs
@@ -175,6 +175,60 @@ public sealed class ClassStatementTests(ITestOutputHelper output) : InternalTest
     }
 
     [Fact(Timeout = 2000)]
+    public async Task ClassMethodCreatedInsideWithCapturedClosure_RejectsCachedIrSeed()
+    {
+        await using var engine = CreateEngine();
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(async () =>
+        {
+            await engine.Evaluate("""
+                function makeBox(scopeObj) {
+                    with (scopeObj) {
+                        return class Box {
+                            read() {
+                                return answer;
+                            }
+                        };
+                    }
+                }
+
+                const Box = makeBox({ answer: 42 });
+                Box.prototype.read.call({});
+                """);
+        });
+
+        Assert.Contains("with", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact(Timeout = 2000)]
+    public async Task ClassConstructorCreatedInsideWithCapturedClosure_RejectsCachedIrSeed()
+    {
+        await using var engine = CreateEngine();
+
+        var exception = await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await engine.Evaluate("""
+                function makeBox(scopeObj) {
+                    with (scopeObj) {
+                        return class Box {
+                            constructor() {
+                                this.answer = answer;
+                            }
+                        };
+                    }
+                }
+
+                const Box = makeBox({ answer: 42 });
+                new Box();
+                """);
+        });
+
+        var rootCause = exception.GetBaseException();
+        Assert.IsType<NotSupportedException>(rootCause);
+        Assert.Contains("with", rootCause.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact(Timeout = 2000)]
     public async Task ClassConstructorPropertyIsClass()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
Closes #723

## Summary
- add regression coverage for class-created sync callables closed over `with`
- reject cached class callable IR seeds at runtime when the closure chain contains `with`
- keep cached descriptor/build success separate from the explicit runtime rejection path

## Tests
- `dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ClassMethodCreatedInsideWithCapturedClosure_RejectsCachedIrSeed|FullyQualifiedName~ClassConstructorCreatedInsideWithCapturedClosure_RejectsCachedIrSeed|FullyQualifiedName~AssertNoAstEvaluation_Enabled_ClassMethodWithCapturedDynamicScope_ThrowsPlanFailureInsteadOfAstFallback"`
- `dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ExpressionProgramLoweringTests|FullyQualifiedName~AstFreeExecutionAssertionTests|FullyQualifiedName~ClassStatementTests"`
- `rg -n "EvaluateExpression\\(|ProfileEvaluateExpression\\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*`

## Blockers
- `dotnet test tests/Asynkron.JsEngine.Tests` currently fails in unrelated async/module tests already outside this issue's blast radius.
- `dotnet build` currently fails in `tests/Asynkron.JsEngine.Tests.Test262/Generated/Tests262Harness.Test262Test.generated.cs` with `CS1503`, also outside this issue's blast radius.
