### PR TITLE
Route optional named deletes through unified bytecode

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -334,7 +334,7 @@ must still obey the no-mixed-execution rule.
 | `PropertyUpdateDependency` | Property and identifier update expressions outside the admitted direct update, computed expression-key update, and simple nested named receiver update boundary | Existing sync IR update route | Property update lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedNamedPropertyUpdate_AcceptsOwnedPropertyOpcodes"` |
 | `DeleteDependency` | `delete` expressions outside the admitted ordinary named/computed property delete lane and the with-backed dynamic-name delete lane | Existing sync IR delete route | Delete semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_PropertyReadAdjacentFamilies_DeclineWithExplicitCodes"` |
 | `SuperPropertyDependency` | Out-of-boundary super call targets; super property reads/writes/updates are admitted by dedicated VM opcodes | Existing class / constructor route for remaining call-target shapes | Super semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperPropertyAccess_AcceptsOwnedOpcodes"` |
-| `OptionalChainDependency` | Optional chains outside the admitted optional property-read, optional-call, and exact optional computed delete boundaries | Existing sync IR optional-chain route | Optional-chain widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_OptionalSpreadCallExpressionPlan_DeclinesWithOptionalChainDependency"` |
+| `OptionalChainDependency` | Optional chains outside the admitted optional property-read, optional-call, and exact optional named/computed delete boundaries | Existing sync IR optional-chain route | Optional-chain widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_OptionalSpreadCallExpressionPlan_DeclinesWithOptionalChainDependency"` |
 | `ObjectLiteralOrSpreadDependency` | Non-simple object spread sources, unsupported array spread, spread construct arguments, and object methods/accessors only when they appear inside restricted simple literal spans | Existing sync IR literal/spread route for remaining spans | Literal/spread lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NonSimpleSourceArraySpread_DeclinesWithExplicitCode"` |
 | `PrivateFieldDependency` | Private-name operations outside the admitted routes; `#name in obj`, direct private named reads/writes/updates, direct private named compound/logical writes, and direct private named method calls are VM-owned when the surrounding class method is otherwise production-eligible. Private member deletes are parser early errors before production eligibility. | Existing private-name route for remaining private member access | Private-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_PrivateFieldIn_AcceptsAndVmChecksPrivateBrand"` |
 | `ForInDriverStateDependency` | Unsupported for-in driver state such as awaited object source | Existing for-in IR driver route | Driver-state lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~IsSupportedForInInit_AwaitedSource_Declines"` |
@@ -436,13 +436,15 @@ the final post-compile production subset check before VM entry.
   reads before the optional jump-to-chain-end boundary. Nested named receiver
   chains ending in a simple
   computed delete (`delete box.child[key]`) are admitted by
