### PR TITLE
Route derived private fields through unified bytecode

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -122,11 +122,10 @@ statement interpretation.
   entering the VM and avoids sloppy-call `this` coercion for arrows. Arrows that
   need a lexical-this environment or super binding still decline.
 - Simple base class constructors with public or private instance fields and
-  simple derived constructors with public instance fields can route through
+  simple derived constructors with public or private instance fields can route through
   production unified bytecode. The production constructor bridge performs the
   existing base pre-body field initialization/private branding before VM entry
-  and consumes the derived pending field initializer after `super(...)`. Derived
-  private-field branding remains on the class fields lane.
+  and consumes the derived pending field initializer after `super(...)`.
 - Resumable async/generator unified bytecode is narrower than ordinary sync
   production bytecode. The resumable eligibility opcode allow-list is now
   audited against the `ExecuteResumable` switch, so opcodes already implemented
@@ -360,7 +359,6 @@ not always have a `UnifiedBytecodeProductionDeclineCode`.
 | `pre-gate:lexicalThisEnvironment` | Lexical `this` environment captured by arrow / class-derived shapes | Existing lexical-this route | This-binding lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:superConstructor` | Derived-constructor super binding dependency outside the bounded production constructor admission path | Constructor / super route | Super / constructor lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperCall_AcceptsSuperConstructInvocationBoundary"` |
 | `pre-gate:superPrototype` | Method home-object super prototype state; admitted for VM-owned super property reads/writes/updates and first-boundary super calls | Existing super route for remaining shapes | Super semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperPropertyAccess_AcceptsOwnedOpcodes"` |
-| `pre-gate:instanceFields` | Derived private-field brand state. Simple base constructors with public/private instance fields and simple derived constructors with public instance fields initialize on the production route. | Constructor / class route for remaining field shapes | Class fields lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests"` |
 | `pre-gate:activationSlotShape` | `CanUseProductionUnifiedBytecodePlanShape` requires activation slots matching root scope, layout, and parameter-slot length unless with-backed dynamic names or environment-backed class declarations own the materialized activation | Existing execution-plan route | Slot-layout lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests&FullyQualifiedName~UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"` |
 
 ### Prototype Opcode Guard Rows
@@ -763,8 +761,8 @@ support today.
    real `arguments` object and sloppy mapped-arguments dependencies, non-simple
    parameter lists, default/rest/destructured parameter expressions, broader
    class constructor routes beyond simple base constructors and the bounded
-   explicit derived `super(...)` path, default derived constructors, derived
-   private instance fields, and captured activation outside the explicit with-backed
+   explicit derived `super(...)` path, default derived constructors, and captured
+   activation outside the explicit with-backed
    dynamic-name lane. Resumable
    unified bytecode exists, but `EvaluateResumable` admits only a small
    instruction/opcode subset compared with ordinary sync production bytecode.

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -3636,8 +3636,6 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                    !_needsArgumentsBinding &&
                    _lexicalThisEnvironment is null &&
                    _homeObject is null &&
-                   PrivateNameScope is null &&
-                   _capturedPrivateNameScopes.IsDefaultOrEmpty &&
                    (_superConstructor is not null || _superPrototype is not null) &&
                    CanUseProductionUnifiedBytecodeDerivedClassConstructorPlanShape(plan);
         }

--- a/tests/Asynkron.JsEngine.Tests/ExpressionProgramCoverageMapTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/ExpressionProgramCoverageMapTests.cs
@@ -32,7 +32,6 @@ public sealed class ExpressionProgramCoverageMapTests
         "pre-gate:lexicalThisEnvironment",
         "pre-gate:superConstructor",
         "pre-gate:superPrototype",
-        "pre-gate:instanceFields",
         "pre-gate:activationSlotShape"
     ];
 

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionConstructCallTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionConstructCallTests.cs
@@ -542,6 +542,36 @@ public sealed class UnifiedBytecodeProductionConstructCallTests(ITestOutputHelpe
     }
 
     [Fact(Timeout = 5000)]
+    public async Task DerivedConstructorWithPrivateInstanceField_UsesProductionFastPathAndBrandsAfterSuper()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            class Base {
+            }
+
+            class Derived extends Base {
+                #value = 42;
+
+                constructor() {
+                    super();
+                }
+
+                read() {
+                    return this.#value;
+                }
+            }
+
+            new Derived().read();
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=Derived",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task DefaultDerivedConstructor_DeclinesAndFallsBack()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit simple derived constructors with private instance fields into production unified bytecode
- add coverage that private field branding happens after super on the VM route
- retire the pre-gate:instanceFields decline ledger row now that base/derived public/private instance fields are admitted

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests.DerivedConstructorWithPrivateInstanceField_UsesProductionFastPathAndBrandsAfterSuper|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests.DerivedConstructorWithInstanceField_UsesProductionFastPathAndInitializesAfterSuper|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests.BaseClassConstructorWithPrivateInstanceField_UsesProductionFastPathAndBrandsInstance|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramCoverageMapTests"
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner* (no matches)
- rtk git diff --check