### PR TITLE
Admit named-prefix optional plain calls

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -335,7 +335,7 @@ must still obey the no-mixed-execution rule.
 | `PropertyUpdateDependency` | Property and identifier update expressions outside the admitted direct update, computed expression-key update, and simple nested named receiver update boundary | Existing sync IR update route | Property update lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedNamedPropertyUpdate_AcceptsOwnedPropertyOpcodes"` |
 | `DeleteDependency` | `delete` expressions outside the admitted ordinary named/computed property delete lane and the with-backed dynamic-name delete lane | Existing sync IR delete route | Delete semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_PropertyReadAdjacentFamilies_DeclineWithExplicitCodes"` |
 | `SuperPropertyDependency` | Out-of-boundary super call targets; super property reads/writes/updates are admitted by dedicated VM opcodes | Existing class / constructor route for remaining call-target shapes | Super semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperPropertyAccess_AcceptsOwnedOpcodes"` |
-| `OptionalChainDependency` | Optional chains outside the admitted optional property-read, optional-call, and exact optional named/computed delete boundaries | Existing sync IR optional-chain route | Optional-chain widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_OptionalChainNonActivationBaseCallExpressionPlan_Declines"` |
+| `OptionalChainDependency` | Optional chains outside the admitted optional property-read, optional-call, and exact optional named/computed delete boundaries | Existing sync IR optional-chain route | Optional-chain widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_OptionalChainNamedPrefixPlainCallExpressionPlan_AcceptsExecutableInvocationBoundary"` |
 | `ObjectLiteralOrSpreadDependency` | Non-simple object spread sources, unsupported array spread, spread construct arguments, and object methods/accessors only when they appear inside restricted simple literal spans | Existing sync IR literal/spread route for remaining spans | Literal/spread lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NonSimpleSourceArraySpread_DeclinesWithExplicitCode"` |
 | `PrivateFieldDependency` | Private-name operations outside the admitted routes; `#name in obj`, direct private named reads/writes/updates, direct private named compound/logical writes, and direct private named method calls are VM-owned when the surrounding class method is otherwise production-eligible. Private member deletes are parser early errors before production eligibility. | Existing private-name route for remaining private member access | Private-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_PrivateFieldIn_AcceptsAndVmChecksPrivateBrand"` |
 | `ForInDriverStateDependency` | Unsupported for-in driver state such as awaited object source | Existing for-in IR driver route | Driver-state lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~IsSupportedForInInit_AwaitedSource_Declines"` |
@@ -615,19 +615,22 @@ the final post-compile production subset check before VM entry.
   still use the first-boundary call-target helper because they carry
   boundary-local directness metadata or packed nullish short-circuit jump
   targets.
