### PR TITLE
Admit chained optional computed deletes

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -438,14 +438,15 @@ the final post-compile production subset check before VM entry.
   computed delete (`delete box.child[key]`, `delete box.child[left + right]`)
   are admitted by `TryIsFirstBoundaryComputedPropertyDeleteCandidate`; optional
   named deletes (`delete box?.value`, `delete box.child?.value`) and optional
-  computed delete chains (`delete box?.[key]`, `delete box?.child[key]`, and
-  `delete box.child?.[key]`) are admitted for activation-resolved receivers,
-  supported computed-key spans, and compiler-owned nullish short-circuit-to-true
-  lowering (ADR 0317 plus the optional delete follow-ups). The compiler emits
-  the named receiver reads and final `DeleteNamedProperty` /
+  computed delete chains (`delete box?.[key]`, `delete box?.child[key]`,
+  `delete box.child?.[key]`, and `delete box?.child?.[key]`) are admitted for
+  activation-resolved receivers, supported computed-key spans, and
+  compiler-owned nullish short-circuit-to-true lowering (ADR 0317 plus the
+  optional delete follow-ups). The compiler emits the named receiver reads and
+  final `DeleteNamedProperty` /
   `DeleteComputedProperty`, while the VM's descriptor-aware delete helper owns
   strict/sloppy results.
-  Retained declines include chained optional delete neighbors,
+  Retained declines include unsupported chained optional delete neighbors,
   private receiver-chain/mutation neighbors outside the admitted direct named
   shape, dynamic lookup, unsupported computed-key spans, unsupported RHS
   spans, and optional/super/private neighbors of computed-key mutation shapes.

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -7385,6 +7385,22 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        if (TryAppendFirstBoundaryOptionalNamedThenOptionalComputedPropertyDelete(
+                expressionProgram,
+                activationSlots,
+                unified,
+                literalConstants,
+                stringConstants,
+                out reason))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrEmpty(reason))
+        {
+            return false;
+        }
+
         return TryAppendFirstBoundaryOptionalComputedPropertyDeleteWithJump(
             expressionProgram,
             activationSlots,
@@ -7445,6 +7461,96 @@ internal static class UnifiedBytecodeCompiler
                 literalConstants,
                 startInclusive: 2,
                 endExclusive: expressionProgram.OperationCount - 1,
+                out reason))
+        {
+            return false;
+        }
+
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.DeleteComputedProperty));
+        var endJumpIndex = unified.Count;
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.Jump, 0));
+
+        var shortCircuitIndex = unified.Count;
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.Pop));
+        AddTrueLiteral(unified, literalConstants);
+
+        unified[nullishJumpIndex] = new UnifiedBytecodeInstruction(
+            UnifiedBytecodeOpCode.JumpIfNullishReplaceUndefined,
+            shortCircuitIndex);
+        unified[endJumpIndex] = new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.Jump, unified.Count);
+
+        reason = string.Empty;
+        return true;
+    }
+
+    // Handles delete a?.b?.[k], preserving the source program's nullish branch shape.
+    private static bool TryAppendFirstBoundaryOptionalNamedThenOptionalComputedPropertyDelete(
+        ExpressionProgram expressionProgram,
+        ActivationSlotShape activationSlots,
+        ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
+        ImmutableArray<JsValue>.Builder literalConstants,
+        ImmutableArray<string>.Builder stringConstants,
+        out string reason)
+    {
+        if (expressionProgram.OperationCount < 7)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var expressionStringConstants = expressionProgram.StringConstants.AsSpan();
+        var firstHop = expressionProgram.GetOperation(1);
+        if (firstHop.Kind != ExpressionOpKind.GetNamedProperty ||
+            !firstHop.IsOptional ||
+            firstHop.ShortCircuitOnNullishTarget ||
+            firstHop.GetString(expressionStringConstants).IsPrivateName())
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var jumpIndex = 2;
+        var deleteIndex = expressionProgram.OperationCount - 4;
+        var endJumpIndexInProgram = expressionProgram.OperationCount - 3;
+        var popIndex = expressionProgram.OperationCount - 2;
+        var trueIndex = expressionProgram.OperationCount - 1;
+        if (deleteIndex <= jumpIndex + 1 ||
+            expressionProgram.GetOperation(jumpIndex) is not { Kind: ExpressionOpKind.JumpIfNullish, ReplaceWithUndefined: false } jumpIfNullish ||
+            jumpIfNullish.Target != popIndex ||
+            expressionProgram.GetOperation(deleteIndex).Kind != ExpressionOpKind.DeleteComputedProperty ||
+            expressionProgram.GetOperation(endJumpIndexInProgram).Kind != ExpressionOpKind.Jump ||
+            expressionProgram.GetOperation(endJumpIndexInProgram).Target != expressionProgram.OperationCount ||
+            expressionProgram.GetOperation(popIndex).Kind != ExpressionOpKind.Pop ||
+            !IsTrueLiteral(expressionProgram, trueIndex))
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        if (!TryAppendActivationValueLoad(
+                expressionProgram.GetOperation(0),
+                expressionProgram,
+                activationSlots,
+                unified,
+                out reason))
+        {
+            return false;
+        }
+
+        var propertyNameIndex = stringConstants.Count;
+        stringConstants.Add(firstHop.GetString(expressionStringConstants));
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.GetNamedPropertyOptional, propertyNameIndex));
+
+        var nullishJumpIndex = unified.Count;
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.JumpIfNullishReplaceUndefined, 0));
+
+        if (!TryAppendComputedPropertyKeySpan(
+                expressionProgram,
+                activationSlots,
+                unified,
+                literalConstants,
+                startInclusive: jumpIndex + 1,
+                endExclusive: deleteIndex,
                 out reason))
         {
             return false;

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -1119,6 +1119,11 @@ internal static class UnifiedBytecodeProductionEligibility
                         break;
                     }
 
