### PR TITLE
Admit optional identifier spread calls

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -261,6 +261,7 @@ statement interpretation.
 - `ObjectDestructuringRest`
 - `ObjectDestructuringClose`
 - `PrepareIdentifierCallTarget`
+- `PrepareIdentifierOptionalCallTarget`
 - `PrepareDynamicIdentifierCallTarget`
 - `PrepareNamedCallTarget`
 - `PrepareComputedCallTarget`
@@ -334,7 +335,7 @@ must still obey the no-mixed-execution rule.
 | `PropertyUpdateDependency` | Property and identifier update expressions outside the admitted direct update, computed expression-key update, and simple nested named receiver update boundary | Existing sync IR update route | Property update lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedNamedPropertyUpdate_AcceptsOwnedPropertyOpcodes"` |
 | `DeleteDependency` | `delete` expressions outside the admitted ordinary named/computed property delete lane and the with-backed dynamic-name delete lane | Existing sync IR delete route | Delete semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_PropertyReadAdjacentFamilies_DeclineWithExplicitCodes"` |
 | `SuperPropertyDependency` | Out-of-boundary super call targets; super property reads/writes/updates are admitted by dedicated VM opcodes | Existing class / constructor route for remaining call-target shapes | Super semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperPropertyAccess_AcceptsOwnedOpcodes"` |
-| `OptionalChainDependency` | Optional chains outside the admitted optional property-read, optional-call, and exact optional named/computed delete boundaries | Existing sync IR optional-chain route | Optional-chain widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_OptionalSpreadCallExpressionPlan_DeclinesWithOptionalChainDependency"` |
+| `OptionalChainDependency` | Optional chains outside the admitted optional property-read, optional-call, and exact optional named/computed delete boundaries | Existing sync IR optional-chain route | Optional-chain widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_OptionalChainNonActivationBaseCallExpressionPlan_Declines"` |
 | `ObjectLiteralOrSpreadDependency` | Non-simple object spread sources, unsupported array spread, spread construct arguments, and object methods/accessors only when they appear inside restricted simple literal spans | Existing sync IR literal/spread route for remaining spans | Literal/spread lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NonSimpleSourceArraySpread_DeclinesWithExplicitCode"` |
 | `PrivateFieldDependency` | Private-name operations outside the admitted routes; `#name in obj`, direct private named reads/writes/updates, direct private named compound/logical writes, and direct private named method calls are VM-owned when the surrounding class method is otherwise production-eligible. Private member deletes are parser early errors before production eligibility. | Existing private-name route for remaining private member access | Private-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_PrivateFieldIn_AcceptsAndVmChecksPrivateBrand"` |
 | `ForInDriverStateDependency` | Unsupported for-in driver state such as awaited object source | Existing for-in IR driver route | Driver-state lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~IsSupportedForInInit_AwaitedSource_Declines"` |
@@ -559,11 +560,13 @@ the final post-compile production subset check before VM entry.
   VM flattens spread iterables left-to-right at the boundary via the shared
   `TypedAstEvaluator.EnumerateSpread` helper, preserving iteration order and
   side-effects, then invokes through the existing callable helpers with
-  receiver-as-`this`. Optional-start computed member spread calls such as
+  receiver-as-`this`. Optional identifier spread calls such as `fn?.(...args)`
+  skip argument lowering when `fn` is nullish and otherwise use the same
+  spread-mask boundary. Optional-start computed member spread calls such as
   `a?.box[key](...args)` use the same spread-mask boundary after the optional
   receiver has been resolved. Direct eval is admitted only for the one-argument
-  non-spread eval-identifier shape; multi-argument/spread direct eval, super
-  spread, and callee-optional spread calls stay declined.
+  non-spread eval-identifier shape; multi-argument/spread direct eval and super
+  spread stay declined.
 - Synchronous construct calls are admitted (gh2690 plus the construct-boundary
   widening): `new F(...)`, `new F(...args)`, `new box.Ctor(...)`, and
   `new box[key](...)` when the constructor/key/argument subexpressions are
@@ -582,11 +585,14 @@ the final post-compile production subset check before VM entry.
   caller's `new.target`, initializes `this`, and preserves the existing
   double-super-call `ReferenceError`. Spread super constructs
   (`super(...args)`) stay declined as spread construct arguments.
