### PR TITLE
Sync property write decline docs

### DIFF
--- a/docs/rules/expression-bytecode-assignment.md
+++ b/docs/rules/expression-bytecode-assignment.md
@@ -57,10 +57,13 @@ path that can evaluate the assignment.
     production path, simultaneously update the boundary description in
     `docs/unified-bytecode-expansion-contract.md`. Name the newly admitted shape,
     its constraints (activation-resolved base, named key, production binary
-    operator, simple RHS), and the retained declines (logical-assignment operators,
-    deeper chains, computed-expression keys). Do not leave the old blanket
-    "is declined" statement intact — stale decline descriptions mislead agents
-    into thinking a shape is still excluded when it was already admitted.
+    operator, simple RHS), and the retained declines that are still true for
+    the current boundary, such as optional/private/dynamic neighbors, unowned
+    computed-key spans, or unsupported RHS shapes. Do not leave the old blanket
+    "is declined" statement intact, and do not keep historical retained-decline
+    examples after a later slice admits them — stale decline descriptions
+    mislead agents into thinking a shape is still excluded when it was already
+    admitted.
 
 ## Why
 

--- a/docs/rules/unified-bytecode-prototypes.md
+++ b/docs/rules/unified-bytecode-prototypes.md
@@ -317,13 +317,17 @@ all-or-nothing until a separate routing issue proves production readiness.
 21. When admitting nested named receiver writes or updates into production
     unified bytecode, keep the route owned by existing property opcodes and
     prove the extra receiver stack pressure explicitly. Simple chains such as
-    `box.child.value = y` and `++box.child.count` may route when the root is
-    activation-resolved, every intermediate step is a non-optional non-private
-    `GetNamedProperty`, the final operation is `SetNamedProperty` or
-    `UpdateNamedProperty`, and the RHS is still a simple production-owned
-    payload. Do not infer that nested compound/logical assignments,
-    computed-expression keys, optional chains, `super`, private names, calls, or
-    dynamic lookup are covered by the same widening. If preserving an
+    `box.child.value = y`, `++box.child.count`, `box.child.value += y`, and
+    `box.child.value &&= y` may route when the root is activation-resolved,
+    every intermediate step is a non-optional non-private `GetNamedProperty`,
+    the final operation is an owned property write, update, compound-write, or
+    logical-write shape, and the RHS is still a simple production-owned
+    payload. Direct computed assignments may also route with a supported
+    computed-key expression span and simple RHS, for example
+    `box[key + suffix] = y`. Do not infer that computed-expression-key
+    compound/logical/update neighbors, optional chains, `super`, private names,
+    calls, dynamic lookup, or unsupported RHS/key spans are covered by the same
+    widening. If preserving an
     intermediate receiver means the compiled unified-bytecode program needs a
     deeper stack than `ExpressionProgram.MaxStackDepth` reports, raise the
     compiled stack-depth calculation and add a focused stack-depth proof instead

--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -359,8 +359,9 @@ the final post-compile production subset check before VM entry.
   (activation-resolved base, simple key, simple RHS, non-optional/non-private
   target). Direct computed assignments may use the same supported computed-key
   expression span as optional computed reads (`box[key + suffix] = y`) when the
-  RHS is a simple operand. Simple nested named receiver assignments, compound writes, logical
-  writes, and updates (`box.child.value = y`, `box.child.value += y`,
+  RHS is a simple operand. Simple nested named receiver assignments, compound
+  writes, logical writes, and updates (`box.child.value = y`,
+  `box.child.value += y`,
   `box.child.value &&= y`, `box.child.value++`) are admitted through
   `TryIsFirstBoundaryNestedNamedPropertyWriteCandidate` and
   prefix-aware `TryIsFirstBoundaryNamedCompoundPropertyWriteCandidate` and
@@ -382,10 +383,10 @@ the final post-compile production subset check before VM entry.
   The compiler emits the named receiver reads and final `DeleteComputedProperty`,
   while the VM's descriptor-aware delete helper owns strict/sloppy results.
   Retained declines include chained optional delete neighbors, private property
-  access, dynamic lookup, richer unowned computed keys, deeper compound/logical
-  property chains
-  (`box.child.value += …`, `box.child.value &&= …`), and computed-expression
-  keys (`box[key+suffix] += …`).
+  access, dynamic lookup, richer unowned computed-key spans, and
+  computed-expression-key compound/logical/update neighbors such as
+  `box[key + suffix] += y`, `box[key + suffix] &&= y`, and
+  `box[key + suffix]++`.
   Note: slot-identifier logical assignment (`x &&= y`) remains admitted.
 - Super-property reads, writes, and updates are now VM-owned through
   `EnsureSuperReference`, `GetNamedSuperProperty`, `GetComputedSuperProperty`,


### PR DESCRIPTION
## Summary
- remove stale retained-decline wording for nested named compound/logical writes now admitted by PRs #2975/#2976
- clarify computed expression-key assignment support from PR #2977 without implying compound/logical/update neighbors route
- update durable rules so future slices keep retained-decline examples current

## Verification
- rtk rg -n "deeper compound|box\.child\.value \+= …|box\.child\.value &&= …|box\[key\+suffix\]|logical-assignment operators,\s*$|computed-expression keys\)" docs/unified-bytecode-expansion-contract.md docs/rules/unified-bytecode-prototypes.md docs/rules/expression-bytecode-assignment.md (no matches)
- rtk git diff --check
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums" (1 passed; 7 unrelated existing nullable warnings in test files)