### PR TITLE
Reject private delete before bytecode eligibility

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -83,9 +83,10 @@ statement interpretation.
   still decline before VM execution.
 - Expression lowering is still the largest surface. `ExpressionOpKind` contains
   more shapes than the general unified lowering loop accepts. Several operations
-  are admitted only through narrow shape helpers, while private deletes,
-  remaining optional-call chain shapes, and some
-  call/reference helpers remain outside general unified bytecode lowering.
+  are admitted only through narrow shape helpers, while remaining optional-call
+  chain shapes and some call/reference helpers remain outside general unified
+  bytecode lowering. Private delete syntax is rejected before bytecode
+  eligibility.
 - The remaining direct general-expression lowering gaps are drift-checked under
   `### General Expression Lowering Gaps (current)`. Property set/update
   operations plus the `SwapTopTwo`, `DuplicateTopTwo`, and
@@ -101,9 +102,8 @@ statement interpretation.
   compiles the supported expression program first and appends `Pop`, so
   discarded statements route when their underlying operation family is already
   selector/compiler/VM-owned. Remaining discarded-expression declines are
-  declines of the underlying family, such as dynamic lookup, private deletes or
-  unsupported private neighbors, optional-chain neighbors, or other semantic lanes not yet
-  admitted.
+  declines of the underlying family, such as dynamic lookup, unsupported private
+  neighbors, optional-chain neighbors, or other semantic lanes not yet admitted.
 - The current `ExpressionOpKind` names with no unified compiler reference list is
   empty. Computed super-property operations also route their required
   `EnsureSuperReference` op through the general unified expression loop.
@@ -121,7 +121,8 @@ statement interpretation.
   `GetNamedPropertyForCompoundSet` plus `SetNamedProperty` when the receiver
   chain is otherwise the admitted activation-resolved named-write shape.
   Direct private named method calls can execute through `PrepareNamedCallTarget`.
-  Private member deletes still decline as `PrivateFieldDependency`.
+  Private member deletes are parser early errors, so they no longer enter
+  production eligibility.
 - Simple-return arrows can route with captured lexical `this` / `new.target`
   values. The production invocation bridge resolves those captured values before
   entering the VM and avoids sloppy-call `this` coercion for arrows. Arrows that
@@ -335,7 +336,7 @@ must still obey the no-mixed-execution rule.
 | `SuperPropertyDependency` | Out-of-boundary super call targets; super property reads/writes/updates are admitted by dedicated VM opcodes | Existing class / constructor route for remaining call-target shapes | Super semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperPropertyAccess_AcceptsOwnedOpcodes"` |
 | `OptionalChainDependency` | Optional chains outside the admitted optional property-read, optional-call, and exact optional computed delete boundaries | Existing sync IR optional-chain route | Optional-chain widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_OptionalSpreadCallExpressionPlan_DeclinesWithOptionalChainDependency"` |
 | `ObjectLiteralOrSpreadDependency` | Non-simple object spread sources, unsupported array spread, spread construct arguments, and object methods/accessors only when they appear inside restricted simple literal spans | Existing sync IR literal/spread route for remaining spans | Literal/spread lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NonSimpleSourceArraySpread_DeclinesWithExplicitCode"` |
-| `PrivateFieldDependency` | Private member deletes; `#name in obj`, direct private named reads/writes/updates, direct private named compound/logical writes, and direct private named method calls are VM-owned when the surrounding class method is otherwise production-eligible | Existing private-name route for remaining private member access | Private-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_PrivateFieldIn_AcceptsAndVmChecksPrivateBrand"` |
+| `PrivateFieldDependency` | Private-name operations outside the admitted routes; `#name in obj`, direct private named reads/writes/updates, direct private named compound/logical writes, and direct private named method calls are VM-owned when the surrounding class method is otherwise production-eligible. Private member deletes are parser early errors before production eligibility. | Existing private-name route for remaining private member access | Private-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_PrivateFieldIn_AcceptsAndVmChecksPrivateBrand"` |
 | `ForInDriverStateDependency` | Unsupported for-in driver state such as awaited object source | Existing for-in IR driver route | Driver-state lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~IsSupportedForInInit_AwaitedSource_Declines"` |
 | `DestructuringDependency` | Binding declarations with defaults, computed binding names, assignment targets, awaited binding values, unsupported destructuring driver shapes, and targets outside the admitted driver or descriptor-backed lanes | Existing destructuring IR route for remaining shapes | Destructuring driver lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_UnsupportedDestructuringDriverShapes_DeclineWithExplicitReason"` |
 | `LabelControlFlow` | Labeled break/continue that exits an intervening iterator/for-in driver loop not directly targeted by the abrupt jump | Existing IR loop-control route | Multi-driver labeled cleanup lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_LabeledBreakCrossingDriverLoop_DeclinesWithLabelControlFlow"` |
