### PR TITLE
Close stale unified bytecode lowering gates

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -86,6 +86,11 @@ statement interpretation.
   are admitted only through narrow shape helpers, while private property
   reads/writes/updates, generic call-target stack shuffles, and
   some call/reference helpers remain outside general unified bytecode lowering.
+- The remaining direct general-expression lowering gaps are drift-checked under
+  `### General Expression Lowering Gaps (current)`. Property set/update
+  operations and `SwapTopTwo` are no longer helper-only compiler shapes; they
+  lower through the general expression loop, subject to the same private-name and
+  name-inference semantic guards as the owned property-write helpers.
 - The current `ExpressionOpKind` names with no unified compiler reference list is
   empty. Computed super-property operations also route their required
   `EnsureSuperReference` op through the general unified expression loop.
@@ -94,10 +99,11 @@ statement interpretation.
   and activation-resolved `UpdateIdentifier`, while dynamic/with-backed updates
   continue to use `UpdateDynamicIdentifier`.
 - Resumable async/generator unified bytecode is narrower than ordinary sync
-  production bytecode. `EvaluateResumable` currently admits only a small
-  instruction and opcode subset; broad async/generator control flow, calls,
-  dynamic lookup, arguments, awaited iterator sources, and async-generator
-  delegated yield shapes still decline.
+  production bytecode. The resumable eligibility opcode allow-list is now
+  audited against the `ExecuteResumable` switch, so opcodes already implemented
+  by the resumable VM cannot remain stale declines. Broad async/generator
+  control flow, calls, dynamic lookup, arguments, awaited iterator sources, and
+  async-generator delegated yield shapes still decline.
 - `ApplyBindingTarget` is the one explicit bridge inside accepted VM execution:
   the VM owns dispatch and stack/slot state, then applies an already-lowered
   `BindingTargetProgram` for assignment destructuring parity. This is not a
@@ -348,6 +354,17 @@ the final post-compile production subset check before VM entry.
 - Unary, binary, and conversion operations
 - Control flow, stack mechanics, and invocation
 - Stateful iterator, for-in, and array destructuring driver operations
+
+### General Expression Lowering Gaps (current)
+- `Call`
+- `DuplicateTopTwo`
+- `JumpIfShortCircuited`
+- `LoadComputedCallTarget`
+- `LoadComputedSuperCallTarget`
+- `LoadIdentifierCallTarget`
+- `LoadNamedCallTarget`
+- `LoadNamedSuperCallTarget`
+- `RotateTopThreeRight`
 
 ## Production This-Binding Boundary
 - Ordinary sync functions that reference `this` are admitted to the production

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -4123,6 +4123,10 @@ internal static class UnifiedBytecodeCompiler
                     unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.DuplicateTop));
                     break;
 
+                case ExpressionOpKind.SwapTopTwo:
+                    unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.SwapTopTwo));
+                    break;
+
                 case ExpressionOpKind.ApplyBindingTarget:
                     if (bindingTargetConstants is null)
                     {
@@ -4170,6 +4174,58 @@ internal static class UnifiedBytecodeCompiler
                     unified.Add(new UnifiedBytecodeInstruction(
                         UnifiedBytecodeOpCode.UpdateDynamicIdentifier,
                         EncodeUpdateOperand(updateNameIndex, operation)));
+                    break;
+
+                case ExpressionOpKind.SetNamedProperty:
+                    var setNamedPropertyName = operation.GetString(expressionProgram.StringConstants.AsSpan());
+                    if (setNamedPropertyName.IsPrivateName())
+                    {
+                        reason = "Private named property writes are not supported in the general expression loop.";
+                        return false;
+                    }
+
+                    if (operation.AllowNameInference)
+                    {
+                        reason = "Property writes with name inference are not supported in the general expression loop.";
+                        return false;
+                    }
+
+                    var setNamedPropertyIndex = stringConstants.Count;
+                    stringConstants.Add(setNamedPropertyName);
+                    unified.Add(new UnifiedBytecodeInstruction(
+                        UnifiedBytecodeOpCode.SetNamedProperty,
+                        setNamedPropertyIndex));
+                    break;
+
+                case ExpressionOpKind.SetComputedProperty:
+                    if (operation.AllowNameInference)
+                    {
+                        reason = "Computed property writes with name inference are not supported in the general expression loop.";
+                        return false;
+                    }
+
+                    unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.SetComputedProperty));
+                    break;
+
+                case ExpressionOpKind.UpdateNamedProperty:
+                    var updateNamedPropertyName = operation.GetString(expressionProgram.StringConstants.AsSpan());
+                    if (updateNamedPropertyName.IsPrivateName())
+                    {
+                        reason = "Private named property updates are not supported in the general expression loop.";
+                        return false;
+                    }
+
+                    var updateNamedPropertyIndex = stringConstants.Count;
+                    stringConstants.Add(updateNamedPropertyName);
+                    unified.Add(new UnifiedBytecodeInstruction(
+                        UnifiedBytecodeOpCode.UpdateNamedProperty,
+                        EncodeUpdateOperand(updateNamedPropertyIndex, operation)));
+                    break;
+
+                case ExpressionOpKind.UpdateComputedProperty:
+                    unified.Add(new UnifiedBytecodeInstruction(
+                        UnifiedBytecodeOpCode.UpdateComputedProperty,
+                        EncodeUpdateFlags(operation)));
                     break;
 
                 case ExpressionOpKind.SetNamedSuperProperty:

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -601,8 +601,12 @@ internal static class UnifiedBytecodeProductionEligibility
                 UnifiedBytecodeOpCode.Binary or
                 UnifiedBytecodeOpCode.Pop or
                 UnifiedBytecodeOpCode.DuplicateTop or
