### PR TITLE
Admit optional computed reads after named prefixes

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -362,11 +362,12 @@ the final post-compile production subset check before VM entry.
   `TryIsFirstBoundaryNestedNamedPropertyWriteCandidate` and
   `TryIsFirstBoundaryNestedNamedPropertyUpdateCandidate`, which compile the
   receiver chain as owned `GetNamedProperty` opcodes before the final
-  `SetNamedProperty` / `UpdateNamedProperty`. Optional named read chains,
-  including named-then-computed continuations, may also start after a plain
-  named receiver prefix (`box.child?.value`, `box.child?.items[key]`), with the
-  prefix emitted as owned `GetNamedProperty` reads before the optional
-  jump-to-chain-end boundary. Nested named receiver chains ending in a simple
+  `SetNamedProperty` / `UpdateNamedProperty`. Optional named and computed read
+  chains, including named-then-computed continuations, may also start after a
+  plain named receiver prefix (`box.child?.value`, `box.child?.[key]`,
+  `box.child?.items[key]`), with the prefix emitted as owned `GetNamedProperty`
+  reads before the optional jump-to-chain-end boundary. Nested named receiver
+  chains ending in a simple
   computed delete (`delete box.child[key]`) are admitted by
   `TryIsFirstBoundaryComputedPropertyDeleteCandidate`; optional computed delete
   chains are admitted for `delete box?.[key]`, `delete box?.child[key]`, and

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -3736,6 +3736,21 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        if (TryAppendFirstBoundaryOptionalComputedPropertyReadChain(
+                expressionProgram,
+                activationSlots,
+                unified,
+                literalConstants,
+                stringConstants,
+                out reason))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrEmpty(reason))
+        {
+            return false;
+        }
 
         if (TryAppendFirstBoundaryPropertyReadBinaryExpression(
                 expressionProgram,
@@ -7250,7 +7265,6 @@ internal static class UnifiedBytecodeCompiler
             }
         }
 
-
         reason = string.Empty;
         return true;
     }
@@ -7386,6 +7400,153 @@ internal static class UnifiedBytecodeCompiler
         return true;
     }
 