-- Accepted optional call programs use `PrepareIdentifierOptionalCallTarget`,
-  `PrepareNamedOptionalCallTarget`, or `PrepareComputedOptionalCallTarget`
-  followed by `CallInvocationBoundary`. These opcodes pack a call-target
-  constant index (low 16 bits) and a nullish short-circuit jump target (high 16
-  bits) into a single operand. The VM checks the receiver or callee for nullish
-  before argument evaluation proceeds; if nullish, the stack top becomes
-  `Undefined` and execution jumps past the call boundary. Four patterns are
-  admitted: callee-optional identifier calls (`fn?.(args)`), receiver-optional
-  named calls (`box?.read(args)`), callee-optional named calls
-  (`box.read?.(args)`), and callee-optional computed calls (`box[key]?.(args)`).
-  The `IsOptionalReceiverCheck` flag in `UnifiedBytecodeCallTarget`
-  distinguishes the two named variants. (Optional member calls admitted as of
-  gh2689; ADR 0289.)
+- Accepted optional call programs either use a jump-owned optional-start prefix
+  followed by an ordinary call-target preparation opcode (`a?.b.c(args)`,
+  `a.x?.b.c(args)`, `a?.b[k](args)`) or use
+  `PrepareIdentifierOptionalCallTarget`, `PrepareNamedOptionalCallTarget`, or
+  `PrepareComputedOptionalCallTarget` followed by `CallInvocationBoundary`.
+  The optional preparation opcodes pack a call-target constant index (low 16
+  bits) and a nullish short-circuit jump target (high 16 bits) into a single
+  operand. The VM checks the receiver or callee for nullish before argument
+  evaluation proceeds; if nullish, the stack top becomes `Undefined` and
+  execution jumps past the call boundary. Admitted callee/receiver-optional
+  patterns include callee-optional identifier calls (`fn?.(args)`),
+  receiver-optional named calls (`box?.read(args)`), callee-optional named
+  calls (`box.read?.(args)`), and callee-optional computed calls
+  (`box[key]?.(args)`). The `IsOptionalReceiverCheck` flag in
+  `UnifiedBytecodeCallTarget` distinguishes the two named variants. (Optional
+  member calls admitted as of gh2689; ADR 0289.)
 - Direct eval programs use `PrepareIdentifierCallTarget` followed by
   `CallInvocationBoundary` with the direct-eval operand flag. The admitted shape
   is exactly one non-spread eval-identifier argument; the VM invokes the eval host
@@ -799,10 +802,12 @@ support today.
    Simple array and object literal arguments (`fn([a, b])`, `fn({x: a})`) are
    now admitted (gh2705, ADR 0290). Optional-start computed member spread calls
    (`a?.box[key](...args)`) are also admitted through the shared spread-mask
-   invocation boundary. Simple object literal spread entries are now admitted
-   through the `ObjectSpread` opcode when their spread source is a simple
-   operand. Direct eval outside the one-argument non-spread
-   eval-identifier boundary, spread super constructs, spread callee-optional calls,
+   invocation boundary, and named-prefix optional plain calls such as
+   `a.x?.box.read(value)` route through the same optional-call machinery after
+   the prefix is resolved by owned named-property reads. Simple object literal
+   spread entries are now admitted through the `ObjectSpread` opcode when their
+   spread source is a simple operand. Direct eval outside the one-argument
+   non-spread eval-identifier boundary, spread super constructs,
    private-adjacent member targets outside the admitted direct named method-call
    shape, complex receiver/key shapes, non-simple literal argument spans, and receiver-binding-sensitive adjacent families beyond the
    direct activation-resolved and with-backed dynamic-identifier boundaries must

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -5064,9 +5064,9 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
-        // Case 4: optional-chain plain call — a?.b.c(args)
-        // Pattern: [base, GetNamedProperty(opt,b), JumpIfShortCircuited, LoadNamedCallTarget(c), args..., Call]
-        if (callTargetIndexInProgram == 3)
+        // Case 4: optional-chain plain call — a?.b.c(args) / a.x?.b.c(args)
+        // Pattern: [base/prefix..., GetNamedProperty(opt,b), JumpIfShortCircuited, LoadNamedCallTarget(c), args..., Call]
+        if (callTargetIndexInProgram >= 3)
         {
             var maybeShortCircuit = expressionProgram.GetOperation(callTargetIndexInProgram - 1);
             if (maybeShortCircuit.Kind == ExpressionOpKind.JumpIfShortCircuited)
@@ -5705,8 +5705,8 @@ internal static class UnifiedBytecodeCompiler
         return true;
     }
 