@@ -442,10 +443,11 @@ the final post-compile production subset check before VM entry.
   (ADR 0317 plus the simple optional-computed follow-up).
   The compiler emits the named receiver reads and final `DeleteComputedProperty`,
   while the VM's descriptor-aware delete helper owns strict/sloppy results.
-  Retained declines include chained optional delete neighbors, private deletes,
+  Retained declines include chained optional delete neighbors,
   private receiver-chain/mutation neighbors outside the admitted direct named
   shape, dynamic lookup, richer unowned computed-key spans, unsupported RHS
   spans, and optional/super/private neighbors of computed-key mutation shapes.
+  Private member deletes are rejected before this production gate.
   Note: slot-identifier logical assignment (`x &&= y`) remains admitted.
 - Super-property reads, writes, and updates are now VM-owned through
   `EnsureSuperReference`, `GetNamedSuperProperty`, `GetComputedSuperProperty`,
@@ -792,11 +794,12 @@ support today.
    still decline before VM execution.
 3. Property and assignment widening is no longer a blanket property-read/write
    gap, but several member-expression neighbors remain outside production:
-   private member deletes, private receiver-chain/mutation neighbors outside the
-   admitted direct named shapes, optional-chain neighbors outside the admitted
+   private receiver-chain/mutation neighbors outside the admitted direct named
+   shapes, optional-chain neighbors outside the admitted
    read/call/delete shapes, richer computed-key spans, unsupported RHS spans,
    optional/super/private mutation neighbors, and dynamic lookup outside the