+    // Handles: [activation-resolved base, GetNamedProperty(non-optional, non-private)*,
+    // JumpIfNullish(ReplaceWithUndefined:true), key..., GetComputedProperty(!SC),
+    // GetNamedProperty(SC:true)*].
+    private static bool TryAppendFirstBoundaryOptionalComputedPropertyReadChain(
+        ExpressionProgram expressionProgram,
+        ActivationSlotShape activationSlots,
+        ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
+        ImmutableArray<JsValue>.Builder literalConstants,
+        ImmutableArray<string>.Builder stringConstants,
+        out string reason)
+    {
+        if (expressionProgram.OperationCount < 4)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var expressionStringConstants = expressionProgram.StringConstants.AsSpan();
+        var jumpIndex = 1;
+        while (jumpIndex < expressionProgram.OperationCount)
+        {
+            var prefixOp = expressionProgram.GetOperation(jumpIndex);
+            if (prefixOp.Kind != ExpressionOpKind.GetNamedProperty ||
+                prefixOp.IsOptional ||
+                prefixOp.ShortCircuitOnNullishTarget)
+            {
+                break;
+            }
+
+            if (prefixOp.GetString(expressionStringConstants).IsPrivateName())
+            {
+                reason = "Private named property reads are not supported.";
+                return false;
+            }
+
+            jumpIndex++;
+        }
+
+        if (jumpIndex >= expressionProgram.OperationCount)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var jumpOp = expressionProgram.GetOperation(jumpIndex);
+        if (jumpOp.Kind != ExpressionOpKind.JumpIfNullish ||
+            !jumpOp.ReplaceWithUndefined)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var computedSuffixStart = expressionProgram.OperationCount;
+        while (computedSuffixStart > jumpIndex + 2)
+        {
+            var suffixOp = expressionProgram.GetOperation(computedSuffixStart - 1);
+            if (suffixOp.Kind != ExpressionOpKind.GetNamedProperty ||
+                suffixOp.IsOptional ||
+                !suffixOp.ShortCircuitOnNullishTarget)
+            {
+                break;
+            }
+
+            if (suffixOp.GetString(expressionStringConstants).IsPrivateName())
+            {
+                reason = "Private named property reads are not supported.";
+                return false;
+            }
+
+            computedSuffixStart--;
+        }
+
+        var computedIndex = computedSuffixStart - 1;
+        if (computedIndex <= jumpIndex + 1 ||
+            jumpOp.Target != computedIndex + 1)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var computedOp = expressionProgram.GetOperation(computedIndex);
+        if (computedOp.Kind != ExpressionOpKind.GetComputedProperty ||
+            computedOp.ShortCircuitOnNullishTarget)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        if (!IsSupportedComputedPropertyKeySpan(
+                expressionProgram,
+                activationSlots,
+                startInclusive: jumpIndex + 1,
+                endExclusive: computedIndex))
+        {
+            reason = "Unsupported computed property key span.";
+            return false;
+        }
+
+        if (!TryAppendActivationValueLoad(
+                expressionProgram.GetOperation(0),
+                expressionProgram,
+                activationSlots,
+                unified,
+                out reason))
+        {
+            return false;
+        }
+
+        for (var operationIndex = 1; operationIndex < jumpIndex; operationIndex++)
+        {
+            var prefixOp = expressionProgram.GetOperation(operationIndex);
+            var prefixNameIndex = stringConstants.Count;
+            stringConstants.Add(prefixOp.GetString(expressionStringConstants));
+            unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.GetNamedProperty, prefixNameIndex));
+        }
+
+        var unifiedJumpIndex = unified.Count;
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.JumpIfNullishReplaceUndefined, 0));
+
+        if (!TryAppendComputedPropertyKeySpan(
+                expressionProgram,
+                activationSlots,
+                unified,
+                literalConstants,
+                startInclusive: jumpIndex + 1,
+                endExclusive: computedIndex,
+                out reason))
+        {
+            return false;
+        }
+
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.GetComputedProperty));
+        for (var operationIndex = computedIndex + 1; operationIndex < expressionProgram.OperationCount; operationIndex++)
+        {
+            var suffixOp = expressionProgram.GetOperation(operationIndex);
+            var suffixNameIndex = stringConstants.Count;
+            stringConstants.Add(suffixOp.GetString(expressionStringConstants));
+            unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.GetNamedProperty, suffixNameIndex));
+        }
+
+        unified[unifiedJumpIndex] = new UnifiedBytecodeInstruction(
+            UnifiedBytecodeOpCode.JumpIfNullishReplaceUndefined,
+            unified.Count);
+        reason = string.Empty;
+        return true;
+    }
+
     private static bool TryAppendComputedPropertyKeySpan(
         ExpressionProgram expressionProgram,
         ActivationSlotShape activationSlots,
@@ -7451,6 +7612,64 @@ internal static class UnifiedBytecodeCompiler
 
         reason = string.Empty;
         return true;
+    }
+
+    private static bool IsSupportedComputedPropertyKeySpan(
+        ExpressionProgram expressionProgram,
+        ActivationSlotShape activationSlots,
+        int startInclusive,
+        int endExclusive)
+    {
+        var stackDepth = 0;
+        for (var index = startInclusive; index < endExclusive; index++)
+        {
+            var operation = expressionProgram.GetOperation(index);
+            switch (operation.Kind)
+            {
+                case ExpressionOpKind.LoadLiteral:
+                    stackDepth++;
+                    break;
+
+                case ExpressionOpKind.LoadIdentifier:
+                    if (!TryResolveActivationSlot(
+                            operation.GetIdentifier(expressionProgram.IdentifierConstants.AsSpan()),
+                            activationSlots,
+                            out _))
+                    {
+                        return false;
+                    }
+
+                    stackDepth++;
+                    break;
+
+                case ExpressionOpKind.UnaryPlus:
+                case ExpressionOpKind.UnaryMinus:
+                case ExpressionOpKind.UnaryLogicalNot:
+                case ExpressionOpKind.UnaryBitwiseNot:
+                case ExpressionOpKind.UnaryVoid:
+                case ExpressionOpKind.ToString:
+                    if (stackDepth < 1)
+                    {
+                        return false;
+                    }
+
+                    break;
+
+                case ExpressionOpKind.Binary:
+                    if (stackDepth < 2 || !IsSupportedBinaryOperator(operation.Operator))
+                    {
+                        return false;
+                    }
+
+                    stackDepth--;
+                    break;
+
+                default:
+                    return false;
+            }
+        }
+
+        return stackDepth == 1;
     }
 
     private static bool TryAppendFirstBoundaryPropertyReadBinaryExpression(

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -2282,12 +2282,13 @@ internal static class UnifiedBytecodeProductionEligibility
                    optionalStartIndex + 1,
                    computedIndex,
                    identifierConstants,
-                   activationSlots);
+        activationSlots);
     }
 
-
-    // Admits the simple a?.[k] shape:
-    // [activation-resolved base, JumpIfNullish(ReplaceWithUndefined:true), simple key, GetComputedProperty(!ShortCircuitOnNullishTarget)].
+    // Admits a?.[k], a.b?.[k], and optional-computed read continuations:
+    // [activation-resolved base, GetNamedProperty(non-optional, non-private)*,
+    //  JumpIfNullish(ReplaceWithUndefined:true), key..., GetComputedProperty(!ShortCircuitOnNullishTarget),
+    //  GetNamedProperty(ShortCircuitOnNullishTarget:true)*].
     private static bool TryIsFirstBoundaryOptionalComputedPropertyReadChainCandidate(
         ExpressionProgram program,
         ReadOnlySpan<IdentifierOperand> identifierConstants,
@@ -2303,29 +2304,55 @@ internal static class UnifiedBytecodeProductionEligibility
             return false;
         }
 