+                UnifiedBytecodeOpCode.SwapTopTwo or
                 UnifiedBytecodeOpCode.Jump or
                 UnifiedBytecodeOpCode.JumpIfFalse or
+                UnifiedBytecodeOpCode.JumpIfShortCircuitFalse or
+                UnifiedBytecodeOpCode.JumpIfShortCircuitTrue or
+                UnifiedBytecodeOpCode.JumpIfShortCircuitNotNullish or
                 UnifiedBytecodeOpCode.Return or
                 UnifiedBytecodeOpCode.ReturnUndefined or
                 UnifiedBytecodeOpCode.Throw or

--- a/tests/Asynkron.JsEngine.Tests/ExpressionProgramCoverageMapTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/ExpressionProgramCoverageMapTests.cs
@@ -54,6 +54,19 @@ public sealed class ExpressionProgramCoverageMapTests
     [
     ];
 
+    private static readonly string[] UnifiedBytecodeExpressionOpGeneralLoopGapNames =
+    [
+        "Call",
+        "DuplicateTopTwo",
+        "JumpIfShortCircuited",
+        "LoadComputedCallTarget",
+        "LoadComputedSuperCallTarget",
+        "LoadIdentifierCallTarget",
+        "LoadNamedCallTarget",
+        "LoadNamedSuperCallTarget",
+        "RotateTopThreeRight"
+    ];
+
     private sealed record ProductionUnifiedBytecodeProofPackShape(
         string Key,
         string ContractEvidenceText,
@@ -269,6 +282,90 @@ public sealed class ExpressionProgramCoverageMapTests
     }
 
     [Fact]
+    public void UnifiedBytecodeCompiler_GeneralExpressionLoopDeclinesOnlyDocumentedGaps()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var expressionOpPath = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Asynkron.JsEngine",
+            "Execution",
+            "Instructions",
+            "ExpressionOp.cs");
+        var compilerPath = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Asynkron.JsEngine",
+            "Execution",
+            "UnifiedBytecode",
+            "UnifiedBytecodeCompiler.cs");
+        var contractPath = Path.Combine(repositoryRoot.FullName, "docs", "unified-bytecode-expansion-contract.md");
+        Assert.True(File.Exists(expressionOpPath), $"Expected expression op source at '{expressionOpPath}'.");
+        Assert.True(File.Exists(compilerPath), $"Expected compiler source at '{compilerPath}'.");
+        Assert.True(File.Exists(contractPath), $"Expected contract doc at '{contractPath}'.");
+
+        var expressionOpText = File.ReadAllText(expressionOpPath);
+        var compilerText = File.ReadAllText(compilerPath);
+        var contractText = File.ReadAllText(contractPath);
+        var declaredOpKinds = ExtractEnumMemberNames(expressionOpText, "ExpressionOpKind");
+        var generalLoopText = ExtractSourceSection(
+            compilerText,
+            "private static bool TryAppendExpressionProgramOps(",
+            "private static bool TryAppendFirstBoundaryCallTargetPreparation(");
+        var generalLoopCases = ExtractExpressionOpKindCases(generalLoopText);
+        var generalLoopGaps = declaredOpKinds.Except(generalLoopCases, StringComparer.Ordinal);
+        var documentedGeneralLoopGaps = ExtractBacktickedBulletItemsUnderHeading(
+            contractText,
+            "### General Expression Lowering Gaps (current)");
+
+        AssertSameSet(
+            UnifiedBytecodeExpressionOpGeneralLoopGapNames,
+            generalLoopGaps,
+            "Expression op kinds without direct general unified expression-loop cases");
+        AssertSameSet(
+            UnifiedBytecodeExpressionOpGeneralLoopGapNames,
+            documentedGeneralLoopGaps,
+            "Documented general expression lowering gaps");
+    }
+
+    [Fact]
+    public void UnifiedBytecodeResumableEligibility_AllowsEveryResumableVmOpcode()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var eligibilityPath = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Asynkron.JsEngine",
+            "Execution",
+            "UnifiedBytecode",
+            "UnifiedBytecodeProductionEligibility.cs");
+        var virtualMachinePath = Path.Combine(
+            repositoryRoot.FullName,
+            "src",
+            "Asynkron.JsEngine",
+            "Execution",
+            "UnifiedBytecode",
+            "UnifiedBytecodeVirtualMachine.cs");
+        Assert.True(File.Exists(eligibilityPath), $"Expected eligibility source at '{eligibilityPath}'.");
+        Assert.True(File.Exists(virtualMachinePath), $"Expected VM source at '{virtualMachinePath}'.");
+
+        var eligibilityText = File.ReadAllText(eligibilityPath);
+        var virtualMachineText = File.ReadAllText(virtualMachinePath);
+        var resumableAllowListText = ExtractSourceSection(
+            eligibilityText,
+            "private static bool TryFindUnsupportedResumableOpcode(",
+            "private static bool TryFindInstructionDynamicIdentifierDecline(");
+        var executeResumableText = ExtractSourceSection(
+            virtualMachineText,
+            "public static UnifiedBytecodeStepResult ExecuteResumable(",
+            "private static bool TryConsumePendingAwaitResume(");
+        var allowListOpcodes = ExtractUnifiedBytecodeOpcodeReferences(resumableAllowListText);
+        var resumableVmOpcodes = ExtractUnifiedBytecodeOpcodeCases(executeResumableText);
+
+        AssertSameSet(resumableVmOpcodes, allowListOpcodes, "Resumable unified bytecode opcode allow-list");
+    }
+
+    [Fact]
     public void UnifiedBytecodeProductionProofPack_CoversAdmittedOrdinarySyncBaseline()
     {
         var repositoryRoot = FindRepositoryRoot();
@@ -385,6 +482,26 @@ public sealed class ExpressionProgramCoverageMapTests
             .ToArray();
     }
 
