### PR TITLE
Route derived public fields through unified bytecode

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -121,11 +121,12 @@ statement interpretation.
   values. The production invocation bridge resolves those captured values before
   entering the VM and avoids sloppy-call `this` coercion for arrows. Arrows that
   need a lexical-this environment or super binding still decline.
-- Simple base class constructors with public or private instance fields can route
-  through production unified bytecode. The production constructor bridge performs
-  the existing pre-body instance field initialization and private branding before
-  VM entry. Derived constructor field initialization remains on the class fields
-  lane.
+- Simple base class constructors with public or private instance fields and
+  simple derived constructors with public instance fields can route through
+  production unified bytecode. The production constructor bridge performs the
+  existing base pre-body field initialization/private branding before VM entry
+  and consumes the derived pending field initializer after `super(...)`. Derived
+  private-field branding remains on the class fields lane.
 - Resumable async/generator unified bytecode is narrower than ordinary sync
   production bytecode. The resumable eligibility opcode allow-list is now
   audited against the `ExecuteResumable` switch, so opcodes already implemented
@@ -359,7 +360,7 @@ not always have a `UnifiedBytecodeProductionDeclineCode`.
 | `pre-gate:lexicalThisEnvironment` | Lexical `this` environment captured by arrow / class-derived shapes | Existing lexical-this route | This-binding lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:superConstructor` | Derived-constructor super binding dependency outside the bounded production constructor admission path | Constructor / super route | Super / constructor lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperCall_AcceptsSuperConstructInvocationBoundary"` |
 | `pre-gate:superPrototype` | Method home-object super prototype state; admitted for VM-owned super property reads/writes/updates and first-boundary super calls | Existing super route for remaining shapes | Super semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperPropertyAccess_AcceptsOwnedOpcodes"` |
-| `pre-gate:instanceFields` | Derived constructor field initialization state. Simple base constructors with public or private instance fields initialize and brand before VM entry and can route. | Constructor / class route for remaining field shapes | Class fields lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests"` |
+| `pre-gate:instanceFields` | Derived private-field brand state. Simple base constructors with public/private instance fields and simple derived constructors with public instance fields initialize on the production route. | Constructor / class route for remaining field shapes | Class fields lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests"` |
 | `pre-gate:activationSlotShape` | `CanUseProductionUnifiedBytecodePlanShape` requires activation slots matching root scope, layout, and parameter-slot length unless with-backed dynamic names or environment-backed class declarations own the materialized activation | Existing execution-plan route | Slot-layout lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests&FullyQualifiedName~UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"` |
 
 ### Prototype Opcode Guard Rows
@@ -763,7 +764,7 @@ support today.
    parameter lists, default/rest/destructured parameter expressions, broader
    class constructor routes beyond simple base constructors and the bounded
    explicit derived `super(...)` path, default derived constructors, derived
-   instance fields, and captured activation outside the explicit with-backed
+   private instance fields, and captured activation outside the explicit with-backed
    dynamic-name lane. Resumable
    unified bytecode exists, but `EvaluateResumable` admits only a small
    instruction/opcode subset compared with ordinary sync production bytecode.

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -3064,6 +3064,7 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
 
             var slotStorage = ArrayPool<JsValue>.Shared.Rent(program.SlotCount);
             JsEnvironment? executionEnvironment = null;
+            var hasPendingFieldInitialization = false;
             try
             {
                 var vmThisValue = thisValue;
@@ -3138,6 +3139,16 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                         : CreateSimpleIrActivationEnvironment(arguments, vmThisValue, plan, context);
                 }
 