-   explicit with-backed lane.
+   explicit with-backed lane. Private member deletes are parser early errors,
+   not production declines.
 4. Driver-state widening is next. Sync-driver TDZ head environments
    (`for (const x of …)` / `for (let k in …)`) are now admitted via the
    `TdzHeadInit` instruction (Slice A, #2678; see ADR 0288). Async iterator

--- a/src/Asynkron.JsEngine/Parser/JsAstParser.cs
+++ b/src/Asynkron.JsEngine/Parser/JsAstParser.cs
@@ -2536,7 +2536,8 @@ public sealed class JsAstParser(
 
             if (Match(TokenType.Delete))
             {
-                return new UnaryExpression(CreateSourceReference(Previous()), UnaryOperator.Delete, ParseUnary(), true);
+                var token = Previous();
+                return CreateUnaryExpression(token, UnaryOperator.Delete, ParseUnary());
             }
 
             if (Check(TokenType.Yield))
@@ -2874,7 +2875,7 @@ public sealed class JsAstParser(
                     TokenType.Delete => UnaryOperator.Delete,
                     _ => throw new InvalidOperationException()
                 };
-                var unary = new UnaryExpression(CreateSourceReference(token), op, operand, true);
+                var unary = CreateUnaryExpression(token, op, operand);
                 return ApplyCallSuffix(unary, allowCallSuffix);
             }
 
@@ -3036,6 +3037,34 @@ public sealed class JsAstParser(
         private ExpressionNode ApplyCallSuffix(ExpressionNode expression, bool allowCallSuffix)
         {
             return allowCallSuffix ? ParseCallSuffix(expression) : expression;
+        }
+
+        private UnaryExpression CreateUnaryExpression(Token token, UnaryOperator op, ExpressionNode operand)
+        {
+            if (op == UnaryOperator.Delete && TryGetPrivateMemberName(operand, out var privateName))
+            {
+                throw new ParseException($"Private field '{privateName}' cannot be deleted.", token, source);
+            }
+
+            return new UnaryExpression(CreateSourceReference(token), op, operand, true);
+        }
+
+        private static bool TryGetPrivateMemberName(ExpressionNode expression, out string privateName)
+        {
+            if (expression is MemberExpression
+                {
+                    IsComputed: false,
+                    Property: LiteralExpression { Value.IsString: true } property
+                } &&
+                property.Value.AsString() is { } propertyName &&
+                propertyName.IsPrivateName())
+            {
+                privateName = propertyName;
+                return true;
+            }
+
+            privateName = string.Empty;
+            return false;
         }
 
         private ImmutableArray<CallArgument> ParseArgumentList()

--- a/tests/Asynkron.JsEngine.Tests/PrivateNameEarlyErrorTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/PrivateNameEarlyErrorTests.cs
@@ -52,4 +52,67 @@ public sealed class PrivateNameEarlyErrorTests(ITestOutputHelper output) : Inter
 
         Assert.Equal(42.0, result);
     }
+
+    [Fact(Timeout = 2000)]
+    public async Task PrivateNamedPropertyDelete_ThrowsParseException()
+    {
+        await using var engine = CreateEngine();
+
+        var ex = await Assert.ThrowsAsync<ParseException>(async () =>
+        {
+            await engine.Evaluate("""
+                                  class C {
+                                      #x = 42;
+                                      remove() {
+                                          return delete this.#x;
+                                      }
+                                  }
+                                  """);
+        });
+
+        Assert.Contains("Private field '#x' cannot be deleted", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact(Timeout = 2000)]
+    public async Task DeletePublicPropertyReadThroughPrivateField_RemainsValid()
+    {
+        await using var engine = CreateEngine();
+
+        var result = await engine.Evaluate("""
+                                           class C {
+                                               #box = { value: 42 };
+                                               remove() {
+                                                   const deleted = delete this.#box.value;
+                                                   return deleted && this.#box.value === undefined;
+                                               }
+                                           }
+                                           new C().remove();
+                                           """);
+
+        Assert.True((bool)result!);
+    }
+
+    [Fact(Timeout = 2000)]
+    public async Task DirectEvalInsideClassMethod_PrivateNamedPropertyDelete_ThrowsSyntaxError()
+    {
+        await using var engine = CreateEngine();
+
+        var result = await engine.Evaluate("""
+                                           class C {
+                                               #x = 42;
+                                               removeViaEval() {
+                                                   try {
+                                                       eval("delete this.#x");
+                                                       return false;
+                                                   } catch (e) {
+                                                       return e instanceof SyntaxError &&
+                                                           e.message.indexOf("Private field '#x' cannot be deleted") >= 0;
+                                                   }
+                                               }
+                                           }
+                                           new C().removeViaEval();
+                                           """);
+
+        Assert.True((bool)result!);
+    }
 }

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -5,6 +5,7 @@ using Asynkron.JsEngine.Execution;
 using Asynkron.JsEngine.Execution.Instructions;
 using Asynkron.JsEngine.Execution.UnifiedBytecode;
 using Asynkron.JsEngine.JsTypes;
+using Asynkron.JsEngine.Parser;
 using Xunit.Abstractions;
 
 namespace Asynkron.JsEngine.Tests;
@@ -2798,26 +2799,21 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
-    public void Evaluate_PrivateNamedPropertyDelete_DeclinesWithExplicitCode()
+    public void Evaluate_PrivateNamedPropertyDelete_IsRejectedBeforeEligibility()
     {
-        var plan = GetClassMethodPlan("""
-            class Holder {
-                #field = 1;
-                remove(receiver) {
-                    return delete receiver.#field;
+        var ex = Assert.Throws<ParseException>(() =>
+            GetClassMethodPlan("""
+                class Holder {
+                    #field = 1;
+                    remove(receiver) {
+                        return delete receiver.#field;
+                    }
                 }
-            }
-            """,
-            "Holder",
-            "remove");
+                """,
+                "Holder",
+                "remove"));
 
-        var result = UnifiedBytecodeProductionEligibility.Evaluate(
-            plan,
-            new UnifiedBytecodeProductionActivationDescriptor());
-
-        Assert.False(result.IsEligible);
-        Assert.Equal(UnifiedBytecodeProductionDeclineCode.PrivateFieldDependency, result.Code);
-        Assert.Contains("Private-field", result.Reason, StringComparison.Ordinal);
+        Assert.Contains("Private field '#field' cannot be deleted", ex.Message, StringComparison.Ordinal);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- reject direct private-member delete syntax in the parser before expression/unified bytecode eligibility
- keep public property deletes through private-field receivers valid
- update the unified bytecode expansion contract so private deletes are no longer listed as production declines

## Tests
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~PrivateNameEarlyErrorTests|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_PrivateNamedPropertyDelete_IsRejectedBeforeEligibility|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramCoverageMapTests|FullyQualifiedName~DeleteOperatorTests|FullyQualifiedName~PrivateNameEarlyErrorTests"
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk git diff --check