-- Accepted identifier-call programs use `PrepareIdentifierCallTarget` followed
-  by `CallInvocationBoundary`; the VM resolves the callable from unified
-  bytecode-owned slot state and invokes it through existing callable invocation
-  helpers with the active `EvaluationContext` and caller `JsEnvironment` when
-  the callee needs environment-aware or debug-aware invocation state.
+- Accepted identifier-call programs use `PrepareIdentifierCallTarget` or
+  `PrepareIdentifierOptionalCallTarget` followed by `CallInvocationBoundary`;
+  the VM resolves the callable from unified bytecode-owned slot state and
+  invokes it through existing callable invocation helpers with the active
+  `EvaluationContext` and caller `JsEnvironment` when the callee needs
+  environment-aware or debug-aware invocation state. The optional variant packs
+  a nullish short-circuit jump target and jumps past argument lowering and the
+  call boundary when the callee slot is nullish.
 - Accepted named member-call programs use `PrepareNamedCallTarget` followed by
   `CallInvocationBoundary`; the VM keeps the final receiver on the stack, loads
   the named callee from that receiver, and invokes through the existing
@@ -609,17 +615,19 @@ the final post-compile production subset check before VM entry.
   still use the first-boundary call-target helper because they carry
   boundary-local directness metadata or packed nullish short-circuit jump
   targets.
-- Accepted optional member-call programs use `PrepareNamedOptionalCallTarget`
-  or `PrepareComputedOptionalCallTarget` followed by `CallInvocationBoundary`.
-  Both opcodes pack a call-target constant index (low 16 bits) and a nullish
-  short-circuit jump target (high 16 bits) into a single operand. The VM checks
-  the receiver or callee for nullish before evaluation proceeds; if nullish the
-  stack top is replaced with `Undefined` and execution jumps past the call
-  boundary. Three patterns are admitted: receiver-optional named calls
-  (`box?.read(args)`), callee-optional named calls (`box.read?.(args)`), and
-  callee-optional computed calls (`box[key]?.(args)`). The `IsOptionalReceiverCheck`
-  flag in `UnifiedBytecodeCallTarget` distinguishes the two named variants.
-  (Optional calls admitted as of gh2689; ADR 0289.)
+- Accepted optional call programs use `PrepareIdentifierOptionalCallTarget`,
+  `PrepareNamedOptionalCallTarget`, or `PrepareComputedOptionalCallTarget`
+  followed by `CallInvocationBoundary`. These opcodes pack a call-target
+  constant index (low 16 bits) and a nullish short-circuit jump target (high 16
+  bits) into a single operand. The VM checks the receiver or callee for nullish
+  before argument evaluation proceeds; if nullish, the stack top becomes
+  `Undefined` and execution jumps past the call boundary. Four patterns are
+  admitted: callee-optional identifier calls (`fn?.(args)`), receiver-optional
+  named calls (`box?.read(args)`), callee-optional named calls
+  (`box.read?.(args)`), and callee-optional computed calls (`box[key]?.(args)`).
+  The `IsOptionalReceiverCheck` flag in `UnifiedBytecodeCallTarget`
+  distinguishes the two named variants. (Optional member calls admitted as of
+  gh2689; ADR 0289.)
 - Direct eval programs use `PrepareIdentifierCallTarget` followed by
   `CallInvocationBoundary` with the direct-eval operand flag. The admitted shape
   is exactly one non-spread eval-identifier argument; the VM invokes the eval host

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -4792,6 +4792,25 @@ internal static class UnifiedBytecodeCompiler
                 return false;
             }
 