+                if (IsClassConstructor &&
+                    _isDerivedClassConstructor &&
+                    !_instanceFields.IsDefaultOrEmpty &&
+                    executionEnvironment?.Enclosing is { } functionEnvironment)
+                {
+                    context.PushClassFieldInitializer(
+                        new PendingClassFieldInitialization(this, functionEnvironment));
+                    hasPendingFieldInitialization = true;
+                }
+
                 RealmState.Logger?.LogInformation(
                     "unified-bytecode-production-fast-path func={Function} argc={ArgumentCount}",
                     _function.Name?.Name ?? "<anonymous>",
@@ -3166,6 +3177,11 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
             }
             finally
             {
+                if (hasPendingFieldInitialization)
+                {
+                    context.RemovePendingClassFieldInitializer(this);
+                }
+
                 ReturnSimpleIrActivationEnvironment(executionEnvironment);
                 ArrayPool<JsValue>.Shared.Return(slotStorage, clearArray: true);
             }
@@ -3358,7 +3374,9 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                 _function.IsDefaultDerivedConstructor ||
                 _hasParameterExpressions ||
                 !_hasOnlySimpleIdentifierParameters ||
-                !_instanceFields.IsDefaultOrEmpty && !canUseBaseClassConstructorPath)
+                !_instanceFields.IsDefaultOrEmpty &&
+                !canUseDerivedClassConstructorPath &&
+                !canUseBaseClassConstructorPath)
             {
                 return false;
             }
@@ -3620,7 +3638,6 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                    _homeObject is null &&
                    PrivateNameScope is null &&
                    _capturedPrivateNameScopes.IsDefaultOrEmpty &&
-                   _instanceFields.IsDefaultOrEmpty &&
                    (_superConstructor is not null || _superPrototype is not null) &&
                    CanUseProductionUnifiedBytecodeDerivedClassConstructorPlanShape(plan);
         }

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeVirtualMachine.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeVirtualMachine.cs
@@ -6002,6 +6002,21 @@ internal static class UnifiedBytecodeVirtualMachine
             context.MarkThisInitialized();
             targetEnvironment.SetThisInitializationStatus(true);
 
+            if (thisAfterSuper is IJsObjectLike initializedObject &&
+                context.TryPopClassFieldInitializer(out var pendingInitializer) &&
+                pendingInitializer.Constructor is TypedAstEvaluator.SyncFunctionInvoker pendingConstructor)
+            {
+                pendingConstructor.InitializeInstance(
+                    initializedObject,
+                    pendingInitializer.Environment,
+                    context);
+                if (context.ShouldStopEvaluation)
+                {
+                    stack[baseIndex] = context.FlowValue;
+                    return baseIndex + 1;
+                }
+            }
+
             stack[baseIndex] = result;
             return baseIndex + 1;
         }

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionConstructCallTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionConstructCallTests.cs
@@ -514,15 +514,18 @@ public sealed class UnifiedBytecodeProductionConstructCallTests(ITestOutputHelpe
     }
 
     [Fact(Timeout = 5000)]
-    public async Task DerivedConstructorWithInstanceField_DeclinesAndFallsBack()
+    public async Task DerivedConstructorWithInstanceField_UsesProductionFastPathAndInitializesAfterSuper()
     {
         await using var engine = CreateEngine();
         var result = await engine.Evaluate("""
             class Base {
+                constructor() {
+                    this.baseValue = 40;
+                }
             }
 
             class Derived extends Base {
-                value = 42;
+                value = this.baseValue + 2;
                 constructor() {
                     super();
                 }
@@ -532,7 +535,7 @@ public sealed class UnifiedBytecodeProductionConstructCallTests(ITestOutputHelpe
             """);
 
         Assert.Equal(42d, result);
-        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(
                 "unified-bytecode-production-fast-path func=Derived",
                 StringComparison.Ordinal));


### PR DESCRIPTION
## Summary
- admit simple derived constructors with public instance fields into production unified bytecode
- push the existing pending class-field initializer before VM execution and consume it after the VM super construct boundary initializes this
- update constructor coverage and the decline contract to leave only derived private-field branding in this gate

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests.DerivedConstructorWithInstanceField_UsesProductionFastPathAndInitializesAfterSuper|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests.SuperConstruct_InitializesThis|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests.SuperConstruct_DoubleCallThrows|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramCoverageMapTests"
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner* (no matches)
- rtk git diff --check