### PR TITLE
feat: route simple optional computed delete

### DIFF
--- a/docs/rules/unified-bytecode-prototypes.md
+++ b/docs/rules/unified-bytecode-prototypes.md
@@ -1847,19 +1847,18 @@ avoids the build-back repair cycle that the sibling task (PR #2748) required.
     expression-stack fallback for the receiver chain.
 
     Optional computed delete routing is narrower than optional-chain delete as
-    a family. The admitted shapes are exactly `delete box?.child[key]` and
-    `delete box.child?.[key]`, with activation-resolved receivers,
+    a family. The admitted shapes are exactly `delete box?.[key]`,
+    `delete box?.child[key]`, and `delete box.child?.[key]`, with activation-resolved receivers,
     non-private named receiver hops, supported computed-key spans, and
     compiler-owned nullish short-circuit-to-true lowering. For
     `delete box?.child[key]`, emit the nullish guard before the named hop so
     the computed key is skipped on the short-circuit path. For
-    `delete box.child?.[key]`, recognize the existing
+    `delete box?.[key]` and `delete box.child?.[key]`, recognize the existing
     `JumpIfNullish, key span, DeleteComputedProperty, Jump, Pop, true` tail and
-    re-lower it to the same VM-owned short-circuit block. Keep simple optional
-    computed delete without a named receiver hop (`delete box?.[key]`), chained
-    optional delete neighbors, richer computed-key payloads, dynamic lookup,
-    private names, and `super` as pre-VM declines until a later slice proves
-    those exact semantics.
+    re-lower it to the same VM-owned short-circuit block. Keep chained optional
+    delete neighbors, richer computed-key payloads, dynamic lookup, private
+    names, and `super` as pre-VM declines until a later slice proves those exact
+    semantics.
 
     Pair each positive widening with opcode proof, public fast-path route logs,
     computed-key coercion/order proof for computed deletes, strict/sloppy

--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -365,16 +365,15 @@ the final post-compile production subset check before VM entry.
   `SetNamedProperty` / `UpdateNamedProperty`. Nested named receiver chains
   ending in a simple computed delete (`delete box.child[key]`) are admitted by
   `TryIsFirstBoundaryComputedPropertyDeleteCandidate`; optional computed delete
-  chains are admitted only for `delete box?.child[key]` and
+  chains are admitted for `delete box?.[key]`, `delete box?.child[key]`, and
   `delete box.child?.[key]` shapes with activation-resolved receivers, supported
   computed-key spans, and compiler-owned nullish short-circuit-to-true lowering
-  (ADR 0317).
+  (ADR 0317 plus the simple optional-computed follow-up).
   The compiler emits the named receiver reads and final `DeleteComputedProperty`,
   while the VM's descriptor-aware delete helper owns strict/sloppy results.
-  Retained declines include simple optional computed deletes without a named
-  receiver hop (`delete box?.[key]`), chained optional delete neighbors,
-  private property access, dynamic lookup, richer unowned computed keys,
-  deeper compound/logical property chains
+  Retained declines include chained optional delete neighbors, private property
+  access, dynamic lookup, richer unowned computed keys, deeper compound/logical
+  property chains
   (`box.child.value += …`, `box.child.value &&= …`), and computed-expression
   keys (`box[key+suffix] += …`).
   Note: slot-identifier logical assignment (`x &&= y`) remains admitted.

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -6924,7 +6924,7 @@ internal static class UnifiedBytecodeCompiler
         return true;
     }
 
