### PR TITLE
Route lexical arrow bindings through unified bytecode

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -117,6 +117,10 @@ statement interpretation.
   scopes into the VM, so `#name in receiver` can execute through
   `PrivateFieldIn`. Private member reads/writes/updates and private
   named-property operations still decline as `PrivateFieldDependency`.
+- Simple-return arrows can route with captured lexical `this` / `new.target`
+  values. The production invocation bridge resolves those captured values before
+  entering the VM and avoids sloppy-call `this` coercion for arrows. Arrows that
+  need a lexical-this environment or super binding still decline.
 - Resumable async/generator unified bytecode is narrower than ordinary sync
   production bytecode. The resumable eligibility opcode allow-list is now
   audited against the `ExecuteResumable` switch, so opcodes already implemented
@@ -338,7 +342,7 @@ not always have a `UnifiedBytecodeProductionDeclineCode`.
 | Pre-gate key | Owning source / current example | Current fallback route | Planned batch / lane | Proof command |
 |---|---|---|---|---|
 | `pre-gate:IsClassConstructor` | Class constructor invokers outside the admitted simple base constructor route and explicit derived-constructor `super(...)` route without `this` body reads/writes | Constructor route | Constructor boundary lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
-| `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no lexical `this`, `new.target`, super, closure-variable, or dynamic-identifier dependency | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
+| `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no super, closure-variable, or dynamic-identifier dependency. Captured lexical `this` / `new.target` values are VM-owned; lexical-this environments remain a separate pre-gate. | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:IsAsyncLike` | Async and formerly-async ordinary invokers | Async route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_AsyncLikeActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:IsGenerator` | Generator functions before ordinary sync production routing | Generator route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_GeneratorActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:IsDefaultDerivedConstructor` | Default derived class constructor setup | Constructor route | Constructor boundary lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
@@ -748,9 +752,9 @@ support today.
 ## Ranked Next Unsupported Buckets (current boundary)
 1. Activation model gaps are still larger than any single expression-family
    neighbor. Ordinary sync production routing still pre-gates async-like
-   functions, generators, arrows with lexical `this` / `new.target`, closure or
-   dynamic identifier dependencies, or non-simple bodies, real `arguments`
-   object and sloppy mapped-arguments dependencies, non-simple
+   functions, generators, arrows needing lexical-this environments or super
+   bindings, closure or dynamic identifier dependencies, or non-simple bodies,
+   real `arguments` object and sloppy mapped-arguments dependencies, non-simple
    parameter lists, default/rest/destructured parameter expressions, broader
    class constructor routes beyond simple base constructors and the bounded
    explicit derived `super(...)` path, default derived constructors, instance

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -3067,13 +3067,30 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
             try
             {
                 var vmThisValue = thisValue;
+                var vmNewTarget = newTarget;
+                if (IsArrowFunction)
+                {
+                    var lexicalThis = _lexicalThis;
+                    if (_lexicalThisEnvironment is not null &&
+                        _lexicalThisEnvironment.TryFindBindingJsValue(Symbol.This, true, out _, out var envThis))
+                    {
+                        lexicalThis = envThis;
+                    }
+
+                    vmThisValue = lexicalThis.IsUninitialized ? JsValue.Undefined : lexicalThis;
+                    if (vmNewTarget.IsUndefined && !_lexicalNewTarget.IsUndefined)
+                    {
+                        vmNewTarget = _lexicalNewTarget;
+                    }
+                }
+
                 if (IsClassConstructor && !_isDerivedClassConstructor)
                 {
-                    if (thisValue.IsUndefined)
+                    if (vmThisValue.IsUndefined)
                     {
-                        vmThisValue = JsValue.FromObjectUnsafe(CreateConstructedThis(newTarget, RealmState));
+                        vmThisValue = JsValue.FromObjectUnsafe(CreateConstructedThis(vmNewTarget, RealmState));
                     }
-                    else if (!thisValue.IsObject)
+                    else if (!vmThisValue.IsObject)
                     {
                         return false;
                     }
@@ -3085,19 +3102,21 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                 slots.Fill(JsValue.Undefined);
                 InitializeProductionUnifiedBytecodeLexicalSlots(slots, program);
                 PopulateProductionUnifiedBytecodeParameterSlots(arguments, slots, program);
-                var boundThis = _isStrict ? vmThisValue : CoerceThisValueForNonStrict(vmThisValue);
+                var boundThis = IsArrowFunction || _isStrict
+                    ? vmThisValue
+                    : CoerceThisValueForNonStrict(vmThisValue);
                 if (IsClassConstructor && !_isDerivedClassConstructor)
                 {
                     executionEnvironment = CreateSimpleBaseClassConstructorEnvironment(
                         arguments,
                         vmThisValue,
-                        newTarget,
+                        vmNewTarget,
                         plan);
                 }
                 else if (_hasFunctionDeclarations || RequiresProductionUnifiedBytecodeCallEnvironment(program))
                 {
                     executionEnvironment = IsClassConstructor && _isDerivedClassConstructor
-                        ? CreateSimpleDerivedClassConstructorEnvironment(arguments, newTarget, plan)
+                        ? CreateSimpleDerivedClassConstructorEnvironment(arguments, vmNewTarget, plan)
                         : CreateSimpleIrActivationEnvironment(arguments, vmThisValue, plan, context);
                 }
 
@@ -3118,7 +3137,7 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                     context,
                     executionEnvironment,
                     boundThis,
-                    newTarget,
+                    vmNewTarget,
                     _isStrict);
                 CompleteProductionUnifiedBytecodeClassConstructorResult(
                     executionEnvironment,
@@ -3610,9 +3629,15 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                    _superConstructor is null &&
                    _superPrototype is null &&
                    _instanceFields.IsDefaultOrEmpty &&
-                   CanUseSimpleIrActivationArrowFastPath(plan) &&
+                   CanUseProductionUnifiedBytecodeArrowProgramShape(plan) &&
                    CanUseProductionUnifiedBytecodeArrowActivationDependencyPath(plan) &&
                    CanUseSimpleIrActivationPlanShape(plan);
+        }
+
+        private static bool CanUseProductionUnifiedBytecodeArrowProgramShape(ExecutionPlan plan)
+        {
+            return plan.SimpleReturnProgram is { } returnProgram &&
+                   !ContainsSuperOperation(returnProgram);
         }
 
         private static bool CanUseProductionUnifiedBytecodeArrowActivationDependencyPath(ExecutionPlan plan)

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -5902,7 +5902,7 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
         Assert.Equal(42d, result);
         Assert.Contains(CurrentLogger!.Collector.Snapshot(),
             record => record.Message.Contains(
-                UnifiedBytecodeProductionFastPathLog,
+                "unified-bytecode-production-fast-path func=<anonymous>",
                 StringComparison.Ordinal));
     }
 
@@ -5949,19 +5949,42 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
-    public async Task ArrowFunction_LexicalThis_DeclinesUnifiedBytecodeProductionFastPath()
+    public async Task ArrowFunction_LexicalThis_UsesUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();
         var result = await engine.Evaluate("""
-            this.marker = 42;
-            var readThis = () => this.marker;
-            readThis();
+            function outer() {
+                var readThis = () => this.marker;
+                return readThis.call({ marker: 0 });
+            }
+
+            outer.call({ marker: 42 });
             """);
 
         Assert.Equal(42d, result);
-        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
             record => record.Message.Contains(
-                "unified-bytecode-production-fast-path func=readThis",
+                UnifiedBytecodeProductionFastPathLog,
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ArrowFunction_LexicalNewTarget_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function outer() {
+                var readNewTarget = () => typeof new.target;
+                this.kind = readNewTarget();
+            }
+
+            new outer().kind;
+            """);
+
+        Assert.Equal("function", result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous>",
                 StringComparison.Ordinal));
     }
 


### PR DESCRIPTION
## Summary
- pass captured lexical this/new.target values into production unified-bytecode VM entry for arrows
- widen simple-return arrow admission to allow LoadThis/LoadNewTarget while still declining super/environment-backed arrows
- add invocation coverage for lexical this/new.target arrows and update the expansion contract

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ArrowFunction_LexicalThis_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ArrowFunction_LexicalNewTarget_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.SimpleArrowFunction_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ArrowFunction_CapturedThis_DeclinesUnifiedBytecodeProductionFastPath|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~ExpressionProgramCoverageMapTests"
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk git diff --check