-        var jumpOp = program.GetOperation(1);
+        var stringConstants = program.StringConstants.AsSpan();
+        var jumpIndex = 1;
+        while (jumpIndex < program.OperationCount)
+        {
+            var prefixOp = program.GetOperation(jumpIndex);
+            if (prefixOp.Kind != ExpressionOpKind.GetNamedProperty ||
+                prefixOp.IsOptional ||
+                prefixOp.ShortCircuitOnNullishTarget ||
+                prefixOp.GetString(stringConstants).IsPrivateName())
+            {
+                break;
+            }
+
+            jumpIndex++;
+        }
+
+        if (jumpIndex >= program.OperationCount)
+        {
+            return false;
+        }
+
+        var jumpOp = program.GetOperation(jumpIndex);
         if (jumpOp.Kind != ExpressionOpKind.JumpIfNullish || !jumpOp.ReplaceWithUndefined)
         {
             return false;
         }
 
-        var stringConstants = program.StringConstants.AsSpan();
         var computedSuffixStart = program.OperationCount;
-        while (computedSuffixStart > 3 &&
+        while (computedSuffixStart > jumpIndex + 2 &&
                IsShortCircuitNamedPropertyRead(program.GetOperation(computedSuffixStart - 1), stringConstants))
         {
             computedSuffixStart--;
         }
 
         var computedIndex = computedSuffixStart - 1;
-        if (computedIndex <= 2 || jumpOp.Target != computedIndex + 1)
+        if (computedIndex <= jumpIndex + 1 || jumpOp.Target != computedIndex + 1)
         {
             return false;
         }
 
         var getComputedOp = program.GetOperation(computedIndex);
         return getComputedOp.Kind == ExpressionOpKind.GetComputedProperty &&
-               !getComputedOp.ShortCircuitOnNullishTarget;
+               !getComputedOp.ShortCircuitOnNullishTarget &&
+               IsSupportedComputedPropertyKeySpan(
+                   program,
+                   jumpIndex + 1,
+                   computedIndex,
+                   identifierConstants,
+                   activationSlots);
     }
 
     private static bool TryIsEmbeddedOptionalReadOperandOperation(

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -5213,6 +5213,30 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
+    public void Evaluate_OptionalComputedPropertyReadWithNamedPrefix_AcceptsWithJumpIfNullishReplaceUndefinedOpcode()
+    {
+        var plan = GetFunctionPlan("""
+            function optComputedPrefixed(box, key) {
+                return box.child?.[key];
+            }
+            """,
+            "optComputedPrefixed");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.JumpIfNullishReplaceUndefined);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.GetComputedProperty);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.GetNamedProperty);
+    }
+
+    [Fact]
     public void Evaluate_OptionalNamedPropertyReadChainExpressionPlan_AcceptsWithJumpIfNullishReplaceUndefined()
     {
         // AC-1: a?.b.c with an activation-resolved base is admitted.

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -2325,6 +2325,35 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task OptionalComputedPropertyReadAfterNamedPrefix_SkipsKeyOnNullish()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var keyHits = 0;
+            var key = {
+                toString() {
+                    keyHits++;
+                    return "item";
+                }
+            };
+
+            function readOptionalComputed(box, key) {
+                return box.child?.[key];
+            }
+
+            var whenNull = readOptionalComputed({ child: null }, key);
+            var whenPresent = readOptionalComputed({ child: { item: 42 } }, key);
+            "" + whenNull + ":" + whenPresent + ":" + keyHits;
+            """);
+
+        Assert.Equal("undefined:42:1", result?.ToString());
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=readOptionalComputed",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task OptionalNamedPropertyRead_ReturnsUndefinedWhenBaseIsUndefined()
     {
         // gh2771: a?.b short-circuits to undefined when base is undefined (not only null).


### PR DESCRIPTION
## Summary
- admit prefixed optional computed reads like box.child?.[key] into production unified bytecode
- emit named receiver prefixes before the nullish boundary, then computed key/property reads and short-circuit suffixes
- update the unified bytecode expansion contract and add eligibility/invocation coverage

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_OptionalComputedPropertyReadWithNamedPrefix_AcceptsWithJumpIfNullishReplaceUndefinedOpcode|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalComputedPropertyReadAfterNamedPrefix_SkipsKeyOnNullish|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalComputedPropertyRead_ReturnsPropertyValueWhenBaseIsNonNull|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalComputedPropertyRead_ReturnsUndefinedWhenBaseIsNull"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release
- rtk git diff --check
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk ./tools/profile forloop --memory

## Notes
- Full tests are currently blocked by the same 14 baseline failures reproduced on untouched main in the TDZ/const/slot/tail-call subset, so they are not introduced by this branch.
- rtk dotnet format is a verify wrapper and reported pre-existing analyzer findings in these large touched compiler files; local whitespace issues from this change were fixed.