-    // Case 4: a?.b.c(args) — optional-start chain, plain non-optional call.
-    // Lowers to: LoadSlot(base), JumpIfNullishReplaceUndefined(end), GetNamedProperty(b),
+    // Case 4: a?.b.c(args) / a.x?.b.c(args) — optional-start chain, plain non-optional call.
+    // Lowers to: prefix-load, JumpIfNullishReplaceUndefined(end), GetNamedProperty(b),
     //            PrepareNamedCallTarget(c), args, (end:)
     private static bool TryAppendOptionalChainPlainCallTarget(
         ExpressionProgram expressionProgram,
@@ -5722,13 +5722,22 @@ internal static class UnifiedBytecodeCompiler
     {
         var activationSlots = slotLayout.ActivationSlots;
         var expressionStringConstants = expressionProgram.StringConstants.AsSpan();
+        var shortCircuitIndex = callTargetIndexInProgram - 1;
+        var optionalHopIndex = shortCircuitIndex - 1;
 
-        // Emit base load
-        if (!TryAppendActivationValueLoad(
-                expressionProgram.GetOperation(0),
+        if (optionalHopIndex < 1)
+        {
+            reason = string.Empty;
+            return false;
+        }
+
+        if (!TryAppendNamedReceiverOperations(
                 expressionProgram,
                 activationSlots,
                 unified,
+                stringConstants,
+                optionalHopIndex,
+                allowDeepChain: true,
                 out reason))
         {
             return false;
@@ -5739,7 +5748,7 @@ internal static class UnifiedBytecodeCompiler
         unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.JumpIfNullishReplaceUndefined, 0));
 
         // Emit GetNamedProperty(b) — receiver for c()
-        var firstHop = expressionProgram.GetOperation(1);
+        var firstHop = expressionProgram.GetOperation(optionalHopIndex);
         var receiverNameIndex = stringConstants.Count;
         stringConstants.Add(firstHop.GetString(expressionStringConstants));
         unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.GetNamedProperty, receiverNameIndex));

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -2974,9 +2974,9 @@ internal static class UnifiedBytecodeProductionEligibility
                    callIndex);
     }
 
-    // Case 4: a?.b.c() — optional-start chain, plain non-optional call
-    // Expression program: [base(0), GetNamedProperty(IsOptional:true,b)(1), JumpIfShortCircuited(2),
-    //                       LoadNamedCallTarget(c)(3), args..., Call]
+    // Case 4: a?.b.c() / a.x?.b.c() — optional-start chain, plain non-optional call
+    // Expression program: [base/prefix..., GetNamedProperty(IsOptional:true,b), JumpIfShortCircuited,
+    //                       LoadNamedCallTarget(c), args..., Call]
     private static bool TryIsFirstBoundaryOptionalChainPlainCallCandidate(
         ExpressionProgram program,
         ReadOnlySpan<IdentifierOperand> identifierConstants,
@@ -2997,35 +2997,43 @@ internal static class UnifiedBytecodeProductionEligibility
         }
 
         var namedCallTargetIndex = FindFirstOperation(program, ExpressionOpKind.LoadNamedCallTarget);
-        // LoadNamedCallTarget must be at index 3 exactly (base + optional hop + JumpIfShortCircuited).
-        if (namedCallTargetIndex != 3)
+        if (namedCallTargetIndex < 3)
         {
             return false;
         }
 
-        // op[2] = JumpIfShortCircuited
-        if (program.GetOperation(2).Kind != ExpressionOpKind.JumpIfShortCircuited)
+        var shortCircuitIndex = namedCallTargetIndex - 1;
+        if (program.GetOperation(shortCircuitIndex).Kind != ExpressionOpKind.JumpIfShortCircuited)
         {
             return false;
         }
 
-        // op[1] = GetNamedProperty(IsOptional:true, !SC, non-private)
-        var firstHop = program.GetOperation(1);
-        if (firstHop.Kind != ExpressionOpKind.GetNamedProperty ||
-            !firstHop.IsOptional ||
-            firstHop.ShortCircuitOnNullishTarget ||
-            firstHop.GetString(program.StringConstants.AsSpan()).IsPrivateName())
+        var optionalHopIndex = shortCircuitIndex - 1;
+        if (optionalHopIndex < 1)
         {
             return false;
         }
 