+            if (TryAppendCalleeOptionalIdentifierCallTarget(
+                    expressionProgram,
+                    slotLayout,
+                    unified,
+                    literalConstants,
+                    stringConstants,
+                    callTargetConstants,
+                    call,
+                    callIndex,
+                    out reason))
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(reason))
+            {
+                return false;
+            }
+
             if (TryAppendNamedMemberCallTargetPreparation(
                     expressionProgram,
                     slotLayout,
@@ -4945,6 +4964,79 @@ internal static class UnifiedBytecodeCompiler
             argsStartIndex: 1,
             call,
             out reason);
+    }
+
+    private static bool TryAppendCalleeOptionalIdentifierCallTarget(
+        ExpressionProgram expressionProgram,
+        UnifiedBytecodeSlotLayout slotLayout,
+        ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
+        ImmutableArray<JsValue>.Builder literalConstants,
+        ImmutableArray<string>.Builder stringConstants,
+        ImmutableArray<UnifiedBytecodeCallTarget>.Builder callTargetConstants,
+        PackedExpressionOp call,
+        int callIndex,
+        out string reason)
+    {
+        if (callIndex < 2)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var callTarget = expressionProgram.GetOperation(0);
+        if (callTarget.Kind != ExpressionOpKind.LoadIdentifierCallTarget)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var jumpOp = expressionProgram.GetOperation(1);
+        if (jumpOp.Kind != ExpressionOpKind.JumpIfNullish || !jumpOp.ReplaceWithUndefined)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        var identifier = callTarget.GetIdentifier(expressionProgram.IdentifierConstants.AsSpan());
+        if (!TryResolveActivationCallTargetSlot(identifier, slotLayout, out var slotIndex))
+        {
+            reason = callTarget.IsArguments
+                ? "arguments call targets are outside the optional identifier call-target preparation boundary."
+                : "Optional identifier call targets require an activation-resolved identifier slot.";
+            return false;
+        }
+
+        var nameIndex = stringConstants.Count;
+        stringConstants.Add(identifier.Name.Name ?? string.Empty);
+        var callTargetConstantIndex = callTargetConstants.Count;
+        callTargetConstants.Add(new UnifiedBytecodeCallTarget(
+            UnifiedBytecodeCallTargetKind.Identifier,
+            slotIndex,
+            nameIndex));
+
+        var prepareIndex = unified.Count;
+        unified.Add(new UnifiedBytecodeInstruction(
+            UnifiedBytecodeOpCode.PrepareIdentifierOptionalCallTarget,
+            callTargetConstantIndex));
+
+        if (!TryAppendCallArguments(
+                expressionProgram,
+                slotLayout,
+                unified,
+                literalConstants,
+                stringConstants,
+                argsStartIndex: 2,
+                call,
+                callIndex,
+                out reason))
+        {
+            return false;
+        }
+
+        unified[prepareIndex] = new UnifiedBytecodeInstruction(
+            UnifiedBytecodeOpCode.PrepareIdentifierOptionalCallTarget,
+            callTargetConstantIndex | (unified.Count << 16));
+        return true;
     }
 
     private static bool TryAppendNamedMemberCallTargetPreparation(

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -2611,12 +2611,13 @@ internal static class UnifiedBytecodeProductionEligibility
             return false;
         }
 
-        // Optional-call shapes (box?.read(), box.read?.(), box[key]?.()) carry a
+        // Optional-call shapes (fn?.(), box?.read(), box.read?.(), box[key]?.()) carry a
         // JumpIfNullish short-circuit and, for callee-optional cases, a trailing
         // Jump/SwapTopTwo/Pop structure that the non-optional branches below would
         // reject (or never reach, because they end in Pop rather than Call). Detect
         // them first so the dedicated optional candidates own these shapes.
