### PR TITLE
Admit prefixed optional named read chains

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -362,8 +362,11 @@ the final post-compile production subset check before VM entry.
   `TryIsFirstBoundaryNestedNamedPropertyWriteCandidate` and
   `TryIsFirstBoundaryNestedNamedPropertyUpdateCandidate`, which compile the
   receiver chain as owned `GetNamedProperty` opcodes before the final
-  `SetNamedProperty` / `UpdateNamedProperty`. Nested named receiver chains
-  ending in a simple computed delete (`delete box.child[key]`) are admitted by
+  `SetNamedProperty` / `UpdateNamedProperty`. Optional named read chains may
+  also start after a plain named receiver prefix (`box.child?.value`), with the
+  prefix emitted as owned `GetNamedProperty` reads before the optional
+  jump-to-chain-end boundary. Nested named receiver chains ending in a simple
+  computed delete (`delete box.child[key]`) are admitted by
   `TryIsFirstBoundaryComputedPropertyDeleteCandidate`; optional computed delete
   chains are admitted for `delete box?.[key]`, `delete box?.child[key]`, and
   `delete box.child?.[key]` shapes with activation-resolved receivers, supported

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -7131,10 +7131,12 @@ internal static class UnifiedBytecodeCompiler
 
     // Handles multi-hop optional named chains a?.b.c and a?.b?.c:
     //   [activation-resolved base,
+    //    GetNamedProperty(non-optional, non-private)*,
     //    GetNamedProperty(IsOptional:true, !ShortCircuitOnNullishTarget, non-private),
     //    GetNamedProperty(ShortCircuitOnNullishTarget:true, non-private)+]
     // Emits a jump-based lowering that keeps the operand stack a plain JsValue[]:
     //   LoadSlot,
+    //   [GetNamedProperty,]                               // non-optional receiver prefix
     //   JumpIfNullishReplaceUndefined(END), GetNamedProperty,   // first optional hop
     //   [JumpIfNullishReplaceUndefined(END),] GetNamedProperty, // each subsequent hop (jump only when ?. optional)
     //   END:
@@ -7155,8 +7157,33 @@ internal static class UnifiedBytecodeCompiler
         }
 
         var expressionStringConstants = expressionProgram.StringConstants.AsSpan();
