### PR TITLE
Admit computed expression-key mutations

### DIFF
--- a/docs/rules/unified-bytecode-prototypes.md
+++ b/docs/rules/unified-bytecode-prototypes.md
@@ -322,12 +322,13 @@ all-or-nothing until a separate routing issue proves production readiness.
     every intermediate step is a non-optional non-private `GetNamedProperty`,
     the final operation is an owned property write, update, compound-write, or
     logical-write shape, and the RHS is still a simple production-owned
-    payload. Direct computed assignments may also route with a supported
-    computed-key expression span and simple RHS, for example
-    `box[key + suffix] = y`. Do not infer that computed-expression-key
-    compound/logical/update neighbors, optional chains, `super`, private names,
-    calls, dynamic lookup, or unsupported RHS/key spans are covered by the same
-    widening. If preserving an
+    payload. Direct computed assignments, compound writes, logical writes, and
+    updates may also route with a supported computed-key expression span and
+    simple RHS, for example `box[key + suffix] = y`,
+    `box[key + suffix] += y`, `box[key + suffix] &&= y`, and
+    `box[key + suffix]++`. Do not infer that optional chains, `super`, private
+    names, calls, dynamic lookup, or unsupported RHS/key spans are covered by
+    the same widening. If preserving an
     intermediate receiver means the compiled unified-bytecode program needs a
     deeper stack than `ExpressionProgram.MaxStackDepth` reports, raise the
     compiled stack-depth calculation and add a focused stack-depth proof instead

--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -273,8 +273,8 @@ must still obey the no-mixed-execution rule.
 | `CallDependency` | Direct eval outside the one-argument non-spread eval-identifier boundary, out-of-boundary call-target preparation, complex call arguments, and descriptor-level non-parameter callee calls | Existing sync IR call route | Wider call invocation lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_CallWithComplexTemplateLiteralSubstitution_DeclinesCallDependency"` |
 | `DynamicLookupDependency` | Unresolved identifier loads/stores/typeof/update outside the with-backed dynamic-name path | Existing sync IR / environment lookup route | Dynamic-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_DynamicIdentifierLookup_DeclinesWithDynamicLookupDependency"` |
 | `PropertyReadBoundaryOutOfScope` | Named/computed property reads outside the admitted activation-resolved boundaries | Existing sync IR property route | Property read widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_ComputedPropertyReadOutsideFirstBoundary_DeclinesWithBoundaryCode"` |
-| `PropertyWriteDependency` | Property writes and compound/logical property writes outside the admitted direct property-write shapes, computed expression-key assignment shape, simple nested named receiver assignment shape, nested named compound-write shape, and nested named logical-write shape | Existing sync IR property-write route | Property write widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_LogicalAndAssignment_UnsupportedShapes_DeclineWithExplicitCodes"` |
-| `PropertyUpdateDependency` | Property and identifier update expressions outside the admitted direct update and simple nested named receiver update boundary | Existing sync IR update route | Property update lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedNamedPropertyUpdate_AcceptsOwnedPropertyOpcodes"` |
+| `PropertyWriteDependency` | Property writes and compound/logical property writes outside the admitted direct property-write shapes, supported computed expression-key mutation shapes, simple nested named receiver assignment shape, nested named compound-write shape, and nested named logical-write shape | Existing sync IR property-write route | Property write widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_LogicalAndAssignment_UnsupportedShapes_DeclineWithExplicitCodes"` |
+| `PropertyUpdateDependency` | Property and identifier update expressions outside the admitted direct update, computed expression-key update, and simple nested named receiver update boundary | Existing sync IR update route | Property update lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedNamedPropertyUpdate_AcceptsOwnedPropertyOpcodes"` |
 | `DeleteDependency` | `delete` expressions outside the admitted ordinary named/computed property delete lane and the with-backed dynamic-name delete lane | Existing sync IR delete route | Delete semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_PropertyReadAdjacentFamilies_DeclineWithExplicitCodes"` |
 | `SuperPropertyDependency` | Out-of-boundary super call targets; super property reads/writes/updates are admitted by dedicated VM opcodes | Existing class / constructor route for remaining call-target shapes | Super semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperPropertyAccess_AcceptsOwnedOpcodes"` |
 | `OptionalChainDependency` | Optional chains outside the admitted optional property-read, optional-call, and exact optional computed delete boundaries | Existing sync IR optional-chain route | Optional-chain widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_OptionalSpreadCallExpressionPlan_DeclinesWithOptionalChainDependency"` |