-        if (TryIsFirstBoundaryReceiverOptionalNamedCallCandidate(program, identifierConstants, stringConstants, activationSlots) ||
+        if (TryIsFirstBoundaryCalleeOptionalIdentifierCallCandidate(program, identifierConstants, activationSlots) ||
+            TryIsFirstBoundaryReceiverOptionalNamedCallCandidate(program, identifierConstants, stringConstants, activationSlots) ||
             TryIsFirstBoundaryCalleeOptionalNamedCallCandidate(program, identifierConstants, stringConstants, activationSlots) ||
             TryIsFirstBoundaryCalleeOptionalComputedCallCandidate(program, identifierConstants, activationSlots) ||
             TryIsFirstBoundaryOptionalChainPlainCallCandidate(program, identifierConstants, stringConstants, activationSlots) ||
@@ -2762,6 +2763,52 @@ internal static class UnifiedBytecodeProductionEligibility
 
     private static bool IsDirectEvalSingleArgumentCandidate(PackedExpressionOp operation) =>
         operation.Kind is ExpressionOpKind.LoadIdentifier or ExpressionOpKind.LoadLiteral;
+
+    // Case 0: fn?.(args) — callee-optional identifier call
+    // Expression program: [LoadIdentifierCallTarget, JumpIfNullish, args..., Call, Jump, SwapTopTwo, Pop]
+    private static bool TryIsFirstBoundaryCalleeOptionalIdentifierCallCandidate(
+        ExpressionProgram program,
+        ReadOnlySpan<IdentifierOperand> identifierConstants,
+        ActivationSlotShape activationSlots)
+    {
+        if (program.OperationCount < 6)
+        {
+            return false;
+        }
+
+        if (!IsCalleeOptionalTrailingStructure(program, out var callIndex))
+        {
+            return false;
+        }
+
+        var call = program.GetOperation(callIndex);
+        if (!call.HasExplicitThis || call.IsDirectEval)
+        {
+            return false;
+        }
+
+        var callTarget = program.GetOperation(0);
+        if (callTarget.Kind != ExpressionOpKind.LoadIdentifierCallTarget || callTarget.IsArguments)
+        {
+            return false;
+        }
+
+        var jumpOp = program.GetOperation(1);
+        if (jumpOp.Kind != ExpressionOpKind.JumpIfNullish || !jumpOp.ReplaceWithUndefined)
+        {
+            return false;
+        }
+
+        var identifier = callTarget.GetIdentifier(identifierConstants);
+        return TryResolveActivationSlot(identifier, activationSlots) &&
+               HasSimpleCallArguments(
+                   program,
+                   identifierConstants,
+                   activationSlots,
+                   argsStartIndex: 2,
+                   call,
+                   callIndex);
+    }
 
     // Case 1: box?.read(args) — receiver-optional named call
     // Expression program: [Receiver..., JumpIfNullish, LoadNamedCallTarget, args..., Call]
@@ -4469,6 +4516,7 @@ internal static class UnifiedBytecodeProductionEligibility
                 case UnifiedBytecodeOpCode.LoadLiteral:
                 case UnifiedBytecodeOpCode.LoadRegexLiteral:
                 case UnifiedBytecodeOpCode.PrepareIdentifierCallTarget:
+                case UnifiedBytecodeOpCode.PrepareIdentifierOptionalCallTarget:
                 case UnifiedBytecodeOpCode.PrepareDynamicIdentifierCallTarget:
                 case UnifiedBytecodeOpCode.PrepareNamedCallTarget:
                 case UnifiedBytecodeOpCode.PrepareComputedCallTarget:

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProgram.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProgram.cs
@@ -111,6 +111,7 @@ internal enum UnifiedBytecodeOpCode : byte
     ObjectDestructuringRest,
     ObjectDestructuringClose,
     PrepareIdentifierCallTarget,
+    PrepareIdentifierOptionalCallTarget,
     PrepareDynamicIdentifierCallTarget,
     PrepareNamedCallTarget,
     PrepareComputedCallTarget,

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeVirtualMachine.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeVirtualMachine.cs
@@ -345,6 +345,53 @@ internal static class UnifiedBytecodeVirtualMachine
                     programCounter++;
                     break;
 
+                case UnifiedBytecodeOpCode.PrepareIdentifierOptionalCallTarget:
+                {
+                    var optCallTargetIdx = instruction.Operand & 0xFFFF;
+                    var optJumpTarget = instruction.Operand >> 16;
+                    var optCallTarget = program.CallTargetConstants[optCallTargetIdx];
+                    if (optCallTarget.Kind != UnifiedBytecodeCallTargetKind.Identifier)
+                    {
+                        throw new InvalidOperationException(
+                            "Optional identifier call-target preparation requires an identifier call target constant.");
+                    }
+
+                    if (IsInactiveCatchBindingSlot(inactiveCatchBindingSlots, optCallTarget.SlotIndex))
+                    {
+                        SetInactiveCatchBindingReferenceError(program, optCallTarget.SlotIndex, context);
+                        if (TryHandleCurrentContextThrow(slots))
+                        {
+                            break;
+                        }
+
+                        return StopWithDriverCleanup(slots, slotEnvironments, context, true);
+                    }
+
+                    var optCallableValue = slots[optCallTarget.SlotIndex];
+                    if (optCallableValue.IsUninitialized)
+                    {
+                        SetUninitializedSlotReferenceError(program, optCallTarget.SlotIndex, context);
+                        if (TryHandleCurrentContextThrow(slots))
+                        {
+                            break;
+                        }
+
+                        return StopWithDriverCleanup(slots, slotEnvironments, context, true);
+                    }
+
+                    if (optCallableValue.IsNullOrUndefined)
+                    {
+                        PushValue(JsValue.Undefined);
+                        programCounter = optJumpTarget;
+                        break;
+                    }
+
+                    PushValue(JsValue.Undefined);
+                    PushValue(optCallableValue);
+                    programCounter++;
+                    break;
+                }
+
                 case UnifiedBytecodeOpCode.PrepareDynamicIdentifierCallTarget:
                     var dynamicCallEnvironment = RequireDynamicEnvironment(currentCallingEnvironment);
                     PrepareDynamicIdentifierCallTarget(

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -1053,9 +1053,9 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
-    public void Evaluate_OptionalSpreadCallExpressionPlan_DeclinesWithOptionalChainDependency()
+    public void Evaluate_OptionalIdentifierSpreadCallExpressionPlan_AcceptsExecutableInvocationBoundary()
     {
-        // gh2676 keeps optional spread calls declined.
+        // Activation-slot optional identifier spread calls skip argument lowering when nullish.
         var plan = GetFunctionPlan("""
             function invoke(fn, args) {
                 return fn?.(...args);
@@ -1067,7 +1067,13 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
             plan,
             new UnifiedBytecodeProductionActivationDescriptor());
 
-        Assert.False(result.IsEligible);
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.PrepareIdentifierOptionalCallTarget);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.CallInvocationBoundary);
+        Assert.NotEmpty(result.Program.CallSpreadMasks);
     }
 
     [Fact]

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionSpreadCallTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionSpreadCallTests.cs
@@ -5,7 +5,8 @@ namespace Asynkron.JsEngine.Tests;
 /// <summary>
 /// Covers admission of synchronous spread calls into the production unified bytecode
 /// pipeline (gh2676): <c>f(...args)</c>, <c>f(...a, ...b)</c>, <c>obj.method(...args)</c>,
-/// and mixed <c>f(a, ...b, c)</c>. Optional/construct/super/direct-eval calls stay declined.
+/// optional identifier spread calls, and mixed <c>f(a, ...b, c)</c>.
+/// Super/direct-eval spread calls stay declined.
 /// </summary>
 [Category(TestCategories.RuntimeSemantics)]
 public sealed class UnifiedBytecodeProductionSpreadCallTests(ITestOutputHelper output)
@@ -150,7 +151,7 @@ public sealed class UnifiedBytecodeProductionSpreadCallTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
-    public async Task OptionalSpreadCall_DeclinesProductionFastPath()
+    public async Task OptionalIdentifierSpreadCall_UsesProductionFastPath()
     {
         await using var engine = CreateEngine();
         var result = await engine.Evaluate("""
@@ -166,7 +167,35 @@ public sealed class UnifiedBytecodeProductionSpreadCallTests(ITestOutputHelper o
             """);
 
         Assert.Equal(42d, result);
-        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=invoke",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task OptionalIdentifierSpreadCall_SkipsSpreadIterationWhenCalleeNullish()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function invoke(fn, args) {
+                return fn?.(...args);
+            }
+
+            var log = [];
+            var source = {
+                [Symbol.iterator]() {
+                    log.push("iterated");
+                    return [][Symbol.iterator]();
+                }
+            };
+
+            var value = invoke(null, source);
+            String(value) + ":" + log.join(",");
+            """);
+
+        Assert.Equal("undefined:", result?.ToString());
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(
                 "unified-bytecode-production-fast-path func=invoke",
                 StringComparison.Ordinal));


### PR DESCRIPTION
## Summary
- add a unified-bytecode optional identifier call-target opcode
- route activation-slot optional identifier calls such as `fn?.(...args)` through production unified bytecode
- prove nullish callees skip spread iteration and update the expansion contract

## Verification
- `rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_OptionalIdentifierSpreadCallExpressionPlan_AcceptsExecutableInvocationBoundary|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_OptionalChainNonActivationBaseCallExpressionPlan_Declines|FullyQualifiedName~UnifiedBytecodeProductionSpreadCallTests|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeVirtualMachine_HandlesEveryDeclaredOpcode'`
- `rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~UnifiedBytecodeProductionSpreadCallTests|FullyQualifiedName~ExpressionProgramLoweringTests|FullyQualifiedName~ExpressionProgramCoverageMapTests|FullyQualifiedName~AstFreeExecutionAssertionTests'`
- `rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release`
- `rtk rg 'EvaluateExpression\(|ProfileEvaluateExpression\(' src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*` (no matches)
- `rtk git diff --check`