### PR TITLE
Route simple arrows through unified bytecode

### DIFF
--- a/docs/rules/unified-bytecode-prototypes.md
+++ b/docs/rules/unified-bytecode-prototypes.md
@@ -129,6 +129,14 @@ all-or-nothing until a separate routing issue proves production readiness.
      invocation descriptor, expression selector, and compiler in agreement so a
      name-only `operation.IsArguments` check cannot block shadowed bindings or
      accidentally admit the real arguments object.
+10c. When admitting arrow functions to production unified bytecode, reuse the
+     lowered-plan dependency proof used by simple IR activation. Only arrows
+     whose simple return program contains no lexical `this`, `new.target`, or
+     super operation, no closure-variable or dynamic identifier dependency, and
+     no nested function/class literal may clear the arrow and captured-activation
+     blockers. Dependency-bearing arrows, parameter expressions, non-simple
+     parameters, private scopes, and dynamic lookup stay on existing routes until
+     the VM and invocation bridge own those semantics directly.
 11. When updating docs, ADRs, roadmap text, or evidence reports for unified
     bytecode production routing, treat ADR 0253 as the current loop-control
     production widening layered on ADR 0210, and keep ADR 0204/#2227

--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -320,7 +320,7 @@ not always have a `UnifiedBytecodeProductionDeclineCode`.
 | Pre-gate key | Owning source / current example | Current fallback route | Planned batch / lane | Proof command |
 |---|---|---|---|---|
 | `pre-gate:IsClassConstructor` | Class constructor invokers outside the admitted simple base constructor route and explicit derived-constructor `super(...)` route without `this` body reads/writes | Constructor route | Constructor boundary lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
-| `pre-gate:IsArrowFunction` | Arrow functions, especially lexical `this` / `new.target` shapes | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
+| `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no lexical `this`, `new.target`, super, closure-variable, or dynamic-identifier dependency | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:IsAsyncLike` | Async and formerly-async ordinary invokers | Async route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_AsyncLikeActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:IsGenerator` | Generator functions before ordinary sync production routing | Generator route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_GeneratorActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:IsDefaultDerivedConstructor` | Default derived class constructor setup | Constructor route | Constructor boundary lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
@@ -426,7 +426,10 @@ the final post-compile production subset check before VM entry.
 - Sloppy-mode `this` coercion is handled before VM entry: `boundThis` is
   computed via `CoerceThisValueForNonStrict` in `TryInvokeProductionUnifiedBytecode`,
   so the VM's `LoadThis` opcode always receives the correctly coerced value.
-- Arrow functions still decline via the `IsArrowFunction` and
+- Simple-return arrow functions whose lowered body has no lexical `this`,
+  `new.target`, super, closure-variable, dynamic-identifier, or nested
+  function/class literal dependency may route. Dependency-bearing arrows still
+  decline via the `IsArrowFunction`, captured-activation, or
   `_lexicalThisEnvironment is not null` pre-gates.
 - There is no retained `this` decline in the production activation descriptor;
   future shapes that cannot thread `this` through the VM should introduce a
@@ -729,8 +732,9 @@ support today.
 ## Ranked Next Unsupported Buckets (current boundary)
 1. Activation model gaps are still larger than any single expression-family
    neighbor. Ordinary sync production routing still pre-gates async-like
-   functions, generators, arrows with lexical `this` / `new.target`, real
-   `arguments` object and sloppy mapped-arguments dependencies, non-simple
+   functions, generators, arrows with lexical `this` / `new.target`, closure or
+   dynamic identifier dependencies, or non-simple bodies, real `arguments`
+   object and sloppy mapped-arguments dependencies, non-simple
    parameter lists, default/rest/destructured parameter expressions, broader
    class constructor routes beyond simple base constructors and the bounded
    explicit derived `super(...)` path, default derived constructors, instance fields,

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -3249,9 +3249,9 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
             var result = UnifiedBytecodeProductionEligibility.Evaluate(
                 plan,
                 CreateProductionUnifiedBytecodeActivationDescriptor(
-                    newTarget,
                     CanUseProductionUnifiedBytecodeDynamicNameFastPath(),
                     CanUseProductionUnifiedBytecodeOrdinaryDynamicNameFastPath(plan),
+                    CanUseProductionUnifiedBytecodeArrowFunctionActivation(plan, newTarget),
                     CanUseProductionUnifiedBytecodeDerivedClassConstructorActivation(plan, newTarget),
                     CanUseProductionUnifiedBytecodeBaseClassConstructorActivation(plan, newTarget)));
 
