### PR TITLE
Tighten unified opcode inventory audit

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -137,6 +137,13 @@ statement interpretation.
 - `GetComputedPropertyForCompoundSet`
 - `SetNamedProperty`
 - `SetComputedProperty`
+- `EnsureSuperReference`
+- `GetNamedSuperProperty`
+- `GetComputedSuperProperty`
+- `SetNamedSuperProperty`
+- `SetComputedSuperProperty`
+- `UpdateNamedSuperProperty`
+- `UpdateComputedSuperProperty`
 - `UpdateNamedProperty`
 - `UpdateComputedProperty`
 - `UpdateDynamicIdentifier`
@@ -225,6 +232,7 @@ statement interpretation.
 - `YieldStar`
 - `LoadClassLiteral`
 - `ApplyBindingTarget`
+- `ApplyDeclarationBindingTarget`
 - `EnsureHasName`
 
 ### Production Decline Families (current)

--- a/tests/Asynkron.JsEngine.Tests/ExpressionProgramCoverageMapTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/ExpressionProgramCoverageMapTests.cs
@@ -133,6 +133,14 @@ public sealed class ExpressionProgramCoverageMapTests
             Assert.Contains($"`{opcodeName}`", contractText, StringComparison.Ordinal);
         }
 
+        var documentedOpcodeNames = ExtractBacktickedBulletItemsUnderHeading(
+            contractText,
+            "### Unified Opcode Inventory (current)");
+        AssertSameSet(
+            Enum.GetNames<UnifiedBytecodeOpCode>(),
+            documentedOpcodeNames,
+            "Unified opcode inventory");
+
         var declineCodeNames = Enum.GetNames<UnifiedBytecodeProductionDeclineCode>();
         foreach (var declineCodeName in declineCodeNames)
         {


### PR DESCRIPTION
## Summary
- Add missing current unified opcodes to the contract's opcode inventory section.
- Tighten the contract drift guard so the inventory section itself must match UnifiedBytecodeOpCode exactly.

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeVirtualMachine_HandlesEveryDeclaredOpcode|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeCompiler_HandlesEveryDeclaredInstructionExceptDocumentedDeclines|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeCompiler_AccountsForEveryExpressionOpKind" (4 passed; existing nullable warnings in unrelated tests)
- rtk git diff --check
- manual enum-vs-inventory comm check produced no missing or unexpected opcode rows