-    // Handles delete a.b?.[k], preserving the source program's nullish branch shape.
+    // Handles delete a?.[k] and delete a.b?.[k], preserving the source program's nullish branch shape.
     private static bool TryAppendFirstBoundaryOptionalComputedPropertyDeleteWithJump(
         ExpressionProgram expressionProgram,
         ActivationSlotShape activationSlots,
@@ -6933,7 +6933,7 @@ internal static class UnifiedBytecodeCompiler
         ImmutableArray<string>.Builder stringConstants,
         out string reason)
     {
-        if (expressionProgram.OperationCount < 8)
+        if (expressionProgram.OperationCount < 7)
         {
             reason = string.Empty;
             return false;
@@ -6959,8 +6959,7 @@ internal static class UnifiedBytecodeCompiler
         var endJumpIndexInProgram = expressionProgram.OperationCount - 3;
         var popIndex = expressionProgram.OperationCount - 2;
         var trueIndex = expressionProgram.OperationCount - 1;
-        if (jumpIndex < 2 ||
-            deleteIndex <= jumpIndex + 1 ||
+        if (deleteIndex <= jumpIndex + 1 ||
             expressionProgram.GetOperation(jumpIndex) is not { Kind: ExpressionOpKind.JumpIfNullish, ReplaceWithUndefined: false } jumpIfNullish ||
             jumpIfNullish.Target != popIndex ||
             expressionProgram.GetOperation(deleteIndex).Kind != ExpressionOpKind.DeleteComputedProperty ||

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -2018,15 +2018,15 @@ internal static class UnifiedBytecodeProductionEligibility
                    activationSlots);
     }
 
-    // Admits delete a.b?.[k]:
-    // [activation-resolved base, GetNamedProperty(non-optional, non-private)+,
+    // Admits delete a?.[k] and delete a.b?.[k]:
+    // [activation-resolved base, GetNamedProperty(non-optional, non-private)*,
     //  JumpIfNullish, simple key, DeleteComputedProperty, Jump, Pop, true].
     private static bool TryIsFirstBoundaryOptionalComputedPropertyDeleteCandidate(
         ExpressionProgram program,
         ReadOnlySpan<IdentifierOperand> identifierConstants,
         ActivationSlotShape activationSlots)
     {
-        if (program.OperationCount < 8 ||
+        if (program.OperationCount < 7 ||
             !TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
         {
             return false;
@@ -2046,11 +2046,6 @@ internal static class UnifiedBytecodeProductionEligibility
             }
 
             jumpIndex++;
-        }
-
-        if (jumpIndex < 2)
-        {
-            return false;
         }
 
         var jumpIfNullish = program.GetOperation(jumpIndex);

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -1320,6 +1320,13 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     [InlineData(
         """
         function remove(box, key) {
+            return delete box?.[key];
+        }
+        """,
+        "remove")]
+    [InlineData(
+        """
+        function remove(box, key) {
             return delete box?.child[key];
         }
         """,
@@ -2525,13 +2532,6 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         """
         function remove(box) {
             return delete box?.value;
-        }
-        """,
-        "remove")]
-    [InlineData(
-        """
-        function remove(box, key) {
-            return delete box?.[key];
         }
         """,
         "remove")]

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -4400,6 +4400,39 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task SimpleOptionalComputedPropertyDelete_UsesUnifiedBytecodeProductionFastPathAndSkipsNullishKey()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var hits = 0;
+            var key = {
+                toString() {
+                    hits = hits + 1;
+                    return "value";
+                }
+            };
+
+            function remove(box, key) {
+                return delete box?.[key];
+            }
+
+            var box = { value: 42 };
+            var removed = remove(box, key);
+            var skipped = remove(null, key);
+            removed + "|" +
+                skipped + "|" +
+                hits + "|" +
+                Object.prototype.hasOwnProperty.call(box, "value");
+            """);
+
+        Assert.Equal("true|true|1|false", result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=remove argc=2",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task NamedPropertyDelete_UsesUnifiedBytecodeProductionFastPathAndStrictSloppyFailureSemantics()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit `delete box?.[key]` into production unified bytecode via the existing optional computed delete short-circuit lowering
- keep optional named delete and chained optional delete neighbors as explicit declines
- add public route proof and update the unified-bytecode contract/rule docs

## Verification
- `rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_OptionalComputedPropertyDeleteCandidate_AcceptsOwnedPropertyOpcodes|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_OptionalPropertyDelete_DeclinesWithExplicitCode|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_UnsupportedOptionalComputedPropertyDeleteNeighbor_DeclinesWithExplicitCode|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.SimpleOptionalComputedPropertyDelete_UsesUnifiedBytecodeProductionFastPathAndSkipsNullishKey|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalComputedPropertyDelete_UsesUnifiedBytecodeProductionFastPathAndSkipsNullishKey"`
- `rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"`
- `rtk rg "EvaluateExpression\\(|ProfileEvaluateExpression\\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*` (no matches)
- `rtk ./tools/profile forloop --memory` (Total allocated 6.85 MB)
- `rtk git diff --check`