### PR TITLE
Route private compound property writes through unified bytecode

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -83,8 +83,8 @@ statement interpretation.
   still decline before VM execution.
 - Expression lowering is still the largest surface. `ExpressionOpKind` contains
   more shapes than the general unified lowering loop accepts. Several operations
-  are admitted only through narrow shape helpers, while private property
-  reads/writes/updates, remaining optional-call chain shapes, and some
+  are admitted only through narrow shape helpers, while private deletes,
+  remaining optional-call chain shapes, and some
   call/reference helpers remain outside general unified bytecode lowering.
 - The remaining direct general-expression lowering gaps are drift-checked under
   `### General Expression Lowering Gaps (current)`. Property set/update
@@ -101,8 +101,8 @@ statement interpretation.
   compiles the supported expression program first and appends `Pop`, so
   discarded statements route when their underlying operation family is already
   selector/compiler/VM-owned. Remaining discarded-expression declines are
-  declines of the underlying family, such as dynamic lookup, private names,
-  unsupported optional-chain neighbors, or other semantic lanes not yet
+  declines of the underlying family, such as dynamic lookup, private deletes or
+  unsupported private neighbors, optional-chain neighbors, or other semantic lanes not yet
   admitted.
 - The current `ExpressionOpKind` names with no unified compiler reference list is
   empty. Computed super-property operations also route their required
@@ -117,6 +117,9 @@ statement interpretation.
   scopes into the VM, so `#name in receiver` can execute through
   `PrivateFieldIn` and direct private named reads/writes/updates can execute
   through `GetNamedProperty` / `SetNamedProperty` / `UpdateNamedProperty`.
+  Direct private named compound and logical writes execute through
+  `GetNamedPropertyForCompoundSet` plus `SetNamedProperty` when the receiver
+  chain is otherwise the admitted activation-resolved named-write shape.
   Direct private named method calls can execute through `PrepareNamedCallTarget`.
   Private member deletes still decline as `PrivateFieldDependency`.
 - Simple-return arrows can route with captured lexical `this` / `new.target`
@@ -332,7 +335,7 @@ must still obey the no-mixed-execution rule.
 | `SuperPropertyDependency` | Out-of-boundary super call targets; super property reads/writes/updates are admitted by dedicated VM opcodes | Existing class / constructor route for remaining call-target shapes | Super semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperPropertyAccess_AcceptsOwnedOpcodes"` |
 | `OptionalChainDependency` | Optional chains outside the admitted optional property-read, optional-call, and exact optional computed delete boundaries | Existing sync IR optional-chain route | Optional-chain widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_OptionalSpreadCallExpressionPlan_DeclinesWithOptionalChainDependency"` |
 | `ObjectLiteralOrSpreadDependency` | Non-simple object spread sources, unsupported array spread, spread construct arguments, and object methods/accessors only when they appear inside restricted simple literal spans | Existing sync IR literal/spread route for remaining spans | Literal/spread lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NonSimpleSourceArraySpread_DeclinesWithExplicitCode"` |
-| `PrivateFieldDependency` | Private member deletes; `#name in obj`, direct private named reads/writes/updates, and direct private named method calls are VM-owned when the surrounding class method is otherwise production-eligible | Existing private-name route for remaining private member access | Private-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_PrivateFieldIn_AcceptsAndVmChecksPrivateBrand"` |
+| `PrivateFieldDependency` | Private member deletes; `#name in obj`, direct private named reads/writes/updates, direct private named compound/logical writes, and direct private named method calls are VM-owned when the surrounding class method is otherwise production-eligible | Existing private-name route for remaining private member access | Private-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_PrivateFieldIn_AcceptsAndVmChecksPrivateBrand"` |
 | `ForInDriverStateDependency` | Unsupported for-in driver state such as awaited object source | Existing for-in IR driver route | Driver-state lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~IsSupportedForInInit_AwaitedSource_Declines"` |
 | `DestructuringDependency` | Binding declarations with defaults, computed binding names, assignment targets, awaited binding values, unsupported destructuring driver shapes, and targets outside the admitted driver or descriptor-backed lanes | Existing destructuring IR route for remaining shapes | Destructuring driver lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_UnsupportedDestructuringDriverShapes_DeclineWithExplicitReason"` |
 | `LabelControlFlow` | Labeled break/continue that exits an intervening iterator/for-in driver loop not directly targeted by the abrupt jump | Existing IR loop-control route | Multi-driver labeled cleanup lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_LabeledBreakCrossingDriverLoop_DeclinesWithLabelControlFlow"` |
