### PR TITLE
Route private base fields through unified bytecode

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -121,11 +121,11 @@ statement interpretation.
   values. The production invocation bridge resolves those captured values before
   entering the VM and avoids sloppy-call `this` coercion for arrows. Arrows that
   need a lexical-this environment or super binding still decline.
-- Simple base class constructors with public instance fields can route through
-  production unified bytecode. The production constructor bridge performs the
-  existing pre-body instance field initialization before VM entry. Derived
-  constructor field initialization and private-field brands remain on the class
-  fields lane.
+- Simple base class constructors with public or private instance fields can route
+  through production unified bytecode. The production constructor bridge performs
+  the existing pre-body instance field initialization and private branding before
+  VM entry. Derived constructor field initialization remains on the class fields
+  lane.
 - Resumable async/generator unified bytecode is narrower than ordinary sync
   production bytecode. The resumable eligibility opcode allow-list is now
   audited against the `ExecuteResumable` switch, so opcodes already implemented
@@ -359,7 +359,7 @@ not always have a `UnifiedBytecodeProductionDeclineCode`.
 | `pre-gate:lexicalThisEnvironment` | Lexical `this` environment captured by arrow / class-derived shapes | Existing lexical-this route | This-binding lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:superConstructor` | Derived-constructor super binding dependency outside the bounded production constructor admission path | Constructor / super route | Super / constructor lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperCall_AcceptsSuperConstructInvocationBoundary"` |
 | `pre-gate:superPrototype` | Method home-object super prototype state; admitted for VM-owned super property reads/writes/updates and first-boundary super calls | Existing super route for remaining shapes | Super semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperPropertyAccess_AcceptsOwnedOpcodes"` |
-| `pre-gate:instanceFields` | Derived constructor field initialization and private-field brand state. Simple base constructors with public instance fields initialize before VM entry and can route. | Constructor / class route for remaining field shapes | Class fields lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests"` |
+| `pre-gate:instanceFields` | Derived constructor field initialization state. Simple base constructors with public or private instance fields initialize and brand before VM entry and can route. | Constructor / class route for remaining field shapes | Class fields lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests"` |
 | `pre-gate:activationSlotShape` | `CanUseProductionUnifiedBytecodePlanShape` requires activation slots matching root scope, layout, and parameter-slot length unless with-backed dynamic names or environment-backed class declarations own the materialized activation | Existing execution-plan route | Slot-layout lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests&FullyQualifiedName~UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"` |
 
 ### Prototype Opcode Guard Rows
@@ -762,9 +762,9 @@ support today.
    real `arguments` object and sloppy mapped-arguments dependencies, non-simple
    parameter lists, default/rest/destructured parameter expressions, broader
    class constructor routes beyond simple base constructors and the bounded
-   explicit derived `super(...)` path, default derived constructors, derived or
-   private instance fields, and captured activation outside the explicit
-   with-backed dynamic-name lane. Resumable
+   explicit derived `super(...)` path, default derived constructors, derived
+   instance fields, and captured activation outside the explicit with-backed
+   dynamic-name lane. Resumable
    unified bytecode exists, but `EvaluateResumable` admits only a small
    instruction/opcode subset compared with ordinary sync production bytecode.
 2. Wider call invocation remains a high-impact unsupported bucket. Synchronous

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -3740,8 +3740,6 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                    _allowIdentifierCache &&
                    _lexicalThisEnvironment is null &&
                    _homeObject is null &&
-                   PrivateNameScope is null &&
-                   _capturedPrivateNameScopes.IsDefaultOrEmpty &&
                    _superConstructor is null &&
                    _superPrototype is null &&
                    CanUseSimpleIrActivationPlanShape(plan);

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionConstructCallTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionConstructCallTests.cs
@@ -173,7 +173,7 @@ public sealed class UnifiedBytecodeProductionConstructCallTests(ITestOutputHelpe
     }
 
     [Fact(Timeout = 5000)]
-    public async Task BaseClassConstructorWithPrivateInstanceField_DeclinesAndFallsBack()
+    public async Task BaseClassConstructorWithPrivateInstanceField_UsesProductionFastPathAndBrandsInstance()
     {
         await using var engine = CreateEngine();
         var result = await engine.Evaluate("""
@@ -181,6 +181,8 @@ public sealed class UnifiedBytecodeProductionConstructCallTests(ITestOutputHelpe
                 #value = 42;
 
                 constructor() {
+                    var branded = #value in this;
+                    this.hasBrand = branded;
                 }
 
                 read() {
@@ -188,13 +190,14 @@ public sealed class UnifiedBytecodeProductionConstructCallTests(ITestOutputHelpe
                 }
             }
 
-            new Box().read();
+            var box = new Box();
+            box.hasBrand + ":" + box.read();
             """);
 
-        Assert.Equal(42d, result);
-        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
+        Assert.Equal("true:42", result?.ToString());
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(
-                "unified-bytecode-production-fast-path func=Box",
+                "unified-bytecode-production-fast-path func=Box argc=0",
                 StringComparison.Ordinal));
     }
 

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -5520,7 +5520,7 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
         Assert.Equal(42d, result);
         Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             record => record.Message.Contains(
-                UnifiedBytecodeProductionFastPathLog,
+                "unified-bytecode-production-fast-path func=read",
                 StringComparison.Ordinal));
     }
 


### PR DESCRIPTION
## Summary
- admit simple base class constructors with private instance fields into production unified bytecode
- initialize/brand private instance fields before VM entry on the production constructor bridge
- update decline contract docs and tighten the private-read decline assertion around method routing

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests.BaseClassConstructorWithPrivateInstanceField_UsesProductionFastPathAndBrandsInstance|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests.BaseClassConstructorWithInstanceField_UsesProductionFastPathAndInitializesBeforeBody|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests.DerivedConstructorWithInstanceField_DeclinesAndFallsBack|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramCoverageMapTests"
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner* (no matches)
- rtk git diff --check