### PR TITLE
fix: update traceability test for FunctionLiteralDescriptor wrapping

### DIFF
--- a/tests/Asynkron.JsEngine.Tests/Issue400And722ExpressionBytecodeTraceabilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/Issue400And722ExpressionBytecodeTraceabilityTests.cs
@@ -92,7 +92,7 @@ public sealed class Issue400And722ExpressionBytecodeTraceabilityTests : IAsyncLi
         Assert.True(program.ContainsStringConstant("helper"));
         Assert.True(program.ContainsStringConstant("Box"));
         Assert.True(program.ContainsIdentifierConstant(identifier => identifier.Name.Name == "alpha"));
-        Assert.True(program.ContainsObjectConstant<FunctionExpression>(function => function.Name!.Name == "helperImpl"));
+        Assert.True(program.ContainsObjectConstant<FunctionLiteralDescriptor>(d => d.Function.Name!.Name == "helperImpl"));
         Assert.True(program.ContainsObjectConstant<ClassExpression>(classExpression => classExpression.Name!.Name == "Box"));
     }
 


### PR DESCRIPTION
## Summary
Closes #733

- Update `ConstantPools_RecordLiteralStringObjectAndIdentifierEntries` to assert on `FunctionLiteralDescriptor` instead of `FunctionExpression`, matching the wrapping introduced in PR #731.

## Changes
- `ContainsObjectConstant<FunctionExpression>(f => f.Name!.Name == "helperImpl")` → `ContainsObjectConstant<FunctionLiteralDescriptor>(d => d.Function.Name!.Name == "helperImpl")`

## Tests
- [x] `ConstantPools_RecordLiteralStringObjectAndIdentifierEntries` passes
- [x] All 3 traceability tests pass
- [x] Full internal test suite: 3555 passed, 3 pre-existing failures (unrelated to this change)

## Traceability
- **Issue:** #733
- **Root cause:** PR #731 wrapped `FunctionExpression` in `FunctionLiteralDescriptor` before interning into object constants
- **Blast radius:** 1 assertion in 1 test file, no production code changes