### PR TITLE
fix: restore async await lowering on main

### DIFF
--- a/src/Asynkron.JsEngine/Execution/GeneratorYieldLowerer.cs
+++ b/src/Asynkron.JsEngine/Execution/GeneratorYieldLowerer.cs
@@ -236,10 +236,63 @@ internal static class GeneratorYieldLowerer
                     continue;
                 }
 
+                if (_rewriteAwaits && TryRewriteNestedAwaitLoopBody(statement, out var rewrittenLoopStatement))
+                {
+                    builder.Add(rewrittenLoopStatement);
+                    changed = true;
+                    continue;
+                }
+
                 builder.Add(statement);
             }
 
             return changed ? builder.ToImmutable() : statements;
+        }
+
+        private bool TryRewriteNestedAwaitLoopBody(
+            StatementNode statement,
+            out StatementNode rewrittenStatement)
+        {
+            rewrittenStatement = statement;
+
+            switch (statement)
+            {
+                case ForStatement { Body: BlockStatement forBody } forStatement:
+                {
+                    var rewrittenBody = RewriteBlock(forBody);
+                    if (ReferenceEquals(rewrittenBody, forBody))
+                    {
+                        return false;
+                    }
+
+                    rewrittenStatement = forStatement with { Body = rewrittenBody };
+                    return true;
+                }
+                case WhileStatement { Body: BlockStatement whileBody } whileStatement:
+                {
+                    var rewrittenBody = RewriteBlock(whileBody);
+                    if (ReferenceEquals(rewrittenBody, whileBody))
+                    {
+                        return false;
+                    }
+
+                    rewrittenStatement = whileStatement with { Body = rewrittenBody };
+                    return true;
+                }
+                case DoWhileStatement { Body: BlockStatement doWhileBody } doWhileStatement:
+                {
+                    var rewrittenBody = RewriteBlock(doWhileBody);
+                    if (ReferenceEquals(rewrittenBody, doWhileBody))
+                    {
+                        return false;
+                    }
+
+                    rewrittenStatement = doWhileStatement with { Body = rewrittenBody };
+                    return true;
+                }
+                default:
+                    return false;
+            }
         }
 
         private bool TryRewriteNestedAwaitStatement(
@@ -624,8 +677,25 @@ internal static class GeneratorYieldLowerer
                 return false;
             }
 
+            if (TryRewriteBinaryExpressionWithNestedAwait(
+                    expression,
+                    out prefixStatements,
+                    out rewrittenExpression))
+            {
+                return true;
+            }
+
             if (TryRewriteComputedMemberAwaitProperty(
                     expression,
+                    out prefixStatements,
+                    out rewrittenExpression))
+            {
+                return true;
+            }
+
+            if (expression is BinaryExpression binaryExpression &&
+                TryRewriteBinaryExpressionWithNestedAwait(
+                    binaryExpression,
                     out prefixStatements,
                     out rewrittenExpression))
             {
@@ -646,6 +716,145 @@ internal static class GeneratorYieldLowerer
                     VariableKind.Let,
                     [new VariableDeclarator(awaitedExpression.Source, tempBinding, awaitedExpression)])
             ];