+    private static string[] ExtractExpressionOpKindCases(string sourceText)
+    {
+        return Regex.Matches(
+                sourceText,
+                @"\bcase\s+ExpressionOpKind\.(?<name>[A-Za-z0-9_]+)\b",
+                RegexOptions.CultureInvariant)
+            .Select(match => match.Groups["name"].Value)
+            .ToArray();
+    }
+
+    private static string[] ExtractUnifiedBytecodeOpcodeReferences(string sourceText)
+    {
+        return Regex.Matches(
+                sourceText,
+                @"\bUnifiedBytecodeOpCode\.(?<name>[A-Za-z0-9_]+)\b",
+                RegexOptions.CultureInvariant)
+            .Select(match => match.Groups["name"].Value)
+            .ToArray();
+    }
+
     private static string[] ExtractUnifiedBytecodeOpcodeCases(string sourceText)
     {
         return Regex.Matches(
@@ -397,10 +514,13 @@ public sealed class ExpressionProgramCoverageMapTests
 
     private static string[] ExtractBacktickedBulletItemsUnderHeading(string documentText, string heading)
     {
-        var headingIndex = documentText.IndexOf(heading, StringComparison.Ordinal);
-        Assert.True(headingIndex >= 0, $"Contract document is missing heading '{heading}'.");
+        var headingMatch = Regex.Match(
+            documentText,
+            $"^{Regex.Escape(heading)}\\s*$",
+            RegexOptions.Multiline | RegexOptions.CultureInvariant);
+        Assert.True(headingMatch.Success, $"Contract document is missing heading '{heading}'.");
 
-        var sectionStart = documentText.IndexOf('\n', headingIndex);
+        var sectionStart = documentText.IndexOf('\n', headingMatch.Index + headingMatch.Length);
         Assert.True(sectionStart >= 0, $"Contract document heading '{heading}' has no content.");
         sectionStart++;
 

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -152,6 +152,32 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
             static instruction => instruction.OpCode == UnifiedBytecodeOpCode.YieldStar);
     }
 
+    [Theory]
+    [InlineData("&&", (int)UnifiedBytecodeOpCode.JumpIfShortCircuitFalse)]
+    [InlineData("||", (int)UnifiedBytecodeOpCode.JumpIfShortCircuitTrue)]
+    [InlineData("??", (int)UnifiedBytecodeOpCode.JumpIfShortCircuitNotNullish)]
+    public void EvaluateResumable_ShortCircuitReturnExpression_AcceptsImplementedVmOpcodes(
+        string operatorText,
+        int expectedOpcode)
+    {
+        var plan = GetFunctionPlan($$"""
+            function* gen(left, right) {
+                return left {{operatorText}} right;
+            }
+            """,
+            "gen");
+
+        var result = UnifiedBytecodeProductionEligibility.EvaluateResumable(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor(IsGenerator: true));
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(
+            result.Program.Instructions,
+            instruction => instruction.OpCode == (UnifiedBytecodeOpCode)expectedOpcode);
+    }
+
     [Fact]
     public void EvaluateResumable_AsyncLikeGeneratorActivation_DeclinesBeforeExecution()
     {


### PR DESCRIPTION
## Summary
- lower VM-owned property set/update ops and SwapTopTwo through the general expression loop
- align resumable eligibility with the opcodes ExecuteResumable already implements
- add drift audits for general expression lowering gaps and resumable opcode allow-list coverage

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~ExpressionProgramCoverageMapTests|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.EvaluateResumable_ShortCircuitReturnExpression_AcceptsImplementedVmOpcodes'
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~ExpressionProgramCoverageMapTests'
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionInvocationTests'
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release
- rtk git diff --check
- rtk rg 'EvaluateExpression\(|ProfileEvaluateExpression\(' src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk ./tools/profile forloop --memory