@@ -356,11 +356,15 @@ the final post-compile production subset check before VM entry.
   `TryIsFirstBoundaryNamedLogicalPropertyWriteCandidate`. Direct computed logical
   writes (`box[key] &&= y`, `box[key] ||= y`, `box[key] ??= y`) are also admitted
   when they match `TryIsFirstBoundaryComputedLogicalPropertyWriteCandidate`
-  (activation-resolved base, simple key, simple RHS, non-optional/non-private
-  target). Direct computed assignments may use the same supported computed-key
-  expression span as optional computed reads (`box[key + suffix] = y`) when the
-  RHS is a simple operand. Simple nested named receiver assignments, compound
-  writes, logical writes, and updates (`box.child.value = y`,
+  (activation-resolved base, supported computed-key span, simple RHS,
+  non-optional/non-private target). Direct computed assignments, compound
+  writes, logical writes, and
+  updates may use the same supported computed-key expression span as optional
+  computed reads (`box[key + suffix] = y`, `box[key + suffix] += y`,
+  `box[key + suffix] &&= y`, `box[key + suffix]++`) when the RHS is a simple
+  operand and the operator-specific shape is already admitted. Simple nested
+  named receiver assignments, compound writes, logical writes, and updates
+  (`box.child.value = y`,
   `box.child.value += y`,
   `box.child.value &&= y`, `box.child.value++`) are admitted through
   `TryIsFirstBoundaryNestedNamedPropertyWriteCandidate` and
@@ -383,10 +387,8 @@ the final post-compile production subset check before VM entry.
   The compiler emits the named receiver reads and final `DeleteComputedProperty`,
   while the VM's descriptor-aware delete helper owns strict/sloppy results.
   Retained declines include chained optional delete neighbors, private property
-  access, dynamic lookup, richer unowned computed-key spans, and
-  computed-expression-key compound/logical/update neighbors such as
-  `box[key + suffix] += y`, `box[key + suffix] &&= y`, and
-  `box[key + suffix]++`.
+  access, dynamic lookup, richer unowned computed-key spans, unsupported RHS
+  spans, and optional/super/private neighbors of computed-key mutation shapes.
   Note: slot-identifier logical assignment (`x &&= y`) remains admitted.
 - Super-property reads, writes, and updates are now VM-owned through
   `EnsureSuperReference`, `GetNamedSuperProperty`, `GetComputedSuperProperty`,
@@ -723,10 +725,9 @@ support today.
 3. Property and assignment widening is no longer a blanket property-read/write
    gap, but several member-expression neighbors remain outside production:
    private member reads/writes/updates, optional-chain neighbors outside the
-   admitted read/call/delete shapes, richer computed-key spans, computed
-   expression-key compound/logical/update forms such as
-   `box[key + suffix] += y`, and dynamic lookup outside the explicit
-   with-backed lane.
+   admitted read/call/delete shapes, richer computed-key spans, unsupported RHS
+   spans, optional/super/private mutation neighbors, and dynamic lookup outside
+   the explicit with-backed lane.
 4. Driver-state widening is next. Sync-driver TDZ head environments
    (`for (const x of …)` / `for (let k in …)`) are now admitted via the
    `TdzHeadInit` instruction (Slice A, #2678; see ADR 0288). Async iterator

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -6075,19 +6075,26 @@ internal static class UnifiedBytecodeCompiler
         ImmutableArray<JsValue>.Builder literalConstants,
         out string reason)
     {
-        if (expressionProgram.OperationCount != 9)
+        if (expressionProgram.OperationCount < 9)
         {
             reason = string.Empty;
             return false;
         }
 
-        var requireObjectCoercible = expressionProgram.GetOperation(2);
-        var resolvePropertyKey = expressionProgram.GetOperation(3);
-        var duplicateTargetAndKey = expressionProgram.GetOperation(4);
-        var propertyRead = expressionProgram.GetOperation(5);
-        var rhs = expressionProgram.GetOperation(6);
-        var binary = expressionProgram.GetOperation(7);
-        var propertySet = expressionProgram.GetOperation(8);
+        var suffixStart = expressionProgram.OperationCount - 7;
+        if (suffixStart <= 1)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var requireObjectCoercible = expressionProgram.GetOperation(suffixStart);
+        var resolvePropertyKey = expressionProgram.GetOperation(suffixStart + 1);
+        var duplicateTargetAndKey = expressionProgram.GetOperation(suffixStart + 2);
+        var propertyRead = expressionProgram.GetOperation(suffixStart + 3);
+        var rhs = expressionProgram.GetOperation(suffixStart + 4);
+        var binary = expressionProgram.GetOperation(suffixStart + 5);
+        var propertySet = expressionProgram.GetOperation(suffixStart + 6);
         if (requireObjectCoercible.Kind != ExpressionOpKind.RequireObjectCoercible ||
             requireObjectCoercible.Depth != 1 ||
             resolvePropertyKey.Kind != ExpressionOpKind.ResolvePropertyKey ||
@@ -6118,38 +6125,65 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        if (!IsSupportedComputedPropertyKeySpan(
+                expressionProgram,
+                activationSlots,
+                startInclusive: 1,
+                endExclusive: suffixStart))
+        {
+            reason = "Unsupported computed property key span.";
+            return false;
+        }
+
+        var stagedUnified = ImmutableArray.CreateBuilder<UnifiedBytecodeInstruction>();
+        stagedUnified.AddRange(unified);
+
+        var stagedLiterals = ImmutableArray.CreateBuilder<JsValue>();
+        stagedLiterals.AddRange(literalConstants);
+
         if (!TryAppendActivationValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
                 activationSlots,
-                unified,
+                stagedUnified,
                 out reason))
         {
             return false;
         }
 
-        if (!TryAppendComputedPropertyKeyLoad(
-                expressionProgram.GetOperation(1),
+        if (!TryAppendComputedPropertyKeySpan(
                 expressionProgram,
                 activationSlots,
-                unified,
-                literalConstants,
+                stagedUnified,
+                stagedLiterals,
+                startInclusive: 1,
+                endExclusive: suffixStart,
                 out reason))
         {
             return false;
         }
 
-        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.RequireObjectCoercible, 1));
-        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.ResolvePropertyKey));
-        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.GetComputedPropertyForCompoundSet));
+        stagedUnified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.RequireObjectCoercible, 1));
+        stagedUnified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.ResolvePropertyKey));
+        stagedUnified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.GetComputedPropertyForCompoundSet));
 