@@ -3297,14 +3297,15 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
         {
             var canUseDynamicNamePath = CanUseProductionUnifiedBytecodeDynamicNameFastPath();
             var canUseOrdinaryDynamicNamePath = CanUseProductionUnifiedBytecodeOrdinaryDynamicNameFastPath(plan);
+            var canUseArrowFunctionPath = CanUseProductionUnifiedBytecodeArrowFunctionActivation(plan, newTarget);
             var canUseDerivedClassConstructorPath =
                 CanUseProductionUnifiedBytecodeDerivedClassConstructorActivation(plan, newTarget);
             var canUseBaseClassConstructorPath =
                 CanUseProductionUnifiedBytecodeBaseClassConstructorActivation(plan, newTarget);
             var activation = CreateProductionUnifiedBytecodeActivationDescriptor(
-                newTarget,
                 canUseDynamicNamePath,
                 canUseOrdinaryDynamicNamePath,
+                canUseArrowFunctionPath,
                 canUseDerivedClassConstructorPath,
                 canUseBaseClassConstructorPath);
             if (UnifiedBytecodeProductionEligibility.TryFindOrdinarySyncActivationDecline(
@@ -3330,15 +3331,15 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
         {
             var canUseDynamicNamePath = CanUseProductionUnifiedBytecodeDynamicNameFastPath();
             return CreateProductionUnifiedBytecodeActivationDescriptor(
-                JsValue.Undefined,
                 canUseDynamicNamePath,
-                canUseOrdinaryDynamicNamePath: false);
+                canUseOrdinaryDynamicNamePath: false,
+                canUseArrowFunctionPath: false);
         }
 
         private UnifiedBytecodeProductionActivationDescriptor CreateProductionUnifiedBytecodeActivationDescriptor(
-            JsValue newTarget,
             bool canUseDynamicNamePath,
             bool canUseOrdinaryDynamicNamePath,
+            bool canUseArrowFunctionPath = false,
             bool canUseDerivedClassConstructorPath = false,
             bool canUseBaseClassConstructorPath = false)
         {
@@ -3350,13 +3351,15 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                 IsAsyncLike: IsAsyncLike,
                 IsGenerator: _function.IsGenerator,
                 HasCapturedOrDynamicActivation:
-                    _hasCapturedActivationInClosure || _hasClosureWithObject && !canUseDynamicNamePath ||
+                    _hasCapturedActivationInClosure && !canUseArrowFunctionPath ||
+                    _hasClosureWithObject && !canUseDynamicNamePath ||
                     hasUnprovenDynamicActivation,
                 HasArgumentsObjectDependency:
                     !_hasDirectEvalInBodyOrParameters &&
                     _argumentsObjectNeeded &&
                     (_usesArguments || _needsArgumentsBinding && !canUseDynamicNamePath),
-                HasArrowLexicalThisDependency: IsArrowFunction || _lexicalThisEnvironment is not null,
+                HasArrowLexicalThisDependency:
+                    IsArrowFunction && !canUseArrowFunctionPath || _lexicalThisEnvironment is not null,
                 HasClassConstructorActivation:
                     IsClassConstructor && !canUseDerivedClassConstructorPath && !canUseBaseClassConstructorPath,
                 HasCallDependency: false,
@@ -3579,6 +3582,97 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                    _instanceFields.IsDefaultOrEmpty &&
                    (_superConstructor is not null || _superPrototype is not null) &&
                    CanUseProductionUnifiedBytecodeDerivedClassConstructorPlanShape(plan);
+        }
+
+        private bool CanUseProductionUnifiedBytecodeArrowFunctionActivation(
+            ExecutionPlan plan,
+            JsValue newTarget)
+        {
+            return IsArrowFunction &&
+                   newTarget.IsUndefined &&
+                   !IsClassConstructor &&
+                   !IsAsyncLike &&
+                   !_function.IsGenerator &&
+                   !_function.IsDefaultDerivedConstructor &&
+                   !_hasParameterExpressions &&
+                   _hasOnlySimpleIdentifierParameters &&
+                   !_usesArguments &&
+                   !_needsArgumentsBinding &&
+                   _allowIdentifierCache &&
+                   _lexicalThisEnvironment is null &&
+                   _homeObject is null &&
+                   PrivateNameScope is null &&
+                   _capturedPrivateNameScopes.IsDefaultOrEmpty &&
+                   _superConstructor is null &&
+                   _superPrototype is null &&
+                   _instanceFields.IsDefaultOrEmpty &&
+                   CanUseSimpleIrActivationArrowFastPath(plan) &&
+                   CanUseProductionUnifiedBytecodeArrowActivationDependencyPath(plan) &&
+                   CanUseSimpleIrActivationPlanShape(plan);
+        }
+
+        private static bool CanUseProductionUnifiedBytecodeArrowActivationDependencyPath(ExecutionPlan plan)
+        {
+            if (plan.ActivationSlots is not { } activationSlots ||
+                plan.SimpleReturnProgram is not { } returnProgram)
+            {
+                return false;
+            }
+
+            var identifierConstants = returnProgram.IdentifierConstants.AsSpan();
+            for (var i = 0; i < returnProgram.OperationCount; i++)
+            {
+                var operation = returnProgram.GetOperation(i);
+                if (operation.Kind is ExpressionOpKind.LoadFunctionLiteral or ExpressionOpKind.LoadClassLiteral)
+                {
+                    return false;
+                }
+
+                if (TryGetIdentifierDependency(operation, identifierConstants, out var identifier) &&
+                    !ResolvesToOwnActivationSlot(identifier, activationSlots))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool TryGetIdentifierDependency(
+            PackedExpressionOp operation,
+            ReadOnlySpan<IdentifierOperand> identifierConstants,
+            out IdentifierOperand identifier)
+        {
+            switch (operation.Kind)
+            {
+                case ExpressionOpKind.LoadIdentifier:
+                case ExpressionOpKind.LoadIdentifierCallTarget:
+                case ExpressionOpKind.ResolveIdentifierReference:
+                case ExpressionOpKind.StoreResolvedIdentifier:
+                case ExpressionOpKind.StoreIdentifier:
+                case ExpressionOpKind.UpdateIdentifier:
+                case ExpressionOpKind.TypeOfIdentifier:
+                case ExpressionOpKind.DeleteIdentifier:
+                    identifier = operation.GetIdentifier(identifierConstants);
+                    return true;
+                default:
+                    identifier = default;
+                    return false;
+            }
+        }
+
+        private static bool ResolvesToOwnActivationSlot(
+            IdentifierOperand identifier,
+            ActivationSlotShape activationSlots)
+        {
+            if (identifier.ScopeId >= 0)
+            {
+                return identifier.ScopeId == activationSlots.ScopeId &&
+                       identifier.SlotIndex >= 0;
+            }
+
+            return identifier.FlatSlotId < 0 &&
+                   activationSlots.SlotMap.ContainsKey(identifier.Name);
         }
 
         private bool CanUseProductionUnifiedBytecodeBaseClassConstructorActivation(

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -5860,6 +5860,39 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task SimpleArrowFunction_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var choose = (x) => x < 42 ? 42 : x;
+            choose(1);
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                UnifiedBytecodeProductionFastPathLog,
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ArrowFunction_LexicalThis_DeclinesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            this.marker = 42;
+            var readThis = () => this.marker;
+            readThis();
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=readThis",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task ArrowFunction_CapturedThis_DeclinesUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit simple-return arrow functions to the production unified-bytecode route when lowered-plan dependency proof shows no lexical this/new.target/super, closure/global/dynamic identifier, or nested function/class dependency
- keep dependency-bearing arrows on the existing declined routes and document the narrowed arrow contract
- add invocation proofs for admitted simple arrows and lexical-this/closure-dependent declines

## Verification
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.SimpleArrowFunction_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ArrowFunction_LexicalThis_DeclinesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ArrowFunction_CapturedThis_DeclinesUnifiedBytecodeProductionFastPath'
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~ExpressionProgramCoverageMapTests'
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~ActivationSemanticsProofPackTests'
- rtk rg 'EvaluateExpression\(|ProfileEvaluateExpression\(' src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk ./tools/profile forloop --memory
- rtk git diff --check

Notes: dotnet format --verify-no-changes still reports pre-existing SyncFunctionInvoker diagnostics at lines 1741, 2965, and 3963; the RCS1163 introduced by this slice was removed.