-        // op[0] = activation-resolved base
-        if (!TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
+        var optionalHop = program.GetOperation(optionalHopIndex);
+        if (optionalHop.Kind != ExpressionOpKind.GetNamedProperty ||
+            !optionalHop.IsOptional ||
+            optionalHop.ShortCircuitOnNullishTarget ||
+            optionalHop.GetString(program.StringConstants.AsSpan()).IsPrivateName())
         {
             return false;
         }
 
-        // LoadNamedCallTarget must not be private
+        if (!IsSupportedNamedReceiverChain(
+                program,
+                identifierConstants,
+                stringConstants,
+                activationSlots,
+                optionalHopIndex,
+                allowDeepChain: true))
+        {
+            return false;
+        }
+
         var namedCallTarget = program.GetOperation(namedCallTargetIndex);
         if (namedCallTarget.GetString(stringConstants).IsPrivateName())
         {

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -818,9 +818,9 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
-    public void Evaluate_OptionalChainNonActivationBaseCallExpressionPlan_Declines()
+    public void Evaluate_OptionalChainNamedPrefixPlainCallExpressionPlan_AcceptsExecutableInvocationBoundary()
     {
-        // gh2806 AC-4: a.x?.b.c() must decline — receiver chain not bounded to activation-resolved base.
+        // Named prefixes before the optional hop are already VM-owned receiver-chain reads.
         var plan = GetFunctionPlan("""
             function invoke(a, value) {
                 return a.x?.box.read(value);
@@ -832,7 +832,12 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
             plan,
             new UnifiedBytecodeProductionActivationDescriptor());
 
-        Assert.False(result.IsEligible);
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.GetNamedProperty);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.CallInvocationBoundary);
     }
 
     [Fact]

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -2895,6 +2895,69 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task OptionalChainNamedPrefixPlainCall_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function invoke(a, value) {
+                return a.x?.box.read(value);
+            }
+
+            var holder = {
+                x: {
+                    box: {
+                        read(value) {
+                            return this === holder.x.box ? value + 1 : -1;
+                        }
+                    }
+                }
+            };
+
+            var present = invoke(holder, 41);
+            var missing = invoke({ x: null }, 1);
+            present + ":" + missing;
+            """);
+
+        Assert.Equal("42:undefined", result?.ToString());
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=invoke",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task OptionalChainNamedPrefixPlainCall_ShortCircuitsBeforePostOptionalRead()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var reads = 0;
+            function invoke(a) {
+                return a.x?.box.read();
+            }
+
+            var holder = {
+                x: {
+                    get box() {
+                        reads++;
+                        return { read() { return 7; } };
+                    }
+                }
+            };
+
+            var missing = invoke({ x: null });
+            var afterMissing = reads;
+            var present = invoke(holder);
+            "" + missing + ":" + afterMissing + ":" + present + ":" + reads;
+            """);
+
+        Assert.Equal("undefined:0:7:1", result?.ToString());
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=invoke",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task LooseEqualityBranchFunction_UsesUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- widen optional-chain plain call recognition from exact `a?.b.c(...)` to named-prefix forms like `a.x?.box.read(value)`
- lower the named prefix through owned property-read ops, then use the existing nullish jump and call boundary
- update eligibility, public route tests, and the unified-bytecode expansion contract

## Verification
- `rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_OptionalChainNamedPrefixPlainCallExpressionPlan_AcceptsExecutableInvocationBoundary|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalChainNamedPrefixPlainCall_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalChainNamedPrefixPlainCall_ShortCircuitsBeforePostOptionalRead|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.OptionalChainComputedPlainCall|FullyQualifiedName~ExpressionProgramCoverageMapTests.UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums'`
- `rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~UnifiedBytecodeProductionSpreadCallTests|FullyQualifiedName~ExpressionProgramLoweringTests|FullyQualifiedName~ExpressionProgramCoverageMapTests|FullyQualifiedName~AstFreeExecutionAssertionTests'`
- `rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release`
- `rtk rg 'EvaluateExpression\(|ProfileEvaluateExpression\(' src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*` (no matches)
- `rtk git diff --check`