+        var optionalStartIndex = 1;
+        while (optionalStartIndex < expressionProgram.OperationCount)
+        {
+            var prefixOp = expressionProgram.GetOperation(optionalStartIndex);
+            if (prefixOp.Kind != ExpressionOpKind.GetNamedProperty ||
+                prefixOp.IsOptional ||
+                prefixOp.ShortCircuitOnNullishTarget)
+            {
+                break;
+            }
 
-        var firstHop = expressionProgram.GetOperation(1);
+            if (prefixOp.GetString(expressionStringConstants).IsPrivateName())
+            {
+                reason = "Private named property reads are not supported.";
+                return false;
+            }
+
+            optionalStartIndex++;
+        }
+
+        if (optionalStartIndex >= expressionProgram.OperationCount)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var firstHop = expressionProgram.GetOperation(optionalStartIndex);
         if (firstHop.Kind != ExpressionOpKind.GetNamedProperty ||
             !firstHop.IsOptional ||
             firstHop.ShortCircuitOnNullishTarget ||
@@ -7166,7 +7193,7 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
-        for (var operationIndex = 2; operationIndex < expressionProgram.OperationCount; operationIndex++)
+        for (var operationIndex = optionalStartIndex + 1; operationIndex < expressionProgram.OperationCount; operationIndex++)
         {
             var op = expressionProgram.GetOperation(operationIndex);
             if (op.Kind != ExpressionOpKind.GetNamedProperty ||
@@ -7198,7 +7225,7 @@ internal static class UnifiedBytecodeCompiler
         {
             var op = expressionProgram.GetOperation(operationIndex);
 
-            // Each optional hop (the leading ?.b and any ?. continuation) emits a boundary jump
+            // Each optional hop (the leading ?.b or prefixed b?.c and any ?. continuation) emits a boundary jump
             // that short-circuits the rest of the chain to undefined when its target is nullish.
             if (op.IsOptional)
             {

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -1064,6 +1064,11 @@ internal static class UnifiedBytecodeProductionEligibility
                         break;
                     }
 
+                    if (TryIsFirstBoundaryOptionalNamedChainCandidate(program, identifierConstants, activationSlots))
+                    {
+                        break;
+                    }
+
                     if (TryIsFirstBoundaryComputedPropertyReadChainCandidate(program, identifierConstants, activationSlots) ||
                         TryIsFirstBoundaryOptionalComputedPropertyReadChainCandidate(program, identifierConstants, activationSlots) ||
                         TryIsFirstBoundaryOptionalNamedThenComputedReadChainCandidate(program, identifierConstants, activationSlots))
@@ -2093,8 +2098,8 @@ internal static class UnifiedBytecodeProductionEligibility
                !getNamedOp.GetString(program.StringConstants.AsSpan()).IsPrivateName();
     }
 
-    // Admits multi-hop optional named chains a?.b.c and a?.b?.c:
-    // [activation-resolved base,
+    // Admits multi-hop optional named chains a?.b.c, a?.b?.c, and a.b?.c:
+    // [activation-resolved base, GetNamedProperty(non-optional, non-private)*,
     //  GetNamedProperty(IsOptional:true, !ShortCircuitOnNullishTarget, non-private),
     //  GetNamedProperty(ShortCircuitOnNullishTarget:true, non-private)+].
     // The compiler lowers this to a jump-based form (JumpIfNullishReplaceUndefined at each
@@ -2117,8 +2122,27 @@ internal static class UnifiedBytecodeProductionEligibility
         }
 
         var stringConstants = program.StringConstants.AsSpan();
+        var optionalStartIndex = 1;
+        while (optionalStartIndex < program.OperationCount)
+        {
+            var prefixOp = program.GetOperation(optionalStartIndex);
+            if (prefixOp.Kind != ExpressionOpKind.GetNamedProperty ||
+                prefixOp.IsOptional ||
+                prefixOp.ShortCircuitOnNullishTarget ||
+                prefixOp.GetString(stringConstants).IsPrivateName())
+            {
+                break;
+            }
 
-        var firstHop = program.GetOperation(1);
+            optionalStartIndex++;
+        }
+
+        if (optionalStartIndex >= program.OperationCount)
+        {
+            return false;
+        }
+
+        var firstHop = program.GetOperation(optionalStartIndex);
         if (firstHop.Kind != ExpressionOpKind.GetNamedProperty ||
             !firstHop.IsOptional ||
             firstHop.ShortCircuitOnNullishTarget ||
@@ -2127,7 +2151,7 @@ internal static class UnifiedBytecodeProductionEligibility
             return false;
         }
 
-        for (var index = 2; index < program.OperationCount; index++)
+        for (var index = optionalStartIndex + 1; index < program.OperationCount; index++)
         {
             var op = program.GetOperation(index);
             if (op.Kind != ExpressionOpKind.GetNamedProperty ||

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -5306,11 +5306,10 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
-    public void Evaluate_OptionalNamedPropertyReadChainWithNonActivationResolvedBase_Declines()
+    public void Evaluate_OptionalNamedPropertyReadChainWithNamedPrefix_Accepts()
     {
-        // AC-3: a?.b.c with a non-activation-resolved base (obj.nested) continues to decline.
-        // The decline code reflects the first failing arm (PropertyReadBoundaryOutOfScope for the
-        // non-activation-resolved named read, or OptionalChainDependency for the optional part).
+        // a.b?.c.d keeps the activation-resolved root, lowers the named prefix as a plain
+        // receiver read, then uses the same jump-owned optional-chain boundary as a?.b.c.
         var plan = GetFunctionPlan("""
             function optChainNonResolved(obj) {
                 return obj.nested?.value.length;
@@ -5322,7 +5321,13 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
             plan,
             new UnifiedBytecodeProductionActivationDescriptor());
 
-        Assert.False(result.IsEligible);
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.JumpIfNullishReplaceUndefined);
+        Assert.True(
+            result.Program.Instructions.Count(static instruction =>
+                instruction.OpCode == UnifiedBytecodeOpCode.GetNamedProperty) >= 3);
     }
 
     [Fact]

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -2578,6 +2578,27 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task OptionalNamedChainAfterNamedPrefix_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function readChain(a) {
+                return a.box?.value;
+            }
+
+            var whenNull = readChain({ box: null });
+            var whenPresent = readChain({ box: { value: 42 } });
+            "" + whenNull + ":" + whenPresent;
+            """);
+
+        Assert.Equal("undefined:42", result?.ToString());
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=readChain",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task OptionalNamedThenComputedRichKey_ReadsValueThroughProductionFastPath()
     {
         // a?.b[left + right]: rich key continuations use the production fast path.


### PR DESCRIPTION
## Summary
- admit optional named read chains whose optional hop follows a plain named receiver prefix, e.g. box.child?.value
- lower the prefix as owned GetNamedProperty ops before the existing jump-to-chain-end optional boundary
- update the decline contract and add eligibility/runtime route proofs

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_OptionalNamedPropertyReadChainWithNamedPrefix_Accepts|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalNamedChainAfterNamedPrefix_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ChainedOptionalNamedChain_ShortCircuitsAtEachOptionalHop|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalThenRegularNamedChain_ReturnsDeepValueWhenBaseIsNonNull"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner* (no matches)
- rtk ./tools/profile forloop --memory (Total allocated 6.86 MB)
- rtk git diff --check