### PR TITLE
Admit optional computed spread calls

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -559,9 +559,11 @@ the final post-compile production subset check before VM entry.
   VM flattens spread iterables left-to-right at the boundary via the shared
   `TypedAstEvaluator.EnumerateSpread` helper, preserving iteration order and
   side-effects, then invokes through the existing callable helpers with
-  receiver-as-`this`. Direct eval is admitted only for the one-argument
+  receiver-as-`this`. Optional-start computed member spread calls such as
+  `a?.box[key](...args)` use the same spread-mask boundary after the optional
+  receiver has been resolved. Direct eval is admitted only for the one-argument
   non-spread eval-identifier shape; multi-argument/spread direct eval, super
-  spread, and optional spread calls stay declined.
+  spread, and callee-optional spread calls stay declined.
 - Synchronous construct calls are admitted (gh2690 plus the construct-boundary
   widening): `new F(...)`, `new F(...args)`, `new box.Ctor(...)`, and
   `new box[key](...)` when the constructor/key/argument subexpressions are
@@ -787,10 +789,12 @@ support today.
    invocation shapes are now admitted too (PR #2862, ADR 0307): non-spread
    derived-constructor `super(...)` plus named/computed super-member calls.
    Simple array and object literal arguments (`fn([a, b])`, `fn({x: a})`) are
-   now admitted (gh2705, ADR 0290). Simple object literal spread entries are now
-   admitted through the `ObjectSpread` opcode when their spread source is a
-   simple operand. Direct eval outside the one-argument non-spread
-   eval-identifier boundary, spread super constructs, spread-onto-optional,
+   now admitted (gh2705, ADR 0290). Optional-start computed member spread calls
+   (`a?.box[key](...args)`) are also admitted through the shared spread-mask
+   invocation boundary. Simple object literal spread entries are now admitted
+   through the `ObjectSpread` opcode when their spread source is a simple
+   operand. Direct eval outside the one-argument non-spread
+   eval-identifier boundary, spread super constructs, spread callee-optional calls,
    private-adjacent member targets outside the admitted direct named method-call
    shape, complex receiver/key shapes, non-simple literal argument spans, and receiver-binding-sensitive adjacent families beyond the
    direct activation-resolved and with-backed dynamic-identifier boundaries must

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -3078,13 +3078,6 @@ internal static class UnifiedBytecodeProductionEligibility
             return false;
         }
 
-        // Keep AC-4 boundary for gh2828 narrow: optional-start computed plain-call
-        // admission does not include spread arguments in this slice.
-        if (call.SpreadMaskConstantIndex >= 0)
-        {
-            return false;
-        }
-
         var computedCallTargetIndex = FindFirstOperation(program, ExpressionOpKind.LoadComputedCallTarget);
         if (computedCallTargetIndex != 4)
         {

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -795,9 +795,8 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
-    public void Evaluate_OptionalChainComputedPlainSpreadCallExpressionPlan_Declines()
+    public void Evaluate_OptionalChainComputedPlainSpreadCallExpressionPlan_AcceptsExecutableInvocationBoundary()
     {
-        // gh2828 AC-4: keep spread variants out of the optional-start computed plain-call slice.
         var plan = GetFunctionPlan("""
             function invoke(a, key, args) {
                 return a?.box[key](...args);
@@ -809,7 +808,13 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
             plan,
             new UnifiedBytecodeProductionActivationDescriptor());
 
-        Assert.False(result.IsEligible);
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.PrepareComputedCallTarget);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.CallInvocationBoundary);
+        Assert.NotEmpty(result.Program.CallSpreadMasks);
     }
 
     [Fact]

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -2866,6 +2866,35 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task OptionalChainComputedPlainSpreadCall_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function invoke(a, key, args) {
+                return a?.box[key](...args);
+            }
+
+            var holder = {
+                box: {
+                    sum(a, b) {
+                        return this === holder.box ? a + b : -1;
+                    }
+                }
+            };
+
+            var present = invoke(holder, "sum", [20, 22]);
+            var missing = invoke(null, "sum", [1, 2]);
+            present + ":" + missing;
+            """);
+
+        Assert.Equal("42:undefined", result?.ToString());
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=invoke",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task LooseEqualityBranchFunction_UsesUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit optional-start computed member spread calls such as a?.box[key](...args)
- use the existing spread-mask call boundary for the optional computed call path
- update the production eligibility/runtime proofs and bytecode expansion contract

## Tests
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_OptionalChainComputedPlainSpreadCallExpressionPlan_AcceptsExecutableInvocationBoundary|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalChainComputedPlainSpreadCall_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionSpreadCallTests|FullyQualifiedName~ExpressionProgramLoweringTests.ReturnInstruction_SpreadCallExpression_IsLoweredToExpressionProgram|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~UnifiedBytecodeProductionSpreadCallTests|FullyQualifiedName~ExpressionProgramLoweringTests|FullyQualifiedName~ExpressionProgramCoverageMapTests|FullyQualifiedName~AstFreeExecutionAssertionTests"
- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk git diff --check