### PR TITLE
Admit prefixed optional computed reads

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -362,8 +362,9 @@ the final post-compile production subset check before VM entry.
   `TryIsFirstBoundaryNestedNamedPropertyWriteCandidate` and
   `TryIsFirstBoundaryNestedNamedPropertyUpdateCandidate`, which compile the
   receiver chain as owned `GetNamedProperty` opcodes before the final
-  `SetNamedProperty` / `UpdateNamedProperty`. Optional named read chains may
-  also start after a plain named receiver prefix (`box.child?.value`), with the
+  `SetNamedProperty` / `UpdateNamedProperty`. Optional named read chains,
+  including named-then-computed continuations, may also start after a plain
+  named receiver prefix (`box.child?.value`, `box.child?.items[key]`), with the
   prefix emitted as owned `GetNamedProperty` reads before the optional
   jump-to-chain-end boundary. Nested named receiver chains ending in a simple
   computed delete (`delete box.child[key]`) are admitted by

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -7255,8 +7255,10 @@ internal static class UnifiedBytecodeCompiler
         return true;
     }
 
-    // Handles: [activation-resolved base, GetNamedProperty(IsOptional:true, !SC, non-private), key..., GetComputedProperty(SC:true), GetNamedProperty(SC:true)*]
-    // Emits: LoadSlot, JumpIfNullishReplaceUndefined(end), GetNamedProperty(b), key..., GetComputedProperty, GetNamedProperty*
+    // Handles: [activation-resolved base, GetNamedProperty(non-optional, non-private)*,
+    // GetNamedProperty(IsOptional:true, !SC, non-private), key..., GetComputedProperty(SC:true), GetNamedProperty(SC:true)*]
+    // Emits: LoadSlot, GetNamedProperty*, JumpIfNullishReplaceUndefined(end), GetNamedProperty(b),
+    // key..., GetComputedProperty, GetNamedProperty*
     private static bool TryAppendFirstBoundaryOptionalNamedThenComputed(
         ExpressionProgram expressionProgram,
         ActivationSlotShape activationSlots,
@@ -7273,9 +7275,35 @@ internal static class UnifiedBytecodeCompiler
 
         var baseLoad = expressionProgram.GetOperation(0);
         var expressionStringConstants = expressionProgram.StringConstants.AsSpan();
-        var firstPropOp = expressionProgram.GetOperation(1);
+        var optionalStartIndex = 1;
+        while (optionalStartIndex < expressionProgram.OperationCount)
+        {
+            var prefixOp = expressionProgram.GetOperation(optionalStartIndex);
+            if (prefixOp.Kind != ExpressionOpKind.GetNamedProperty ||
+                prefixOp.IsOptional ||
+                prefixOp.ShortCircuitOnNullishTarget)
+            {
+                break;
+            }
+
+            if (prefixOp.GetString(expressionStringConstants).IsPrivateName())
+            {
+                reason = "Private named property reads are not supported.";
+                return false;
+            }
+
+            optionalStartIndex++;
+        }
+
+        if (optionalStartIndex >= expressionProgram.OperationCount)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var firstPropOp = expressionProgram.GetOperation(optionalStartIndex);
         var computedSuffixStart = expressionProgram.OperationCount;
-        while (computedSuffixStart > 4)
+        while (computedSuffixStart > optionalStartIndex + 3)
         {
             var suffixOp = expressionProgram.GetOperation(computedSuffixStart - 1);
             if (suffixOp.Kind != ExpressionOpKind.GetNamedProperty ||
@@ -7317,6 +7345,14 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        for (var operationIndex = 1; operationIndex < optionalStartIndex; operationIndex++)
+        {
+            var prefixOp = expressionProgram.GetOperation(operationIndex);
+            var prefixNameIndex = stringConstants.Count;
+            stringConstants.Add(prefixOp.GetString(expressionStringConstants));
+            unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.GetNamedProperty, prefixNameIndex));
+        }
+
         var jumpIndex = unified.Count;
         unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.JumpIfNullishReplaceUndefined, 0));
 
@@ -7329,7 +7365,7 @@ internal static class UnifiedBytecodeCompiler
                 activationSlots,
                 unified,
                 literalConstants,
-                startInclusive: 2,
+                startInclusive: optionalStartIndex + 1,
                 endExclusive: computedIndex,
                 out reason))
         {

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -2209,8 +2209,10 @@ internal static class UnifiedBytecodeProductionEligibility
         return true;
     }
 
