### PR TITLE
Route base class fields through unified bytecode

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -121,6 +121,11 @@ statement interpretation.
   values. The production invocation bridge resolves those captured values before
   entering the VM and avoids sloppy-call `this` coercion for arrows. Arrows that
   need a lexical-this environment or super binding still decline.
+- Simple base class constructors with public instance fields can route through
+  production unified bytecode. The production constructor bridge performs the
+  existing pre-body instance field initialization before VM entry. Derived
+  constructor field initialization and private-field brands remain on the class
+  fields lane.
 - Resumable async/generator unified bytecode is narrower than ordinary sync
   production bytecode. The resumable eligibility opcode allow-list is now
   audited against the `ExecuteResumable` switch, so opcodes already implemented
@@ -354,7 +359,7 @@ not always have a `UnifiedBytecodeProductionDeclineCode`.
 | `pre-gate:lexicalThisEnvironment` | Lexical `this` environment captured by arrow / class-derived shapes | Existing lexical-this route | This-binding lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:superConstructor` | Derived-constructor super binding dependency outside the bounded production constructor admission path | Constructor / super route | Super / constructor lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperCall_AcceptsSuperConstructInvocationBoundary"` |
 | `pre-gate:superPrototype` | Method home-object super prototype state; admitted for VM-owned super property reads/writes/updates and first-boundary super calls | Existing super route for remaining shapes | Super semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperPropertyAccess_AcceptsOwnedOpcodes"` |
-| `pre-gate:instanceFields` | Class instance-field initialization state | Constructor / class route | Class fields lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
+| `pre-gate:instanceFields` | Derived constructor field initialization and private-field brand state. Simple base constructors with public instance fields initialize before VM entry and can route. | Constructor / class route for remaining field shapes | Class fields lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests"` |
 | `pre-gate:activationSlotShape` | `CanUseProductionUnifiedBytecodePlanShape` requires activation slots matching root scope, layout, and parameter-slot length unless with-backed dynamic names or environment-backed class declarations own the materialized activation | Existing execution-plan route | Slot-layout lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests&FullyQualifiedName~UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"` |
 
 ### Prototype Opcode Guard Rows
@@ -757,9 +762,9 @@ support today.
    real `arguments` object and sloppy mapped-arguments dependencies, non-simple
    parameter lists, default/rest/destructured parameter expressions, broader
    class constructor routes beyond simple base constructors and the bounded
-   explicit derived `super(...)` path, default derived constructors, instance
-   fields, and captured activation outside the explicit with-backed dynamic-name
-   lane. Resumable
+   explicit derived `super(...)` path, default derived constructors, derived or
+   private instance fields, and captured activation outside the explicit
+   with-backed dynamic-name lane. Resumable
    unified bytecode exists, but `EvaluateResumable` admits only a small
    instruction/opcode subset compared with ordinary sync production bytecode.
 2. Wider call invocation remains a high-impact unsupported bucket. Synchronous

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -3098,6 +3098,24 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                     context.MarkThisInitialized();
                 }
 
+                if (IsClassConstructor &&
+                    !_isDerivedClassConstructor &&
+                    !_instanceFields.IsDefaultOrEmpty)
+                {
+                    if (!vmThisValue.TryGetObject<IJsObjectLike>(out var constructedInstance))
+                    {
+                        return false;
+                    }
+
+                    var initEnvironment = JsEnvironment.CreateInstance(_closure, isStrict: _isStrict);
+                    InitializeInstance(constructedInstance, initEnvironment, context);
+                    if (context.ShouldStopEvaluation)
+                    {
+                        result = context.FlowValue;
+                        return TryCompleteIrFastExpressionResult(context, callingContext, ref result);
+                    }
+                }
+
                 var slots = slotStorage.AsSpan(0, program.SlotCount);
                 slots.Fill(JsValue.Undefined);
                 InitializeProductionUnifiedBytecodeLexicalSlots(slots, program);
@@ -3340,7 +3358,7 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                 _function.IsDefaultDerivedConstructor ||
                 _hasParameterExpressions ||
                 !_hasOnlySimpleIdentifierParameters ||
-                !_instanceFields.IsDefaultOrEmpty)
+                !_instanceFields.IsDefaultOrEmpty && !canUseBaseClassConstructorPath)
             {
                 return false;
             }
@@ -3724,7 +3742,6 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                    _homeObject is null &&
                    PrivateNameScope is null &&
                    _capturedPrivateNameScopes.IsDefaultOrEmpty &&
-                   _instanceFields.IsDefaultOrEmpty &&
                    _superConstructor is null &&
                    _superPrototype is null &&
                    CanUseSimpleIrActivationPlanShape(plan);

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionConstructCallTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionConstructCallTests.cs
@@ -146,6 +146,59 @@ public sealed class UnifiedBytecodeProductionConstructCallTests(ITestOutputHelpe
     }
 
     [Fact(Timeout = 5000)]
+    public async Task BaseClassConstructorWithInstanceField_UsesProductionFastPathAndInitializesBeforeBody()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var log = "";
+
+            class Box {
+                value = (log += "field;", 41);
+
+                constructor(delta) {
+                    log += "ctor;";
+                    this.value += delta;
+                }
+            }
+
+            var box = new Box(1);
+            box.value + ":" + log;
+            """);
+
+        Assert.Equal("42:field;ctor;", result?.ToString());
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=Box argc=1",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task BaseClassConstructorWithPrivateInstanceField_DeclinesAndFallsBack()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            class Box {
+                #value = 42;
+
+                constructor() {
+                }
+
+                read() {
+                    return this.#value;
+                }
+            }
+
+            new Box().read();
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=Box",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task Construct_PreservesArgumentEvaluationOrder()
     {
         await using var engine = CreateEngine();

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -5542,20 +5542,6 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
         """,
         "arrowLexical",
         42d)]
-    [InlineData(
-        """
-        class Box {
-            extra = 1;
-
-            constructor(value) {
-                this.value = value;
-            }
-        }
-
-        new Box(42).value;
-        """,
-        "Box",
-        42d)]
     public async Task OrdinarySyncActivationBlockers_DeclineUnifiedBytecodeAndFallBack(
         string source,
         string functionName,


### PR DESCRIPTION
## Summary
- allow simple base class constructors with public instance fields to use production unified bytecode
- initialize public instance fields before VM entry on the production constructor bridge
- add positive constructor-field routing coverage, preserve private-field constructor decline coverage, and update the expansion contract

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests.BaseClassConstructorWithInstanceField_UsesProductionFastPathAndInitializesBeforeBody|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests.BaseClassConstructorBody_UsesProductionFastPathAndInitializesThis|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests.DerivedConstructorWithInstanceField_DeclinesAndFallsBack|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramCoverageMapTests"
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk git diff --check