-  `TryIsFirstBoundaryComputedPropertyDeleteCandidate`; optional computed delete
-  chains are admitted for `delete box?.[key]`, `delete box?.child[key]`, and
-  `delete box.child?.[key]` shapes with activation-resolved receivers, supported
-  computed-key spans, and compiler-owned nullish short-circuit-to-true lowering
-  (ADR 0317 plus the simple optional-computed follow-up).
-  The compiler emits the named receiver reads and final `DeleteComputedProperty`,
-  while the VM's descriptor-aware delete helper owns strict/sloppy results.
+  `TryIsFirstBoundaryComputedPropertyDeleteCandidate`; optional named deletes
+  (`delete box?.value`, `delete box.child?.value`) and optional computed delete
+  chains (`delete box?.[key]`, `delete box?.child[key]`, and
+  `delete box.child?.[key]`) are admitted for activation-resolved receivers,
+  supported computed-key spans, and compiler-owned nullish short-circuit-to-true
+  lowering (ADR 0317 plus the optional delete follow-ups). The compiler emits
+  the named receiver reads and final `DeleteNamedProperty` /
+  `DeleteComputedProperty`, while the VM's descriptor-aware delete helper owns
+  strict/sloppy results.
   Retained declines include chained optional delete neighbors,
   private receiver-chain/mutation neighbors outside the admitted direct named
   shape, dynamic lookup, richer unowned computed-key spans, unsupported RHS

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -3749,6 +3749,22 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        if (TryAppendFirstBoundaryOptionalNamedPropertyDelete(
+                expressionProgram,
+                activationSlots,
+                unified,
+                literalConstants,
+                stringConstants,
+                out reason))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrEmpty(reason))
+        {
+            return false;
+        }
+
         if (TryAppendFirstBoundaryOptionalComputedPropertyDelete(
                 expressionProgram,
                 activationSlots,
@@ -7245,6 +7261,102 @@ internal static class UnifiedBytecodeCompiler
         unified.AddRange(stagedUnified);
         literalConstants.Clear();
         literalConstants.AddRange(stagedLiterals);
+        reason = string.Empty;
+        return true;
+    }
+
+    // Handles delete a?.b and delete a.b?.c, preserving the source program's nullish branch shape.
+    private static bool TryAppendFirstBoundaryOptionalNamedPropertyDelete(
+        ExpressionProgram expressionProgram,
+        ActivationSlotShape activationSlots,
+        ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
+        ImmutableArray<JsValue>.Builder literalConstants,
+        ImmutableArray<string>.Builder stringConstants,
+        out string reason)
+    {
+        if (expressionProgram.OperationCount < 6)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var expressionStringConstants = expressionProgram.StringConstants.AsSpan();
+        var jumpIndex = 1;
+        while (jumpIndex < expressionProgram.OperationCount)
+        {
+            var operation = expressionProgram.GetOperation(jumpIndex);
+            if (operation.Kind != ExpressionOpKind.GetNamedProperty ||
+                operation.IsOptional ||
+                operation.ShortCircuitOnNullishTarget ||
+                operation.GetString(expressionStringConstants).IsPrivateName())
+            {
+                break;
+            }
+
+            jumpIndex++;
+        }
+
+        if (jumpIndex >= expressionProgram.OperationCount)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var deleteIndex = expressionProgram.OperationCount - 4;
+        var endJumpIndexInProgram = expressionProgram.OperationCount - 3;
+        var popIndex = expressionProgram.OperationCount - 2;
+        var trueIndex = expressionProgram.OperationCount - 1;
+        var deleteProperty = expressionProgram.GetOperation(deleteIndex);
+        if (deleteIndex != jumpIndex + 1 ||
+            expressionProgram.GetOperation(jumpIndex) is not { Kind: ExpressionOpKind.JumpIfNullish, ReplaceWithUndefined: false } jumpIfNullish ||
+            jumpIfNullish.Target != popIndex ||
+            deleteProperty.Kind != ExpressionOpKind.DeleteNamedProperty ||
+            deleteProperty.GetString(expressionStringConstants).IsPrivateName() ||
+            expressionProgram.GetOperation(endJumpIndexInProgram).Kind != ExpressionOpKind.Jump ||
+            expressionProgram.GetOperation(endJumpIndexInProgram).Target != expressionProgram.OperationCount ||
+            expressionProgram.GetOperation(popIndex).Kind != ExpressionOpKind.Pop ||
+            !IsTrueLiteral(expressionProgram, trueIndex))
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        if (!TryAppendActivationValueLoad(
+                expressionProgram.GetOperation(0),
+                expressionProgram,
+                activationSlots,
+                unified,
+                out reason))
+        {
+            return false;
+        }
+
+        for (var index = 1; index < jumpIndex; index++)
+        {
+            var propertyRead = expressionProgram.GetOperation(index);
+            var propertyNameIndex = stringConstants.Count;
+            stringConstants.Add(propertyRead.GetString(expressionStringConstants));
+            unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.GetNamedProperty, propertyNameIndex));
+        }
+
+        var nullishJumpIndex = unified.Count;
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.JumpIfNullishReplaceUndefined, 0));
+
+        var deleteNameIndex = stringConstants.Count;
+        stringConstants.Add(deleteProperty.GetString(expressionStringConstants));
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.DeleteNamedProperty, deleteNameIndex));
+        var endJumpIndex = unified.Count;
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.Jump, 0));
+
+        var shortCircuitIndex = unified.Count;
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.Pop));
+        AddTrueLiteral(unified, literalConstants);
+
+        unified[nullishJumpIndex] = new UnifiedBytecodeInstruction(
+            UnifiedBytecodeOpCode.JumpIfNullishReplaceUndefined,
+            shortCircuitIndex);
+        unified[endJumpIndex] = new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.Jump, unified.Count);
+
         reason = string.Empty;
         return true;
     }

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -1119,6 +1119,11 @@ internal static class UnifiedBytecodeProductionEligibility
                         break;
                     }
 