-        if (!TryAppendSimpleOperandLoad(rhs, expressionProgram, activationSlots, unified, literalConstants, out reason))
+        if (!TryAppendSimpleOperandLoad(
+                rhs,
+                expressionProgram,
+                activationSlots,
+                stagedUnified,
+                stagedLiterals,
+                out reason))
         {
             return false;
         }
 
-        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.Binary, (int)binary.Operator));
-        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.SetComputedProperty));
+        stagedUnified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.Binary, (int)binary.Operator));
+        stagedUnified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.SetComputedProperty));
+        unified.Clear();
+        unified.AddRange(stagedUnified);
+        literalConstants.Clear();
+        literalConstants.AddRange(stagedLiterals);
         reason = string.Empty;
         return true;
     }
@@ -6334,25 +6368,32 @@ internal static class UnifiedBytecodeCompiler
         ImmutableArray<JsValue>.Builder literalConstants,
         out string reason)
     {
-        if (expressionProgram.OperationCount != 15)
+        if (expressionProgram.OperationCount < 15)
         {
             reason = string.Empty;
             return false;
         }
 
-        var requireObjectCoercible = expressionProgram.GetOperation(2);
-        var resolvePropertyKey = expressionProgram.GetOperation(3);
-        var duplicateTargetAndKey = expressionProgram.GetOperation(4);
-        var propertyRead = expressionProgram.GetOperation(5);
-        var jump = expressionProgram.GetOperation(6);
-        var pop = expressionProgram.GetOperation(7);
-        var rhs = expressionProgram.GetOperation(8);
-        var propertySet = expressionProgram.GetOperation(9);
-        var duplicateAssignedValue = expressionProgram.GetOperation(10);
-        var duplicateAssignedValueAgain = expressionProgram.GetOperation(11);
-        var rotateTopThreeRight = expressionProgram.GetOperation(12);
-        var cleanupPop = expressionProgram.GetOperation(13);
-        var cleanupPop2 = expressionProgram.GetOperation(14);
+        var suffixStart = expressionProgram.OperationCount - 13;
+        if (suffixStart <= 1)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var requireObjectCoercible = expressionProgram.GetOperation(suffixStart);
+        var resolvePropertyKey = expressionProgram.GetOperation(suffixStart + 1);
+        var duplicateTargetAndKey = expressionProgram.GetOperation(suffixStart + 2);
+        var propertyRead = expressionProgram.GetOperation(suffixStart + 3);
+        var jump = expressionProgram.GetOperation(suffixStart + 4);
+        var pop = expressionProgram.GetOperation(suffixStart + 5);
+        var rhs = expressionProgram.GetOperation(suffixStart + 6);
+        var propertySet = expressionProgram.GetOperation(suffixStart + 7);
+        var duplicateAssignedValue = expressionProgram.GetOperation(suffixStart + 8);
+        var duplicateAssignedValueAgain = expressionProgram.GetOperation(suffixStart + 9);
+        var rotateTopThreeRight = expressionProgram.GetOperation(suffixStart + 10);
+        var cleanupPop = expressionProgram.GetOperation(suffixStart + 11);
+        var cleanupPop2 = expressionProgram.GetOperation(suffixStart + 12);
         if (requireObjectCoercible.Kind != ExpressionOpKind.RequireObjectCoercible ||
             requireObjectCoercible.Depth != 1 ||
             resolvePropertyKey.Kind != ExpressionOpKind.ResolvePropertyKey ||
@@ -6383,9 +6424,19 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
-        if (jump.Target != 12)
+        if (jump.Target != suffixStart + 10)
         {
             reason = "Logical computed property writes require jump target at cleanup start.";
+            return false;
+        }
+
+        if (!IsSupportedComputedPropertyKeySpan(
+                expressionProgram,
+                activationSlots,
+                startInclusive: 1,
+                endExclusive: suffixStart))
+        {
+            reason = "Unsupported computed property key span.";
             return false;
         }
 
@@ -6405,12 +6456,13 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
-        if (!TryAppendComputedPropertyKeyLoad(
-                expressionProgram.GetOperation(1),
+        if (!TryAppendComputedPropertyKeySpan(
                 expressionProgram,
                 activationSlots,
                 stagedUnified,
                 stagedLiterals,
+                startInclusive: 1,
+                endExclusive: suffixStart,
                 out reason))
         {
             return false;
@@ -6889,43 +6941,65 @@ internal static class UnifiedBytecodeCompiler
         ImmutableArray<JsValue>.Builder literalConstants,
         out string reason)
     {
-        if (expressionProgram.OperationCount != 3)
+        if (expressionProgram.OperationCount < 3)
         {
             reason = string.Empty;
             return false;
         }
 
-        var propertyUpdate = expressionProgram.GetOperation(2);
+        var propertyUpdateIndex = expressionProgram.OperationCount - 1;
+        var propertyUpdate = expressionProgram.GetOperation(propertyUpdateIndex);
         if (propertyUpdate.Kind != ExpressionOpKind.UpdateComputedProperty)
         {
             reason = string.Empty;
             return false;
         }
 
+        if (!IsSupportedComputedPropertyKeySpan(
+                expressionProgram,
+                activationSlots,
+                startInclusive: 1,
+                endExclusive: propertyUpdateIndex))
+        {
+            reason = "Unsupported computed property key span.";
+            return false;
+        }
+
+        var stagedUnified = ImmutableArray.CreateBuilder<UnifiedBytecodeInstruction>();
+        stagedUnified.AddRange(unified);
+
+        var stagedLiterals = ImmutableArray.CreateBuilder<JsValue>();
+        stagedLiterals.AddRange(literalConstants);
+
         if (!TryAppendActivationValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
                 activationSlots,
-                unified,
+                stagedUnified,
                 out reason))
         {
             return false;
         }
 
-        if (!TryAppendSimpleOperandLoad(
-                expressionProgram.GetOperation(1),
+        if (!TryAppendComputedPropertyKeySpan(
                 expressionProgram,
                 activationSlots,
-                unified,
-                literalConstants,
+                stagedUnified,
+                stagedLiterals,
+                startInclusive: 1,
+                endExclusive: propertyUpdateIndex,
                 out reason))
         {
             return false;
         }
 
-        unified.Add(new UnifiedBytecodeInstruction(
+        stagedUnified.Add(new UnifiedBytecodeInstruction(
             UnifiedBytecodeOpCode.UpdateComputedProperty,
             EncodeUpdateFlags(propertyUpdate)));
+        unified.Clear();
+        unified.AddRange(stagedUnified);
+        literalConstants.Clear();
+        literalConstants.AddRange(stagedLiterals);
         reason = string.Empty;
         return true;
     }

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -3599,24 +3599,35 @@ internal static class UnifiedBytecodeProductionEligibility
         ReadOnlySpan<IdentifierOperand> identifierConstants,
         ActivationSlotShape activationSlots)
     {
-        if (program.OperationCount != 9)
+        if (program.OperationCount < 9)
         {
             return false;
         }
 
-        if (!TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots) ||
-            !IsSimpleComputedPropertyKeyOperand(program.GetOperation(1), identifierConstants, activationSlots))
+        if (!TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
         {
             return false;
         }
 
-        var requireObjectCoercible = program.GetOperation(2);
-        var resolvePropertyKey = program.GetOperation(3);
-        var duplicateTargetAndKey = program.GetOperation(4);
-        var propertyRead = program.GetOperation(5);
-        var rhs = program.GetOperation(6);
-        var binary = program.GetOperation(7);
-        var propertyWrite = program.GetOperation(8);
+        var suffixStart = program.OperationCount - 7;
+        if (suffixStart <= 1 ||
+            !IsSupportedComputedPropertyKeySpan(
+                program,
+                startInclusive: 1,
+                endExclusive: suffixStart,
+                identifierConstants,
+                activationSlots))
+        {
+            return false;
+        }
+
+        var requireObjectCoercible = program.GetOperation(suffixStart);
+        var resolvePropertyKey = program.GetOperation(suffixStart + 1);
+        var duplicateTargetAndKey = program.GetOperation(suffixStart + 2);
+        var propertyRead = program.GetOperation(suffixStart + 3);
+        var rhs = program.GetOperation(suffixStart + 4);
+        var binary = program.GetOperation(suffixStart + 5);
+        var propertyWrite = program.GetOperation(suffixStart + 6);
         return requireObjectCoercible.Kind == ExpressionOpKind.RequireObjectCoercible &&
                requireObjectCoercible.Depth == 1 &&
                resolvePropertyKey.Kind == ExpressionOpKind.ResolvePropertyKey &&
@@ -3709,30 +3720,41 @@ internal static class UnifiedBytecodeProductionEligibility
     {
         // Shape: [base, key, RequireObjectCoercible, ResolvePropertyKey, DuplicateTopTwo, GetComputedProperty,
         // JumpIf*, Pop, rhs, SetComputedProperty, DuplicateTop, DuplicateTop, RotateTopThreeRight, Pop, Pop]
-        if (program.OperationCount != 15)
+        if (program.OperationCount < 15)
         {
             return false;
         }
 
-        if (!TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots) ||
-            !IsSimpleComputedPropertyKeyOperand(program.GetOperation(1), identifierConstants, activationSlots))
+        if (!TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
         {
             return false;
         }
 
-        var requireObjectCoercible = program.GetOperation(2);
-        var resolvePropertyKey = program.GetOperation(3);
-        var duplicateTargetAndKey = program.GetOperation(4);
-        var propertyRead = program.GetOperation(5);
-        var jump = program.GetOperation(6);
-        var pop = program.GetOperation(7);
-        var rhs = program.GetOperation(8);
-        var propertyWrite = program.GetOperation(9);
-        var duplicateAssignedValue = program.GetOperation(10);
-        var duplicateAssignedValueAgain = program.GetOperation(11);
-        var rotateTopThreeRight = program.GetOperation(12);
-        var cleanupPop = program.GetOperation(13);
-        var cleanupPop2 = program.GetOperation(14);
+        var suffixStart = program.OperationCount - 13;
+        if (suffixStart <= 1 ||
+            !IsSupportedComputedPropertyKeySpan(
+                program,
+                startInclusive: 1,
+                endExclusive: suffixStart,
+                identifierConstants,
+                activationSlots))
+        {
+            return false;
+        }
+
+        var requireObjectCoercible = program.GetOperation(suffixStart);
+        var resolvePropertyKey = program.GetOperation(suffixStart + 1);
+        var duplicateTargetAndKey = program.GetOperation(suffixStart + 2);
+        var propertyRead = program.GetOperation(suffixStart + 3);
+        var jump = program.GetOperation(suffixStart + 4);
+        var pop = program.GetOperation(suffixStart + 5);
+        var rhs = program.GetOperation(suffixStart + 6);
+        var propertyWrite = program.GetOperation(suffixStart + 7);
+        var duplicateAssignedValue = program.GetOperation(suffixStart + 8);
+        var duplicateAssignedValueAgain = program.GetOperation(suffixStart + 9);
+        var rotateTopThreeRight = program.GetOperation(suffixStart + 10);
+        var cleanupPop = program.GetOperation(suffixStart + 11);
+        var cleanupPop2 = program.GetOperation(suffixStart + 12);
         return requireObjectCoercible.Kind == ExpressionOpKind.RequireObjectCoercible &&
                requireObjectCoercible.Depth == 1 &&
                resolvePropertyKey.Kind == ExpressionOpKind.ResolvePropertyKey &&
@@ -3749,7 +3771,7 @@ internal static class UnifiedBytecodeProductionEligibility
                rotateTopThreeRight.Kind == ExpressionOpKind.RotateTopThreeRight &&
                cleanupPop.Kind == ExpressionOpKind.Pop &&
                cleanupPop2.Kind == ExpressionOpKind.Pop &&
-               jump.Target == 12;
+               jump.Target == suffixStart + 10;
     }
 
     private static bool TryIsFirstBoundaryPropertyWriteCandidate(
@@ -3873,14 +3895,20 @@ internal static class UnifiedBytecodeProductionEligibility
                    TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots);
         }
 
-        if (program.OperationCount != 3)
+        if (program.OperationCount < 3)
         {
             return false;
         }
 
-        return program.GetOperation(2).Kind == ExpressionOpKind.UpdateComputedProperty &&
+        var propertyUpdateIndex = program.OperationCount - 1;
+        return program.GetOperation(propertyUpdateIndex).Kind == ExpressionOpKind.UpdateComputedProperty &&
                TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots) &&
-               IsSimpleOperand(program.GetOperation(1), identifierConstants, activationSlots);
+               IsSupportedComputedPropertyKeySpan(
+                   program,
+                   startInclusive: 1,
+                   endExclusive: propertyUpdateIndex,
+                   identifierConstants,
+                   activationSlots);
     }
 
     private static bool TryIsFirstBoundaryNestedNamedPropertyUpdateCandidate(

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -1401,6 +1401,30 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
             instruction.OpCode == UnifiedBytecodeOpCode.SetComputedProperty);
     }
 
+    [Fact]
+    public void Evaluate_ComputedCompoundPropertyWriteWithExpressionKey_AcceptsOwnedPropertyOpcodes()
+    {
+        var plan = GetFunctionPlan("""
+            function write(box, key, suffix, value) {
+                return box[key + suffix] += value;
+            }
+            """,
+            "write");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction is { OpCode: UnifiedBytecodeOpCode.Binary, Operand: (int)BinaryOperator.Add });
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.GetComputedPropertyForCompoundSet);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.SetComputedProperty);
+    }
+
     [Theory]
     [MemberData(nameof(CompoundNamedPropertyWriteOperators))]
     public void Evaluate_NamedCompoundPropertyWrite_AcceptsForEachProductionOperator(
@@ -1488,6 +1512,28 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
 
         Assert.True(result.IsEligible, result.Reason);
         Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.UpdateComputedProperty);