-    // Admits the a?.b[k] and a?.b[k].c shapes:
-    // [activation-resolved base, GetNamedProperty(IsOptional:true, !SC, non-private), key..., GetComputedProperty(SC:true), GetNamedProperty(SC:true)*]
+    // Admits the a?.b[k], a?.b[k].c, and a.b?.c[k] shapes:
+    // [activation-resolved base, GetNamedProperty(non-optional, non-private)*,
+    //  GetNamedProperty(IsOptional:true, !SC, non-private), key..., GetComputedProperty(SC:true),
+    //  GetNamedProperty(SC:true)*]
     private static bool TryIsFirstBoundaryOptionalNamedThenComputedReadChainCandidate(
         ExpressionProgram program,
         ReadOnlySpan<IdentifierOperand> identifierConstants,
@@ -2227,7 +2229,27 @@ internal static class UnifiedBytecodeProductionEligibility
         }
 
         var stringConstants = program.StringConstants.AsSpan();
-        var firstPropOp = program.GetOperation(1);
+        var optionalStartIndex = 1;
+        while (optionalStartIndex < program.OperationCount)
+        {
+            var prefixOp = program.GetOperation(optionalStartIndex);
+            if (prefixOp.Kind != ExpressionOpKind.GetNamedProperty ||
+                prefixOp.IsOptional ||
+                prefixOp.ShortCircuitOnNullishTarget ||
+                prefixOp.GetString(stringConstants).IsPrivateName())
+            {
+                break;
+            }
+
+            optionalStartIndex++;
+        }
+
+        if (optionalStartIndex >= program.OperationCount)
+        {
+            return false;
+        }
+
+        var firstPropOp = program.GetOperation(optionalStartIndex);
         if (firstPropOp.Kind != ExpressionOpKind.GetNamedProperty ||
             !firstPropOp.IsOptional ||
             firstPropOp.ShortCircuitOnNullishTarget ||
@@ -2237,7 +2259,7 @@ internal static class UnifiedBytecodeProductionEligibility
         }
 
         var computedSuffixStart = program.OperationCount;
-        while (computedSuffixStart > 4)
+        while (computedSuffixStart > optionalStartIndex + 3)
         {
             var suffixOp = program.GetOperation(computedSuffixStart - 1);
             if (suffixOp.Kind != ExpressionOpKind.GetNamedProperty ||
@@ -2255,7 +2277,12 @@ internal static class UnifiedBytecodeProductionEligibility
         var computedOp = program.GetOperation(computedIndex);
         return computedOp.Kind == ExpressionOpKind.GetComputedProperty &&
                computedOp.ShortCircuitOnNullishTarget &&
-               IsSupportedComputedPropertyKeySpan(program, 2, computedIndex, identifierConstants, activationSlots);
+               IsSupportedComputedPropertyKeySpan(
+                   program,
+                   optionalStartIndex + 1,
+                   computedIndex,
+                   identifierConstants,
+                   activationSlots);
     }
 
 

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -5306,6 +5306,31 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
+    public void Evaluate_OptionalNamedThenComputedReadWithNamedPrefix_Accepts()
+    {
+        var plan = GetFunctionPlan("""
+            function optChainComputed(obj, key) {
+                return obj.nested?.items[key].value;
+            }
+            """,
+            "optChainComputed");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.JumpIfNullishReplaceUndefined);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.GetComputedProperty);
+        Assert.True(
+            result.Program.Instructions.Count(static instruction =>
+                instruction.OpCode == UnifiedBytecodeOpCode.GetNamedProperty) >= 3);
+    }
+
+    [Fact]
     public void Evaluate_OptionalNamedPropertyReadChainWithNamedPrefix_Accepts()
     {
         // a.b?.c.d keeps the activation-resolved root, lowers the named prefix as a plain

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -2620,6 +2620,35 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task OptionalNamedThenComputedAfterNamedPrefix_SkipsKeyOnNullish()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var keyHits = 0;
+            var key = {
+                toString() {
+                    keyHits++;
+                    return "item";
+                }
+            };
+
+            function readChain(a, key) {
+                return a.box?.items[key];
+            }
+
+            var whenNull = readChain({ box: null }, key);
+            var whenPresent = readChain({ box: { items: { item: 42 } } }, key);
+            "" + whenNull + ":" + whenPresent + ":" + keyHits;
+            """);
+
+        Assert.Equal("undefined:42:1", result?.ToString());
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=readChain",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task OptionalNamedThenComputedRichKeyWithTrailingNamedRead_ShortCircuitsBeforeKey()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit optional named-then-computed read chains whose optional named hop follows a plain named receiver prefix, e.g. box.child?.items[key]
- lower the prefix as owned GetNamedProperty ops before the existing optional jump boundary so computed keys are skipped on nullish receivers
- update the decline contract and add eligibility/runtime route proofs

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_OptionalNamedThenComputedReadWithNamedPrefix_Accepts|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalNamedThenComputedAfterNamedPrefix_SkipsKeyOnNullish|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalNamedThenComputedRichKey_ReadsValueThroughProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalNamedChainAfterNamedPrefix_UsesUnifiedBytecodeProductionFastPath"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests" (637 passed)
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner* (no matches)
- rtk ./tools/profile forloop --memory (Total allocated 6.85 MB)
- rtk git diff --check