+            return true;
+        }
+
+        private bool TryRewriteBinaryExpressionWithNestedAwait(
+            BinaryExpression binaryExpression,
+            out ImmutableArray<StatementNode> prefixStatements,
+            out ExpressionNode rewrittenExpression)
+        {
+            prefixStatements = default;
+            rewrittenExpression = binaryExpression;
+
+            var leftHasAwait = AstShapeAnalyzer.ContainsAwait(binaryExpression.Left);
+            var rightHasAwait = AstShapeAnalyzer.ContainsAwait(binaryExpression.Right);
+            if (!leftHasAwait && !rightHasAwait)
+            {
+                return false;
+            }
+
+            var builder = ImmutableArray.CreateBuilder<StatementNode>();
+            var rewrittenLeft = binaryExpression.Left;
+            var rewrittenRight = binaryExpression.Right;
+            var changed = false;
+
+            if (leftHasAwait)
+            {
+                if (binaryExpression.Left is AwaitExpression leftAwait)
+                {
+                    var leftBinding = CreateResumeIdentifier();
+                    builder.Add(CreateTempDeclaration(leftAwait.Source, leftBinding, leftAwait));
+                    rewrittenLeft = new IdentifierExpression(leftAwait.Source, leftBinding.Name);
+                    changed = true;
+                }
+                else if (TryRewriteExpressionWithNestedAwait(
+                             binaryExpression.Left,
+                             out var leftPrefixStatements,
+                             out var rewrittenLeftExpression))
+                {
+                    builder.AddRange(leftPrefixStatements);
+                    rewrittenLeft = rewrittenLeftExpression;
+                    changed = true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            if (rightHasAwait)
+            {
+                if (!leftHasAwait)
+                {
+                    var leftBinding = CreateResumeIdentifier();
+                    builder.Add(CreateTempDeclaration(binaryExpression.Left.Source, leftBinding, rewrittenLeft));
+                    rewrittenLeft = new IdentifierExpression(binaryExpression.Left.Source, leftBinding.Name);
+                    changed = true;
+                }
+
+                if (binaryExpression.Right is AwaitExpression rightAwait)
+                {
+                    var rightBinding = CreateResumeIdentifier();
+                    builder.Add(CreateTempDeclaration(rightAwait.Source, rightBinding, rightAwait));
+                    rewrittenRight = new IdentifierExpression(rightAwait.Source, rightBinding.Name);
+                    changed = true;
+                }
+                else if (TryRewriteExpressionWithNestedAwait(
+                             binaryExpression.Right,
+                             out var rightPrefixStatements,
+                             out var rewrittenRightExpression))
+                {
+                    builder.AddRange(rightPrefixStatements);
+                    rewrittenRight = rewrittenRightExpression;
+                    changed = true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            if (!changed)
+            {
+                return false;
+            }
+
+            prefixStatements = builder.ToImmutable();
+            rewrittenExpression = binaryExpression with
+            {
+                Left = rewrittenLeft,
+                Right = rewrittenRight
+            };
+            return true;
+        }
+
+        private bool TryRewriteBinaryExpressionWithNestedAwait(
+            ExpressionNode expression,
+            out ImmutableArray<StatementNode> prefixStatements,
+            out ExpressionNode rewrittenExpression)
+        {
+            prefixStatements = default;
+            rewrittenExpression = expression;
+
+            if (expression is not BinaryExpression binaryExpression ||
+                binaryExpression.Operator is BinaryOperator.LogicalAnd or BinaryOperator.LogicalOr or
+                    BinaryOperator.NullishCoalescing)
+            {
+                return false;
+            }
+
+            var builder = ImmutableArray.CreateBuilder<StatementNode>();
+            var changed = false;
+            var rewrittenLeft = binaryExpression.Left;
+            var rewrittenRight = binaryExpression.Right;
+
+            if (AstShapeAnalyzer.ContainsAwait(rewrittenLeft))
+            {
+                rewrittenLeft = RewriteAwaitExpressionToSyntheticIdentifier(rewrittenLeft, builder);
+                changed = true;
+            }
+
+            if (AstShapeAnalyzer.ContainsAwait(rewrittenRight))
+            {
+                var capturedLeft = CreateResumeIdentifier();
+                builder.Add(CreateTempDeclaration(binaryExpression.Left.Source, capturedLeft, rewrittenLeft));
+                rewrittenLeft = new IdentifierExpression(binaryExpression.Left.Source, capturedLeft.Name);
+                rewrittenRight = RewriteAwaitExpressionToSyntheticIdentifier(rewrittenRight, builder);
+                changed = true;
+            }
+
+            if (!changed)
+            {
+                return false;
+            }
+
+            prefixStatements = builder.ToImmutable();
+            rewrittenExpression = binaryExpression with
+            {
+                Left = rewrittenLeft,
+                Right = rewrittenRight
+            };
             return true;
         }
 

--- a/src/Asynkron.JsEngine/JsEngine.cs
+++ b/src/Asynkron.JsEngine/JsEngine.cs
@@ -4636,6 +4636,16 @@ public sealed class JsEngine : IAsyncDisposable, IDisposable
                             _statementIndex++;
                             continue;
                         case VariableDeclaration variableDeclaration
+                            when variableDeclaration.Declarators.All(d => d.Target is IdentifierBinding) &&
+                                 ContainsNestedAwaitInitializer(variableDeclaration):
+                            if (!TryEvaluateDeclarationWithAwait(variableDeclaration, env, isStrict))
+                            {
+                                return;
+                            }
+
+                            _statementIndex++;
+                            continue;
+                        case VariableDeclaration variableDeclaration
                             when DeclarationNeedsAwaitTemps(variableDeclaration):
                             if (!TryEvaluateDeclarationWithAwait(variableDeclaration, env, isStrict))
                             {
@@ -4837,6 +4847,30 @@ public sealed class JsEngine : IAsyncDisposable, IDisposable
             return false;
         }
 
+        private static bool ContainsNestedAwaitInitializer(VariableDeclaration declaration)
+        {
+            foreach (var declarator in declaration.Declarators)
+            {
+                if (declarator.Initializer is null or AwaitExpression)
+                {
+                    continue;
+                }
+
+                if (AstShapeAnalyzer.ContainsAwait(declarator.Initializer))
+                {
+                    return true;
+                }
+
+                if (declarator.Initializer is ClassExpression classExpression &&
+                    TryRewriteClassExpressionAwaitTemps(classExpression, out _, out _))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private bool TryEvaluateDeclarationWithAwait(VariableDeclaration declaration, JsEnvironment env, bool isStrict)
         {
             return TryEvaluateDeclarationWithAwait(declaration, env, isStrict, advanceTopLevelStatement: true,
@@ -4888,7 +4922,11 @@ public sealed class JsEngine : IAsyncDisposable, IDisposable
                     return EvaluateDeclarator(index + 1);
                 }
 
-                if (!AstShapeAnalyzer.ContainsAwait(declarator.Initializer))
+                var initializerNeedsAsyncHandling = AstShapeAnalyzer.ContainsAwait(declarator.Initializer) ||
+                    declarator.Initializer is ClassExpression classExpression &&
+                    TryRewriteClassExpressionAwaitTemps(classExpression, out _, out _);
+
+                if (!initializerNeedsAsyncHandling)
                 {
                     try
                     {
@@ -5456,7 +5494,9 @@ public sealed class JsEngine : IAsyncDisposable, IDisposable
                     return TryEvaluateNewExpressionWithAwait(newExpression, env, isStrict, continuation,
                         advanceTopLevelStatement);
 
-                case ClassExpression classExpression when AstShapeAnalyzer.ContainsAwait(classExpression):
+                case ClassExpression classExpression
+                    when AstShapeAnalyzer.ContainsAwait(classExpression) ||
+                         TryRewriteClassExpressionAwaitTemps(classExpression, out _, out _):
                     return TryEvaluateClassExpressionWithAwait(classExpression, env, isStrict, continuation,
                         advanceTopLevelStatement);
 
@@ -5952,15 +5992,28 @@ public sealed class JsEngine : IAsyncDisposable, IDisposable
         {
             var definition = classExpression.Definition;
             var tempBuilder = ImmutableArray.CreateBuilder<AwaitTempBinding>();
+            var rewrittenDefinition = RewriteAwaitExpressionsInClassDefinition(definition, tempBuilder);
+            var changed = tempBuilder.Count > 0;
+
+            rewrittenClass = classExpression with
+            {
+                Definition = rewrittenDefinition
+            };
+            tempBindings = tempBuilder.ToImmutable();
+            return changed;
+        }
+
+        private static ClassDefinition RewriteAwaitExpressionsInClassDefinition(
+            ClassDefinition definition,
+            ImmutableArray<AwaitTempBinding>.Builder tempBindings)
+        {
             var members = definition.Members.ToBuilder();
             var fields = definition.Fields.ToBuilder();
             var rewrittenExtends = definition.Extends;
-            var changed = false;
 
             if (definition.Extends is not null && AstShapeAnalyzer.ContainsAwait(definition.Extends))
             {
-                rewrittenExtends = RewriteAwaitExpressionToSyntheticIdentifier(definition.Extends, tempBuilder);
-                changed = true;
+                rewrittenExtends = RewriteAwaitExpressionToSyntheticIdentifier(definition.Extends, tempBindings);
             }
 
             for (var i = 0; i < members.Count; i++)
@@ -5971,9 +6024,8 @@ public sealed class JsEngine : IAsyncDisposable, IDisposable
                 {
                     members[i] = member with
                     {
-                        ComputedName = RewriteAwaitExpressionToSyntheticIdentifier(member.ComputedName, tempBuilder)
+                        ComputedName = RewriteAwaitExpressionToSyntheticIdentifier(member.ComputedName, tempBindings)
                     };
-                    changed = true;
                 }
             }
 
@@ -5985,23 +6037,17 @@ public sealed class JsEngine : IAsyncDisposable, IDisposable
                 {
                     fields[i] = field with
                     {
-                        ComputedName = RewriteAwaitExpressionToSyntheticIdentifier(field.ComputedName, tempBuilder)
+                        ComputedName = RewriteAwaitExpressionToSyntheticIdentifier(field.ComputedName, tempBindings)
                     };
-                    changed = true;
                 }
             }
 
-            rewrittenClass = classExpression with
+            return definition with
             {
-                Definition = definition with
-                {
-                    Extends = rewrittenExtends,
-                    Members = members.ToImmutable(),
-                    Fields = fields.ToImmutable()
-                }
+                Extends = rewrittenExtends,
+                Members = members.ToImmutable(),
+                Fields = fields.ToImmutable()
             };
-            tempBindings = tempBuilder.ToImmutable();
-            return changed;
         }
 
         private static ExpressionNode RewriteAwaitExpressionToSyntheticIdentifier(
@@ -6145,6 +6191,11 @@ public sealed class JsEngine : IAsyncDisposable, IDisposable
                             .Select(expressionNode =>
                                 RewriteAwaitExpressionToSyntheticIdentifier(expressionNode, tempBindings))
                             .ToImmutableArray()
+                    };
+                case ClassExpression classExpression:
+                    return classExpression with
+                    {
+                        Definition = RewriteAwaitExpressionsInClassDefinition(classExpression.Definition, tempBindings)
                     };
                 default:
                     return expression;
@@ -6416,6 +6467,13 @@ public sealed class JsEngine : IAsyncDisposable, IDisposable
                 case VariableDeclaration variableDeclaration
                     when variableDeclaration.Declarators.All(d => d.Target is IdentifierBinding) &&
                          ContainsDirectAwaitInitializer(variableDeclaration):
+                    return TryEvaluateDeclarationWithAwait(variableDeclaration, env, isStrict,
+                        advanceTopLevelStatement: false,
+                        onCompleted);
+
+                case VariableDeclaration variableDeclaration
+                    when variableDeclaration.Declarators.All(d => d.Target is IdentifierBinding) &&
+                         ContainsNestedAwaitInitializer(variableDeclaration):
                     return TryEvaluateDeclarationWithAwait(variableDeclaration, env, isStrict,
                         advanceTopLevelStatement: false,
                         onCompleted);

--- a/tests/Asynkron.JsEngine.Tests.Test262/Test262Test.cs
+++ b/tests/Asynkron.JsEngine.Tests.Test262/Test262Test.cs
@@ -715,6 +715,19 @@ try {
         ExecuteTestAsync(engine, file).GetAwaiter().GetResult();
     }
 
+    private static void ExecuteTest((JsEngine Engine, Test262AgentRuntime AgentRuntime) executor, Test262File file)
+    {
+        try
+        {
+            ExecuteTest(executor.Engine, file);
+        }
+        finally
+        {
+            executor.AgentRuntime?.Dispose();
+            executor.Engine.Dispose();
+        }
+    }
+
     private static async Task ExecuteTestAsync(JsEngine engine, Test262File file)
     {
         if (file.Type == ProgramType.Module)


### PR DESCRIPTION
Closes #721

## Summary
- restore nested-await lowering for async loop bodies and binary expressions without regressing generator loop lowering
- route async-module variable declarations with awaited class computed names through the async declaration/class rewrite path
- add the missing Test262 executor overload so `dotnet build` succeeds again on the branch

## Tests
- dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~AsyncLoopTests.ForLoop_WithAwaitAndContinue_Works|FullyQualifiedName~AsyncLoopTests.DoWhileLoop_WithAwaitAndBreak_Works|FullyQualifiedName~AsyncAwaitTests.AsyncFunction_WithAwaitInExpression|FullyQualifiedName~AsyncModuleTryAwaitTests.TryCatch_CanEvaluateClassComputedNamesFromAwait"
- dotnet test tests/Asynkron.JsEngine.Tests
- dotnet build