### PR TITLE
fix: resolve LHS reference before RHS in with-scope assignments

### DIFF
--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Statements.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner.Handlers.Statements.cs
@@ -87,6 +87,17 @@ public static partial class TypedAstEvaluator
             var instruction = Unsafe.As<AssignmentSlotInstruction>(instr);
             var isAnonymousFunctionDefinition = instruction.AllowNameInference;
 
+            // §13.15.2: When with/eval scope is active and no static slot resolution,
+            // resolve the LHS assignment reference BEFORE evaluating the RHS.
+            // This ensures delete operations in the RHS don't affect LHS resolution.
+            var usePreResolvedRef = !context.AllowIdentifierCache
+                && instruction.FlatSlotId < 0
+                && instruction.ScopeId < 0;
+
+            var lhsRef = usePreResolvedRef
+                ? environment.ResolveIdentifierAssignmentReference(instruction.TargetSymbol, context)
+                : default;
+
             using var functionNameHint = isAnonymousFunctionDefinition
                 ? context.EnterFunctionNameHint(instruction.TargetSymbol)
                 : null;
@@ -117,24 +128,31 @@ public static partial class TypedAstEvaluator
                     return InstructionResult.Continue;
             }
 
-            var variable = FlatSlotAccessor.Create(runner, instruction.FlatSlotId);
-            if (variable.UseFlatSlot)
+            if (usePreResolvedRef)
             {
-                variable.EnsureAssignable(instruction.TargetSymbol, runner._realmState);
-                variable.Variable.Write(assignedValue);
-            }
-            else if (instruction.ScopeId >= 0 && instruction.SlotIndex >= 0)
-            {
-                environment.TryWriteIdentifierWithSlot(
-                    instruction.TargetSymbol,
-                    instruction.ScopeId,
-                    instruction.SlotIndex,
-                    assignedValue,
-                    context);
+                lhsRef.SetValue(assignedValue);
             }
             else
             {
-                environment.SetIdentifierJsValue(instruction.TargetSymbol, assignedValue, context);
+                var variable = FlatSlotAccessor.Create(runner, instruction.FlatSlotId);
+                if (variable.UseFlatSlot)
+                {
+                    variable.EnsureAssignable(instruction.TargetSymbol, runner._realmState);
+                    variable.Variable.Write(assignedValue);
+                }
+                else if (instruction.ScopeId >= 0 && instruction.SlotIndex >= 0)
+                {
+                    environment.TryWriteIdentifierWithSlot(
+                        instruction.TargetSymbol,
+                        instruction.ScopeId,
+                        instruction.SlotIndex,
+                        assignedValue,
+                        context);
+                }
+                else
+                {
+                    environment.SetIdentifierJsValue(instruction.TargetSymbol, assignedValue, context);
+                }
             }
 
             if (runner._isScriptMode && !instruction.SuppressCompletionValue)


### PR DESCRIPTION
## Summary
Part of #734

Fixes `WithDeleteAssignment_ShouldPreserveReference` test failure. The `HandleAssignmentSlot` handler was evaluating the RHS expression before resolving where to write the LHS, violating ECMAScript §13.15.2. When `delete scope.x` ran in the RHS, the subsequent LHS resolution could no longer find `scope.x` in the with-binding.

## Changes
- In `HandleAssignmentSlot`, when with/eval scope is active (`!AllowIdentifierCache`) and no static slot resolution exists, pre-resolve the LHS `AssignmentReference` before evaluating the RHS
- Use the pre-resolved reference for the write, bypassing the now-stale scope lookup
- Common (fast) path with static slot resolution is unchanged

## Tests
- `WithDeleteAssignment_ShouldPreserveReference` — was RED, now GREEN
- Full test suite: 3555 passed, 3 pre-existing failures unrelated to this change