+    }
+
+    [Fact]
+    public void Evaluate_ComputedPropertyUpdateWithExpressionKey_AcceptsOwnedPropertyOpcode()
+    {
+        var plan = GetFunctionPlan("""
+            function update(box, key, suffix) {
+                return box[key + suffix]++;
+            }
+            """,
+            "update");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction is { OpCode: UnifiedBytecodeOpCode.Binary, Operand: (int)BinaryOperator.Add });
         Assert.Contains(result.Program.Instructions, instruction =>
             instruction.OpCode == UnifiedBytecodeOpCode.UpdateComputedProperty);
     }
@@ -6086,6 +6132,37 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     [InlineData("&&=", (int)UnifiedBytecodeOpCode.JumpIfShortCircuitFalse)]
     [InlineData("||=", (int)UnifiedBytecodeOpCode.JumpIfShortCircuitTrue)]
     [InlineData("??=", (int)UnifiedBytecodeOpCode.JumpIfShortCircuitNotNullish)]
+    public void Evaluate_ComputedLogicalAssignmentWithExpressionKey_AcceptsWithOwnedOpcodes(
+        string logicalOperator,
+        int expectedJumpOpCode)
+    {
+        var plan = GetFunctionPlan($$"""
+            function logicalComputedWrite(box, key, suffix, value) {
+                return box[key + suffix] {{logicalOperator}} value;
+            }
+            """,
+            "logicalComputedWrite");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction is { OpCode: UnifiedBytecodeOpCode.Binary, Operand: (int)BinaryOperator.Add });
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.GetComputedPropertyForCompoundSet);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == (UnifiedBytecodeOpCode)expectedJumpOpCode);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.SetComputedProperty);
+    }
+
+    [Theory]
+    [InlineData("&&=", (int)UnifiedBytecodeOpCode.JumpIfShortCircuitFalse)]
+    [InlineData("||=", (int)UnifiedBytecodeOpCode.JumpIfShortCircuitTrue)]
+    [InlineData("??=", (int)UnifiedBytecodeOpCode.JumpIfShortCircuitNotNullish)]
     public void Evaluate_NestedNamedLogicalAssignment_AcceptsWithOwnedOpcodes(
         string logicalOperator,
         int expectedJumpOpCode)
