### PR TITLE
fix: quarantine with-statement scripts from IR path

### DIFF
--- a/src/Asynkron.JsEngine/Ast/Legacy/StatementNodeExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/Legacy/StatementNodeExtensions.cs
@@ -2348,7 +2348,8 @@ public static partial class TypedAstEvaluator
         // If we plan to execute this program via the IR path, we must initialize the slot layout
         // BEFORE hoisting so that user bindings get created after internal IR slots. Otherwise,
         // internal 0-based IR slot writes can overwrite hoisted user bindings.
-        var requiresDynamicScopeExecutor = executionEnvironment.HasWithObjectInChain();
+        var requiresDynamicScopeExecutor = executionEnvironment.HasWithObjectInChain() ||
+                                            DynamicScopeDetector.ContainsWithStatement(programBlock);
         var canUseNoSlotIr = executionKind == ExecutionKind.Eval || !allowsIdentifierCaching;
         var canUseIrPlan = !requiresDynamicScopeExecutor &&
                            (context.AllowIdentifierCache || canUseNoSlotIr);

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -758,7 +758,11 @@ public static partial class TypedAstEvaluator
             // Direct-eval callables can still execute via IR as long as the closure chain has no
             // active with-object environments. In that mode the runner keeps identifier caching off
             // and relies on dictionary resolution instead of slot/flat-slot fast paths.
-            var canUseIrPlan = _allowIdentifierCache || !_closure.HasWithObjectInChain();
+            // Functions whose body contains 'with' statements must always skip the IR path because
+            // AssignmentSlotInstruction uses slot-based/name-based direct writes that bypass the
+            // with-scope object environment (the IR cannot resolve references through with-scope).
+            var canUseIrPlan = !DynamicScopeDetector.ContainsWithStatement(_function.Body) &&
+                               (_allowIdentifierCache || !_closure.HasWithObjectInChain());
             if (!_function.IsGenerator && !IsAsyncFunction && canUseIrPlan)
             {
                 var plan = _planSeed.Plan;

--- a/tests/Asynkron.JsEngine.Tests/AstFreeExecutionAssertionTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/AstFreeExecutionAssertionTests.cs
@@ -3032,7 +3032,7 @@ public sealed class AstFreeExecutionAssertionTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task AssertNoAstEvaluation_Enabled_AllowsTopLevelWithScriptExecution()
+    public async Task AssertNoAstEvaluation_Enabled_ThrowsOnTopLevelWithScriptExecution()
     {
         var originalValue = EvaluationContext.AssertNoAstEvaluation;
 
@@ -3048,9 +3048,10 @@ public sealed class AstFreeExecutionAssertionTests : IAsyncLifetime
                 result;
                 """);
 
-            var result = await _engine.Evaluate(program);
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _engine.Evaluate(program));
 
-            Assert.Equal(42d, result);
+            Assert.Contains("AST evaluation invoked", exception.Message, StringComparison.Ordinal);
         }
         finally
         {
@@ -3059,7 +3060,7 @@ public sealed class AstFreeExecutionAssertionTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task AssertNoAstEvaluation_Enabled_AllowsTopLevelWithEvalExecution()
+    public async Task AssertNoAstEvaluation_Enabled_ThrowsOnTopLevelWithEvalExecution()
     {
         var originalValue = EvaluationContext.AssertNoAstEvaluation;
 
@@ -3073,9 +3074,10 @@ public sealed class AstFreeExecutionAssertionTests : IAsyncLifetime
                 result;
                 """);
 
-            var result = await _engine.Evaluate(program);
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _engine.Evaluate(program));
 