+                    if (TryIsFirstBoundaryOptionalNamedThenOptionalComputedPropertyDeleteCandidate(program, identifierConstants, activationSlots))
+                    {
+                        break;
+                    }
+
                     if (TryIsFirstBoundaryOptionalNamedPropertyDeleteCandidate(program, identifierConstants, activationSlots))
                     {
                         break;
@@ -1306,6 +1311,7 @@ internal static class UnifiedBytecodeProductionEligibility
 
                 case ExpressionOpKind.DeleteComputedProperty:
                     if (TryIsFirstBoundaryOptionalNamedThenComputedPropertyDeleteCandidate(program, identifierConstants, activationSlots) ||
+                        TryIsFirstBoundaryOptionalNamedThenOptionalComputedPropertyDeleteCandidate(program, identifierConstants, activationSlots) ||
                         TryIsFirstBoundaryOptionalComputedPropertyDeleteCandidate(program, identifierConstants, activationSlots))
                     {
                         break;
@@ -2066,6 +2072,52 @@ internal static class UnifiedBytecodeProductionEligibility
                jumpIfNullish.Target == popIndex &&
                deleteProperty.Kind == ExpressionOpKind.DeleteNamedProperty &&
                !deleteProperty.GetString(stringConstants).IsPrivateName() &&
+               program.GetOperation(endJumpIndex).Kind == ExpressionOpKind.Jump &&
+               program.GetOperation(endJumpIndex).Target == program.OperationCount &&
+               program.GetOperation(popIndex).Kind == ExpressionOpKind.Pop &&
+               IsTrueLiteral(program, trueIndex);
+    }
+
+    // Admits delete a?.b?.[k]:
+    // [activation-resolved base, GetNamedProperty(IsOptional:true, !SC, non-private),
+    //  JumpIfNullish, supported key span, DeleteComputedProperty, Jump, Pop, true].
+    private static bool TryIsFirstBoundaryOptionalNamedThenOptionalComputedPropertyDeleteCandidate(
+        ExpressionProgram program,
+        ReadOnlySpan<IdentifierOperand> identifierConstants,
+        ActivationSlotShape activationSlots)
+    {
+        if (program.OperationCount < 7 ||
+            !TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
+        {
+            return false;
+        }
+
+        var stringConstants = program.StringConstants.AsSpan();
+        var firstHop = program.GetOperation(1);
+        if (firstHop.Kind != ExpressionOpKind.GetNamedProperty ||
+            !firstHop.IsOptional ||
+            firstHop.ShortCircuitOnNullishTarget ||
+            firstHop.GetString(stringConstants).IsPrivateName())
+        {
+            return false;
+        }
+
+        var jumpIndex = 2;
+        var deleteIndex = program.OperationCount - 4;
+        var endJumpIndex = program.OperationCount - 3;
+        var popIndex = program.OperationCount - 2;
+        var trueIndex = program.OperationCount - 1;
+
+        return deleteIndex > jumpIndex + 1 &&
+               program.GetOperation(jumpIndex) is { Kind: ExpressionOpKind.JumpIfNullish, ReplaceWithUndefined: false } jumpIfNullish &&
+               jumpIfNullish.Target == popIndex &&
+               IsSupportedComputedPropertyKeySpan(
+                   program,
+                   startInclusive: jumpIndex + 1,
+                   endExclusive: deleteIndex,
+                   identifierConstants,
+                   activationSlots) &&
+               program.GetOperation(deleteIndex).Kind == ExpressionOpKind.DeleteComputedProperty &&
                program.GetOperation(endJumpIndex).Kind == ExpressionOpKind.Jump &&
                program.GetOperation(endJumpIndex).Target == program.OperationCount &&
                program.GetOperation(popIndex).Kind == ExpressionOpKind.Pop &&

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -1467,6 +1467,13 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         }
         """,
         "remove")]
+    [InlineData(
+        """
+        function remove(box, key) {
+            return delete box?.child?.[key];
+        }
+        """,
+        "remove")]
     public void Evaluate_OptionalComputedPropertyDeleteCandidate_AcceptsOwnedPropertyOpcodes(
         string source,
         string functionName)
@@ -2869,29 +2876,6 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
                 "remove"));
 
         Assert.Contains("Private field '#field' cannot be deleted", ex.Message, StringComparison.Ordinal);
-    }
-
-    [Theory]
-    [InlineData(
-        """
-        function remove(box, key) {
-            return delete box?.child?.[key];
-        }
-        """,
-        "remove")]
-    public void Evaluate_UnsupportedOptionalComputedPropertyDeleteNeighbor_DeclinesWithExplicitCode(
-        string source,
-        string functionName)
-    {
-        var plan = GetFunctionPlan(source, functionName);
-
-        var result = UnifiedBytecodeProductionEligibility.Evaluate(
-            plan,
-            new UnifiedBytecodeProductionActivationDescriptor());
-
-        Assert.False(result.IsEligible);
-        Assert.Equal(UnifiedBytecodeProductionDeclineCode.OptionalChainDependency, result.Code);
-        Assert.Contains("Optional-chain", result.Reason, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -4728,6 +4728,41 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task OptionalNamedThenOptionalComputedPropertyDelete_UsesUnifiedBytecodeProductionFastPathAndSkipsNullishKey()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var hits = 0;
+            var key = {
+                toString() {
+                    hits = hits + 1;
+                    return "value";
+                }
+            };
+
+            function remove(box, key) {
+                return delete box?.child?.[key];
+            }
+
+            var child = { value: 42 };
+            var removed = remove({ child: child }, key);
+            var skippedBase = remove(null, key);
+            var skippedChild = remove({ child: null }, key);
+            removed + "|" +
+                skippedBase + "|" +
+                skippedChild + "|" +
+                hits + "|" +
+                Object.prototype.hasOwnProperty.call(child, "value");
+            """);
+
+        Assert.Equal("true|true|true|1|false", result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=remove argc=2",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task OptionalComputedPropertyDelete_UsesUnifiedBytecodeProductionFastPathAndSkipsNullishKey()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit the bounded optional delete chain delete box?.child?.[key]
- add compiler lowering for optional named hop plus optional computed delete true-short-circuit branch
- update production tests/docs so this shape no longer declines as OptionalChainDependency

## Tests
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_OptionalComputedPropertyDeleteCandidate_AcceptsOwnedPropertyOpcodes|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalNamedThenOptionalComputedPropertyDelete_UsesUnifiedBytecodeProductionFastPathAndSkipsNullishKey|FullyQualifiedName~ExpressionProgramLoweringTests.ReturnInstruction_DeleteOptionalComputedProperty_IsLoweredToExpressionProgram|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~ExpressionProgramLoweringTests|FullyQualifiedName~ExpressionProgramCoverageMapTests|FullyQualifiedName~DeleteOperatorTests|FullyQualifiedName~AstFreeExecutionAssertionTests"
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk git diff --check