+                    if (TryIsFirstBoundaryOptionalNamedPropertyDeleteCandidate(program, identifierConstants, activationSlots))
+                    {
+                        break;
+                    }
+
                     if (HasOptionalDeleteOperation(program))
                     {
                         declineCode = UnifiedBytecodeProductionDeclineCode.OptionalChainDependency;
@@ -1276,6 +1281,11 @@ internal static class UnifiedBytecodeProductionEligibility
                     return true;
 
                 case ExpressionOpKind.DeleteNamedProperty:
+                    if (TryIsFirstBoundaryOptionalNamedPropertyDeleteCandidate(program, identifierConstants, activationSlots))
+                    {
+                        break;
+                    }
+
                     if (HasOptionalDeleteOperation(program))
                     {
                         declineCode = UnifiedBytecodeProductionDeclineCode.OptionalChainDependency;
@@ -2002,6 +2012,58 @@ internal static class UnifiedBytecodeProductionEligibility
                    endExclusive: program.OperationCount - 1,
                    identifierConstants,
                    activationSlots);
+    }
+
+    // Admits delete a?.b and delete a.b?.c:
+    // [activation-resolved base, GetNamedProperty(non-optional, non-private)*,
+    //  JumpIfNullish, DeleteNamedProperty, Jump, Pop, true].
+    private static bool TryIsFirstBoundaryOptionalNamedPropertyDeleteCandidate(
+        ExpressionProgram program,
+        ReadOnlySpan<IdentifierOperand> identifierConstants,
+        ActivationSlotShape activationSlots)
+    {
+        if (program.OperationCount < 6 ||
+            !TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
+        {
+            return false;
+        }
+
+        var stringConstants = program.StringConstants.AsSpan();
+        var jumpIndex = 1;
+        while (jumpIndex < program.OperationCount)
+        {
+            var operation = program.GetOperation(jumpIndex);
+            if (operation.Kind != ExpressionOpKind.GetNamedProperty ||
+                operation.IsOptional ||
+                operation.ShortCircuitOnNullishTarget ||
+                operation.GetString(stringConstants).IsPrivateName())
+            {
+                break;
+            }
+
+            jumpIndex++;
+        }
+
+        if (jumpIndex >= program.OperationCount)
+        {
+            return false;
+        }
+
+        var deleteIndex = program.OperationCount - 4;
+        var endJumpIndex = program.OperationCount - 3;
+        var popIndex = program.OperationCount - 2;
+        var trueIndex = program.OperationCount - 1;
+        var deleteProperty = program.GetOperation(deleteIndex);
+
+        return deleteIndex == jumpIndex + 1 &&
+               program.GetOperation(jumpIndex) is { Kind: ExpressionOpKind.JumpIfNullish, ReplaceWithUndefined: false } jumpIfNullish &&
+               jumpIfNullish.Target == popIndex &&
+               deleteProperty.Kind == ExpressionOpKind.DeleteNamedProperty &&
+               !deleteProperty.GetString(stringConstants).IsPrivateName() &&
+               program.GetOperation(endJumpIndex).Kind == ExpressionOpKind.Jump &&
+               program.GetOperation(endJumpIndex).Target == program.OperationCount &&
+               program.GetOperation(popIndex).Kind == ExpressionOpKind.Pop &&
+               IsTrueLiteral(program, trueIndex);
     }
 
     // Admits delete a?.[k] and delete a.b?.[k]:

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -1393,6 +1393,39 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     [Theory]
     [InlineData(
         """
+        function remove(box) {
+            return delete box?.value;
+        }
+        """,
+        "remove")]
+    [InlineData(
+        """
+        function remove(box) {
+            return delete box.child?.value;
+        }
+        """,
+        "remove")]
+    public void Evaluate_OptionalNamedPropertyDeleteCandidate_AcceptsOwnedPropertyOpcodes(
+        string source,
+        string functionName)
+    {
+        var plan = GetFunctionPlan(source, functionName);
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.JumpIfNullishReplaceUndefined);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.DeleteNamedProperty);
+    }
+
+    [Theory]
+    [InlineData(
+        """
         function remove(box, key) {
             return delete box?.[key];
         }
@@ -2814,29 +2847,6 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
                 "remove"));
 
         Assert.Contains("Private field '#field' cannot be deleted", ex.Message, StringComparison.Ordinal);
-    }
-
-    [Theory]
-    [InlineData(
-        """
-        function remove(box) {
-            return delete box?.value;
-        }
-        """,
-        "remove")]
-    public void Evaluate_OptionalPropertyDelete_DeclinesWithExplicitCode(
-        string source,
-        string functionName)
-    {
-        var plan = GetFunctionPlan(source, functionName);
-
-        var result = UnifiedBytecodeProductionEligibility.Evaluate(
-            plan,
-            new UnifiedBytecodeProductionActivationDescriptor());
-
-        Assert.False(result.IsEligible);
-        Assert.Equal(UnifiedBytecodeProductionDeclineCode.OptionalChainDependency, result.Code);
-        Assert.Contains("Optional-chain", result.Reason, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -4592,6 +4592,30 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task OptionalNamedPropertyDelete_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function remove(box) {
+                return delete box?.value;
+            }
+
+            var box = { value: 42 };
+            var removed = remove(box);
+            var skipped = remove(null);
+            removed + "|" +
+                skipped + "|" +
+                Object.prototype.hasOwnProperty.call(box, "value");
+            """);
+
+        Assert.Equal("true|true|false", result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=remove argc=1",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task ComputedPropertyDelete_UsesUnifiedBytecodeProductionFastPathAndKeySemantics()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit optional named property deletes such as delete box?.value and delete box.child?.value in production unified bytecode
- add the matching compiler lowering for the nullish-to-true delete branch
- update tests/docs so optional named deletes are no longer listed as optional-chain declines

## Tests
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_OptionalNamedPropertyDeleteCandidate_AcceptsOwnedPropertyOpcodes|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_UnsupportedOptionalComputedPropertyDeleteNeighbor_DeclinesWithExplicitCode|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalNamedPropertyDelete_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~ExpressionProgramLoweringTests.ReturnInstruction_DeleteOptionalNamedProperty_IsLoweredToExpressionProgram|FullyQualifiedName~AstFreeExecutionAssertionTests.AssertNoAstEvaluation_Enabled_AllowsDeleteOptionalNamedPropertyExecution|FullyQualifiedName~ExecutionPlanDiagnosticsTests|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~ExpressionProgramLoweringTests|FullyQualifiedName~AstFreeExecutionAssertionTests|FullyQualifiedName~ExpressionProgramCoverageMapTests|FullyQualifiedName~DeleteOperatorTests"
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk git diff --check