-            Assert.Equal(42d, result);
+            Assert.Contains("AST evaluation invoked", exception.Message, StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/Asynkron.JsEngine.Tests/Issue400And722ExpressionBytecodeTraceabilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/Issue400And722ExpressionBytecodeTraceabilityTests.cs
@@ -92,7 +92,7 @@ public sealed class Issue400And722ExpressionBytecodeTraceabilityTests : IAsyncLi
         Assert.True(program.ContainsStringConstant("helper"));
         Assert.True(program.ContainsStringConstant("Box"));
         Assert.True(program.ContainsIdentifierConstant(identifier => identifier.Name.Name == "alpha"));
-        Assert.True(program.ContainsObjectConstant<FunctionExpression>(function => function.Name!.Name == "helperImpl"));
+        Assert.True(program.ContainsObjectConstant<FunctionLiteralDescriptor>(descriptor => descriptor.Function.Name!.Name == "helperImpl"));
         Assert.True(program.ContainsObjectConstant<ClassExpression>(classExpression => classExpression.Name!.Name == "Box"));
     }
 

--- a/tests/Asynkron.JsEngine.Tests/ScriptSlotAnalysisTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/ScriptSlotAnalysisTests.cs
@@ -82,7 +82,7 @@ public sealed class ScriptSlotAnalysisTests : InternalTestBase
     }
 
     [Fact]
-    public async Task ScriptSlotAnalysis_TopLevelWithWithoutCapturedWith_UsesIrPath()
+    public async Task ScriptSlotAnalysis_TopLevelWithWithoutCapturedWith_UsesDynamicScopeExecutor()
     {
         var logger = new TestLogger(Output, "ScriptTopLevelWith", minLogLevel: LogLevel.Debug);
         const string script = """
@@ -103,7 +103,7 @@ public sealed class ScriptSlotAnalysisTests : InternalTestBase
 
         var result = await engine.Evaluate(script);
         Assert.Equal(7d, result);
-        Assert.DoesNotContain(
+        Assert.Contains(
             logger.Collector.Snapshot(),
             static record => record.Message.Contains(
                 "Executing script via dynamic-scope executor",
@@ -111,7 +111,7 @@ public sealed class ScriptSlotAnalysisTests : InternalTestBase
     }
 
     [Fact]
-    public async Task ScriptSlotAnalysis_EvalWithWithoutCapturedWith_UsesIrPath()
+    public async Task ScriptSlotAnalysis_EvalWithWithoutCapturedWith_UsesDynamicScopeExecutor()
     {
         var logger = new TestLogger(Output, "EvalTopLevelWith", minLogLevel: LogLevel.Debug);
         const string script = """
@@ -129,7 +129,7 @@ public sealed class ScriptSlotAnalysisTests : InternalTestBase
 
         var result = await engine.Evaluate(script);
         Assert.Equal(11d, result);
-        Assert.DoesNotContain(
+        Assert.Contains(
             logger.Collector.Snapshot(),
             static record => record.Message.Contains(
                 "Executing script via dynamic-scope executor",


### PR DESCRIPTION
## Summary
Part of #732

Fixes two regressions introduced by `a5988bf` (Seed function literal IR plans, PR #731):

## Changes
- **With-statement IR quarantine** — Wire `DynamicScopeDetector.ContainsWithStatement` into both the script-level (`StatementNodeExtensions.cs`) and function-level (`SyncFunctionInvoker.cs`) IR eligibility checks. Scripts/functions whose body contains `with` statements now correctly fall back to the dynamic-scope executor, preventing `AssignmentSlotInstruction` from bypassing with-scope reference resolution.
- **FunctionLiteralDescriptor test fix** — Update `ConstantPools_RecordLiteralStringObjectAndIdentifierEntries` to expect `FunctionLiteralDescriptor` wrappers instead of raw `FunctionExpression` in the constant pool, matching the new interning behavior.
- **Test expectation updates** — `AstFreeExecutionAssertionTests` and `ScriptSlotAnalysisTests` updated to reflect that with-containing scripts now use the dynamic-scope executor.

## Tests
- `ConstantPools_RecordLiteralStringObjectAndIdentifierEntries` — passes (was failing)
- `WithDeleteAssignment_ShouldPreserveReference` — passes (was failing)
- Full internal test suite: 3558 passed, 0 failed, 3 skipped