@@ -410,7 +413,7 @@ the final post-compile production subset check before VM entry.
   writes (`box[key] &&= y`, `box[key] ||= y`, `box[key] ??= y`) are also admitted
   when they match `TryIsFirstBoundaryComputedLogicalPropertyWriteCandidate`
   (activation-resolved base, supported computed-key span, simple RHS,
-  non-optional/non-private target). Direct computed assignments, compound
+  non-optional target). Direct computed assignments, compound
   writes, logical writes, and
   updates may use the same supported computed-key expression span as optional
   computed reads (`box[key + suffix] = y`, `box[key + suffix] += y`,
@@ -439,8 +442,9 @@ the final post-compile production subset check before VM entry.
   (ADR 0317 plus the simple optional-computed follow-up).
   The compiler emits the named receiver reads and final `DeleteComputedProperty`,
   while the VM's descriptor-aware delete helper owns strict/sloppy results.
-  Retained declines include chained optional delete neighbors, private property
-  access, dynamic lookup, richer unowned computed-key spans, unsupported RHS
+  Retained declines include chained optional delete neighbors, private deletes,
+  private receiver-chain/mutation neighbors outside the admitted direct named
+  shape, dynamic lookup, richer unowned computed-key spans, unsupported RHS
   spans, and optional/super/private neighbors of computed-key mutation shapes.
   Note: slot-identifier logical assignment (`x &&= y`) remains admitted.
 - Super-property reads, writes, and updates are now VM-owned through
@@ -614,7 +618,8 @@ the final post-compile production subset check before VM entry.
   is exactly one non-spread eval-identifier argument; the VM invokes the eval host
   with the caller environment and syncs mutated caller slots back into unified
   bytecode-owned slots before execution continues.
-- Spread super constructs, private member targets, arguments-object dependencies, unsupported
+- Spread super constructs, private-adjacent member targets outside the admitted
+  direct named method-call shape, arguments-object dependencies, unsupported
   non-with dynamic lookup, deeper computed-member call receiver chains,
   complex receiver/key shapes, spread-onto-optional calls, and
   receiver-binding-sensitive adjacent families still decline before VM
@@ -781,16 +786,17 @@ support today.
    admitted through the `ObjectSpread` opcode when their spread source is a
    simple operand. Direct eval outside the one-argument non-spread
    eval-identifier boundary, spread super constructs, spread-onto-optional,
-   private member targets, complex receiver/key shapes, non-simple literal
-   argument spans, and receiver-binding-sensitive adjacent families beyond the
+   private-adjacent member targets outside the admitted direct named method-call
+   shape, complex receiver/key shapes, non-simple literal argument spans, and receiver-binding-sensitive adjacent families beyond the
    direct activation-resolved and with-backed dynamic-identifier boundaries must
    still decline before VM execution.
 3. Property and assignment widening is no longer a blanket property-read/write
    gap, but several member-expression neighbors remain outside production:
-   private member reads/writes/updates, optional-chain neighbors outside the
-   admitted read/call/delete shapes, richer computed-key spans, unsupported RHS
-   spans, optional/super/private mutation neighbors, and dynamic lookup outside
-   the explicit with-backed lane.
+   private member deletes, private receiver-chain/mutation neighbors outside the
+   admitted direct named shapes, optional-chain neighbors outside the admitted
+   read/call/delete shapes, richer computed-key spans, unsupported RHS spans,
+   optional/super/private mutation neighbors, and dynamic lookup outside the
+   explicit with-backed lane.
 4. Driver-state widening is next. Sync-driver TDZ head environments
    (`for (const x of …)` / `for (let k in …)`) are now admitted via the
    `TdzHeadInit` instruction (Slice A, #2678; see ADR 0288). Async iterator

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -6185,6 +6185,7 @@ internal static class UnifiedBytecodeCompiler
         out string reason)
     {
         // Shape: [base, GetNamedProperty(non-optional, non-private)*, DuplicateTop, GetNamedProperty, rhs..., Binary, SetNamedProperty]
+        // The final target may be private; receiver-chain hops stay ordinary only.
         // Minimum: 6 ops (rhs is a single simple operand).
         if (expressionProgram.OperationCount < 6)
         {
@@ -6233,12 +6234,6 @@ internal static class UnifiedBytecodeCompiler
             propertySet.Kind != ExpressionOpKind.SetNamedProperty)
         {
             reason = string.Empty;
-            return false;
-        }
-
-        if (propertyRead.GetString(stringTable).IsPrivateName())
-        {
-            reason = "Private named compound property writes are not supported.";
             return false;
         }
 
@@ -6469,6 +6464,7 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        // The final target may be private; receiver-chain hops stay ordinary only.
         var stringTable = expressionProgram.StringConstants.AsSpan();
         var duplicateIndex = 1;
         while (duplicateIndex < expressionProgram.OperationCount)
@@ -6541,12 +6537,6 @@ internal static class UnifiedBytecodeCompiler
         }
 
         var propertyName = propertyRead.GetString(stringTable);
-        if (propertyName.IsPrivateName())
-        {
-            reason = "Private named logical property writes are not supported.";
-            return false;
-        }
-
         if (propertyName != propertySet.GetString(stringTable))
         {
             reason = "Mismatched named logical property read/write operands are not supported.";

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -720,8 +720,15 @@ internal static class UnifiedBytecodeProductionEligibility
             TryIsFirstBoundaryPropertyWriteCandidate(program, identifierConstants, activationSlots);
         var isFirstBoundaryPropertyUpdateCandidate =
             TryIsFirstBoundaryPropertyUpdateCandidate(program, identifierConstants, activationSlots);
+        var isFirstBoundaryNamedCompoundPropertyWriteCandidate =
+            TryIsFirstBoundaryNamedCompoundPropertyWriteCandidate(program, identifierConstants, activationSlots);
+        var isFirstBoundaryNamedLogicalPropertyWriteCandidate =
+            TryIsFirstBoundaryNamedLogicalPropertyWriteCandidate(program, identifierConstants, activationSlots);
         var isPrivateNamedMutationCandidate =
-            isFirstBoundaryPropertyWriteCandidate || isFirstBoundaryPropertyUpdateCandidate;
+            isFirstBoundaryPropertyWriteCandidate ||
+            isFirstBoundaryPropertyUpdateCandidate ||
+            isFirstBoundaryNamedCompoundPropertyWriteCandidate ||
+            isFirstBoundaryNamedLogicalPropertyWriteCandidate;
 
         // Pre-scan spread source operands before the main loop processes the source ops, which may
         // otherwise trigger a less-specific decline code such as CallDependency.
@@ -1072,11 +1079,11 @@ internal static class UnifiedBytecodeProductionEligibility
                         break;
                     }
 
-                    if (TryIsFirstBoundaryNamedCompoundPropertyWriteCandidate(program, identifierConstants, activationSlots))
+                    if (isFirstBoundaryNamedCompoundPropertyWriteCandidate)
                     {
                         break;
                     }
-                    if (TryIsFirstBoundaryNamedLogicalPropertyWriteCandidate(program, identifierConstants, activationSlots))
+                    if (isFirstBoundaryNamedLogicalPropertyWriteCandidate)
                     {
                         break;
                     }
@@ -1216,8 +1223,8 @@ internal static class UnifiedBytecodeProductionEligibility
                 case ExpressionOpKind.SetComputedProperty:
                     if (TryIsFirstBoundaryPropertyWriteCandidate(program, identifierConstants, activationSlots) ||
                         TryIsFirstBoundaryNestedNamedPropertyWriteCandidate(program, identifierConstants, activationSlots) ||
-                        TryIsFirstBoundaryNamedCompoundPropertyWriteCandidate(program, identifierConstants, activationSlots) ||
-                        TryIsFirstBoundaryNamedLogicalPropertyWriteCandidate(program, identifierConstants, activationSlots) ||
+                        isFirstBoundaryNamedCompoundPropertyWriteCandidate ||
+                        isFirstBoundaryNamedLogicalPropertyWriteCandidate ||
                         TryIsFirstBoundaryComputedCompoundPropertyWriteCandidate(program, identifierConstants, activationSlots) ||
                         TryIsFirstBoundaryComputedLogicalPropertyWriteCandidate(program, identifierConstants, activationSlots))
                     {
@@ -3495,6 +3502,7 @@ internal static class UnifiedBytecodeProductionEligibility
         ActivationSlotShape activationSlots)
     {
         // Shape: [base, GetNamedProperty(non-optional, non-private)*, DuplicateTop, GetNamedProperty, rhs..., Binary, SetNamedProperty]
+        // The final target may be private; receiver-chain hops stay ordinary only.
         // Minimum: 6 ops (rhs is a single simple operand).
         if (program.OperationCount < 6)
         {
@@ -3548,7 +3556,7 @@ internal static class UnifiedBytecodeProductionEligibility
         }
 
         var propertyName = propertyRead.GetString(stringConstants);
-        if (propertyName.IsPrivateName() || propertyName != propertyWrite.GetString(stringConstants))
+        if (propertyName != propertyWrite.GetString(stringConstants))
         {
             return false;
         }
@@ -3622,6 +3630,7 @@ internal static class UnifiedBytecodeProductionEligibility
     {
         // Shape: [base, GetNamedProperty(non-optional, non-private)*, DuplicateTop, GetNamedProperty,
         // JumpIf*, Pop, rhs, SetNamedProperty, DuplicateTop, SwapTopTwo, Pop]
+        // The final target may be private; receiver-chain hops stay ordinary only.
         if (program.OperationCount < 10)
         {
             return false;
@@ -3684,7 +3693,7 @@ internal static class UnifiedBytecodeProductionEligibility
         }
 
         var propertyName = propertyRead.GetString(stringConstants);
-        return !propertyName.IsPrivateName() && propertyName == propertyWrite.GetString(stringConstants);
+        return propertyName == propertyWrite.GetString(stringConstants);
     }
 
     private static bool TryIsFirstBoundaryComputedLogicalPropertyWriteCandidate(

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -2698,6 +2698,72 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
+    public void Evaluate_PrivateNamedCompoundPropertyWrite_AcceptsNamedPropertyOpcodes()
+    {
+        var plan = GetClassMethodPlan("""
+            class Holder {
+                #field = 1;
+                add(receiver, value) {
+                    return receiver.#field += value;
+                }
+            }
+            """,
+            "Holder",
+            "add");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(
+            result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.GetNamedPropertyForCompoundSet);
+        Assert.Contains(
+            result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.SetNamedProperty);
+        Assert.Equal("#field", Assert.Single(result.Program.StringConstants));
+    }
+
+    [Theory]
+    [InlineData("&&=", (int)UnifiedBytecodeOpCode.JumpIfShortCircuitFalse)]
+    [InlineData("||=", (int)UnifiedBytecodeOpCode.JumpIfShortCircuitTrue)]
+    [InlineData("??=", (int)UnifiedBytecodeOpCode.JumpIfShortCircuitNotNullish)]
+    public void Evaluate_PrivateNamedLogicalPropertyWrite_AcceptsNamedPropertyOpcodes(
+        string logicalOperator,
+        int expectedJumpOpCode)
+    {
+        var plan = GetClassMethodPlan($$"""
+            class Holder {
+                #field = 1;
+                assign(receiver, value) {
+                    return receiver.#field {{logicalOperator}} value;
+                }
+            }
+            """,
+            "Holder",
+            "assign");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(
+            result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.GetNamedPropertyForCompoundSet);
+        Assert.Contains(
+            result.Program.Instructions,
+            instruction => instruction.OpCode == (UnifiedBytecodeOpCode)expectedJumpOpCode);
+        Assert.Contains(
+            result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.SetNamedProperty);
+        Assert.Equal("#field", Assert.Single(result.Program.StringConstants));
+    }
+
+    [Fact]
     public void Evaluate_PrivateNamedMethodCall_AcceptsCallTargetPreparation()
     {
         var plan = GetClassMethodPlan("""
@@ -6449,17 +6515,6 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Theory]
-    [InlineData(
-        """
-        class Counter {
-            update(value) {
-                return this.#p &&= value;
-            }
-        }
-        """,
-        "Counter",
-        "update",
-        (int)UnifiedBytecodeProductionDeclineCode.PrivateFieldDependency)]
     [InlineData(
         """
         function logicalAndComputedComplexRhsWrite(box, key, value) {

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -5578,6 +5578,71 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task PrivateNamedCompoundPropertyWrite_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            class Holder {
+                #value = 1;
+
+                add(receiver, value) {
+                    return receiver.#value += value;
+                }
+
+                read(receiver) {
+                    return receiver.#value;
+                }
+            }
+
+            var holder = new Holder();
+            holder.add(holder, 41) + ":" + holder.read(holder);
+            """);
+
+        Assert.Equal("42:42", result?.ToString());
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous> argc=2",
+                StringComparison.Ordinal));
+    }
+
+    [Theory(Timeout = 5000)]
+    [InlineData("&&=", "1", "42:42")]
+    [InlineData("&&=", "0", "0:0")]
+    [InlineData("||=", "0", "42:42")]
+    [InlineData("||=", "7", "7:7")]
+    [InlineData("??=", "null", "42:42")]
+    [InlineData("??=", "7", "7:7")]
+    public async Task PrivateNamedLogicalPropertyWrite_UsesUnifiedBytecodeProductionFastPath(
+        string logicalOperator,
+        string initialValue,
+        string expectedResult)
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate($$"""
+            class Holder {
+                #value = {{initialValue}};
+
+                assign(receiver, value) {
+                    return receiver.#value {{logicalOperator}} value;
+                }
+
+                read(receiver) {
+                    return receiver.#value;
+                }
+            }
+
+            var holder = new Holder();
+            holder.assign(holder, 42) + ":" + holder.read(holder);
+            """);
+
+        Assert.Equal(expectedResult, result?.ToString());
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous> argc=2",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task PrivateNamedMethodCall_UsesUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- route direct private named compound and logical property writes through production unified bytecode
- keep private receiver-chain hops and private deletes outside the admitted boundary
- update the unified bytecode expansion contract to remove stale private read/write/update decline wording

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.PrivateNamedCompoundPropertyWrite_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.PrivateNamedLogicalPropertyWrite_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_PrivateNamedCompoundPropertyWrite_AcceptsNamedPropertyOpcodes|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_PrivateNamedLogicalPropertyWrite_AcceptsNamedPropertyOpcodes|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_PrivateNamedPropertyDelete_DeclinesWithExplicitCode|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramCoverageMapTests"
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk git diff --check

Note: skipped Roslynator/format/duplication gates per maintainer request to get the code in.