@@ -6126,15 +6203,6 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         "Counter",
         "update",
         (int)UnifiedBytecodeProductionDeclineCode.PrivateFieldDependency)]
-    [InlineData(
-        """
-        function logicalAndComputedComplexKeyWrite(box, key, suffix, value) {
-            return box[key + suffix] &&= value;
-        }
-        """,
-        "logicalAndComputedComplexKeyWrite",
-        null,
-        (int)UnifiedBytecodeProductionDeclineCode.PropertyWriteDependency)]
     [InlineData(
         """
         function logicalAndComputedComplexRhsWrite(box, key, value) {

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -4237,6 +4237,82 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task ComputedCompoundPropertyWriteWithExpressionKey_UsesUnifiedBytecodeProductionFastPathAndResolvesKeyOnce()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var events = [];
+            var box = {};
+            Object.defineProperty(box, "value", {
+                get() {
+                    events.push("get");
+                    return 4;
+                },
+                set(value) {
+                    events.push("set:" + value);
+                }
+            });
+            var key = {
+                toString() {
+                    events.push("key");
+                    return "val";
+                }
+            };
+
+            function write(box, key, suffix, value) {
+                return box[key + suffix] += value;
+            }
+
+            String(write(box, key, "ue", 5)) + ":" + events.join(",");
+            """);
+
+        Assert.Equal("9:key,get,set:9", result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=write argc=4",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ComputedPropertyUpdateWithExpressionKey_UsesUnifiedBytecodeProductionFastPathAndResolvesKeyOnce()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var events = [];
+            var store = 4;
+            var box = {};
+            Object.defineProperty(box, "value", {
+                get() {
+                    events.push("get");
+                    return store;
+                },
+                set(value) {
+                    events.push("set:" + value);
+                    store = value;
+                }
+            });
+            var key = {
+                toString() {
+                    events.push("key");
+                    return "val";
+                }
+            };
+
+            function update(box, key, suffix) {
+                return box[key + suffix]++;
+            }
+
+            String(update(box, key, "ue")) + ":" + store + ":" + events.join(",");
+            """);
+
+        Assert.Equal("4:5:key,get,set:5", result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=update argc=3",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task ComputedLogicalPropertyWrite_UsesUnifiedBytecodeProductionFastPathAndPreservesShortCircuitSemantics()
     {
         await using var engine = CreateEngine();
@@ -4270,6 +4346,48 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
         Assert.Contains(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(
                 "unified-bytecode-production-fast-path func=write argc=3",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ComputedLogicalPropertyWriteWithExpressionKey_UsesUnifiedBytecodeProductionFastPathAndPreservesShortCircuitSemantics()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var events = [];
+            function makeBox(initialValue) {
+                var store = initialValue;
+                var box = {};
+                Object.defineProperty(box, "value", {
+                    get() {
+                        events.push("get");
+                        return store;
+                    },
+                    set(value) {
+                        events.push("set:" + value);
+                        store = value;
+                    }
+                });
+                return box;
+            }
+            var key = {
+                toString() {
+                    events.push("key");
+                    return "val";
+                }
+            };
+            function write(box, key, suffix, value) {
+                return box[key + suffix] &&= value;
+            }
+
+            String(write(makeBox(0), key, "ue", 7)) + ":" +
+                String(write(makeBox(1), key, "ue", 7)) + ":" + events.join(",");
+            """);
+
+        Assert.Equal("0:7:key,get,key,get,set:7", result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=write argc=4",
                 StringComparison.Ordinal));
     }
 


### PR DESCRIPTION
## Summary
- Admit direct computed expression-key compound writes, logical writes, and updates through production unified bytecode.
- Reuse supported computed-key spans and staged compiler emission so rejected shapes cannot leave partial unified builders behind.
- Update the expansion contract and durable prototype rule to remove the stale retained-decline wording for these mutation forms.

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests" (650 passed)
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release (0 warnings)
- rtk git diff --check
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner* (no matches)
- rtk ./tools/profile forloop --memory (Total allocated 6.86 MB)