### PR TITLE
Admit dynamic property operands on fast path

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -3660,6 +3660,7 @@ internal static class UnifiedBytecodeCompiler
         if (TryAppendFirstBoundaryNamedPropertySet(
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
                 literalConstants,
                 stringConstants,
@@ -3893,8 +3894,10 @@ internal static class UnifiedBytecodeCompiler
         if (TryAppendFirstBoundaryComputedPropertyRead(
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
                 literalConstants,
+                stringConstants,
                 out reason))
         {
             return true;
@@ -6991,6 +6994,7 @@ internal static class UnifiedBytecodeCompiler
     private static bool TryAppendFirstBoundaryNamedPropertySet(
         ExpressionProgram expressionProgram,
         ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
         ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
         ImmutableArray<JsValue>.Builder literalConstants,
         ImmutableArray<string>.Builder stringConstants,
@@ -7030,12 +7034,14 @@ internal static class UnifiedBytecodeCompiler
 
         if (rhsStart == rhsEnd)
         {
-            if (!TryAppendSimpleOperandLoad(
+            if (!TryAppendSimpleOperandLoadWithDynamic(
                     expressionProgram.GetOperation(rhsStart),
                     expressionProgram,
                     activationSlots,
+                    allowsDynamicIdentifiers,
                     unified,
                     literalConstants,
+                    stringConstants,
                     out reason))
             {
                 return false;
@@ -8773,8 +8779,10 @@ internal static class UnifiedBytecodeCompiler
     private static bool TryAppendFirstBoundaryComputedPropertyRead(
         ExpressionProgram expressionProgram,
         ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
         ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
         ImmutableArray<JsValue>.Builder literalConstants,
+        ImmutableArray<string>.Builder stringConstants,
         out string reason)
     {
         if (expressionProgram.OperationCount != 5)
@@ -8826,8 +8834,10 @@ internal static class UnifiedBytecodeCompiler
                 expressionProgram.GetOperation(1),
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
                 literalConstants,
+                stringConstants,
                 out reason))
         {
             return false;
@@ -8848,10 +8858,39 @@ internal static class UnifiedBytecodeCompiler
         ImmutableArray<JsValue>.Builder literalConstants,
         out string reason)
     {
+        return TryAppendComputedPropertyKeyLoad(
+            operation,
+            expressionProgram,
+            activationSlots,
+            allowsDynamicIdentifiers: false,
+            unified,
+            literalConstants,
+            stringConstants: null,
+            out reason);
+    }
+
+    private static bool TryAppendComputedPropertyKeyLoad(
+        PackedExpressionOp operation,
+        ExpressionProgram expressionProgram,
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
+        ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
+        ImmutableArray<JsValue>.Builder literalConstants,
+        ImmutableArray<string>.Builder? stringConstants,
+        out string reason)
+    {
         switch (operation.Kind)
         {
             case ExpressionOpKind.LoadIdentifier:
-                return TryAppendActivationValueLoad(operation, expressionProgram, activationSlots, unified, out reason);
+                return TryAppendSimpleOperandLoadWithDynamic(
+                    operation,
+                    expressionProgram,
+                    activationSlots,
+                    allowsDynamicIdentifiers,
+                    unified,
+                    literalConstants,
+                    stringConstants,
+                    out reason);
 
             case ExpressionOpKind.LoadLiteral:
                 var literal = operation.GetLiteral(expressionProgram.LiteralConstants.AsSpan());
@@ -9031,6 +9070,43 @@ internal static class UnifiedBytecodeCompiler
                 reason = $"Unsupported simple operand op '{operation.Kind}'.";
                 return false;
         }
+    }
+
+    private static bool TryAppendSimpleOperandLoadWithDynamic(
+        PackedExpressionOp operation,
+        ExpressionProgram expressionProgram,
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
+        ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
+        ImmutableArray<JsValue>.Builder literalConstants,
+        ImmutableArray<string>.Builder? stringConstants,
+        out string reason)
+    {
+        if (TryAppendSimpleOperandLoad(
+                operation,
+                expressionProgram,
+                activationSlots,
+                unified,
+                literalConstants,
+                out reason))
+        {
+            return true;
+        }
+
+        if (!allowsDynamicIdentifiers ||
+            operation.Kind != ExpressionOpKind.LoadIdentifier ||
+            operation.IsArguments ||
+            stringConstants is null)
+        {
+            return false;
+        }
+
+        var identifier = operation.GetIdentifier(expressionProgram.IdentifierConstants.AsSpan());
+        var nameIndex = stringConstants.Count;
+        stringConstants.Add(identifier.Name.Name ?? string.Empty);
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.LoadDynamicIdentifier, nameIndex));
+        reason = string.Empty;
+        return true;
     }
 
     private static int EncodeUpdateOperand(int stringConstantIndex, PackedExpressionOp update) =>

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -717,7 +717,7 @@ internal static class UnifiedBytecodeProductionEligibility
         var identifierConstants = program.IdentifierConstants.AsSpan();
         var stringConstants = program.StringConstants.AsSpan();
         var isFirstBoundaryPropertyWriteCandidate =
-            TryIsFirstBoundaryPropertyWriteCandidate(program, identifierConstants, activationSlots);
+            TryIsFirstBoundaryPropertyWriteCandidate(program, identifierConstants, activationSlots, allowsDynamicIdentifiers);
         var isFirstBoundaryPropertyUpdateCandidate =
             TryIsFirstBoundaryPropertyUpdateCandidate(program, identifierConstants, activationSlots);
         var isFirstBoundaryNamedCompoundPropertyWriteCandidate =
@@ -1223,7 +1223,7 @@ internal static class UnifiedBytecodeProductionEligibility
 
                 case ExpressionOpKind.SetNamedProperty:
                 case ExpressionOpKind.SetComputedProperty:
-                    if (TryIsFirstBoundaryPropertyWriteCandidate(program, identifierConstants, activationSlots) ||
+                    if (TryIsFirstBoundaryPropertyWriteCandidate(program, identifierConstants, activationSlots, allowsDynamicIdentifiers) ||
                         TryIsFirstBoundaryNestedNamedPropertyWriteCandidate(program, identifierConstants, activationSlots) ||
                         isFirstBoundaryNamedCompoundPropertyWriteCandidate ||
                         isFirstBoundaryNamedLogicalPropertyWriteCandidate ||
@@ -4037,7 +4037,8 @@ internal static class UnifiedBytecodeProductionEligibility
     private static bool TryIsFirstBoundaryPropertyWriteCandidate(
         ExpressionProgram program,
         ReadOnlySpan<IdentifierOperand> identifierConstants,
-        ActivationSlotShape activationSlots)
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers)
     {
         if (program.OperationCount < 3)
         {
@@ -4057,7 +4058,11 @@ internal static class UnifiedBytecodeProductionEligibility
 
             if (rhsStart == rhsEnd)
             {
-                return IsSimpleOperand(program.GetOperation(rhsStart), identifierConstants, activationSlots);
+                return IsSimpleOperand(
+                    program.GetOperation(rhsStart),
+                    identifierConstants,
+                    activationSlots,
+                    allowsDynamicIdentifiers);
             }
 
             // Multi-op RHS — try template literal span.
@@ -4358,7 +4363,8 @@ internal static class UnifiedBytecodeProductionEligibility
     private static bool IsSimpleOperand(
         PackedExpressionOp operation,
         ReadOnlySpan<IdentifierOperand> identifierConstants,
-        ActivationSlotShape activationSlots)
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers = false)
     {
         return operation.Kind switch
         {
@@ -4366,7 +4372,9 @@ internal static class UnifiedBytecodeProductionEligibility
             ExpressionOpKind.LoadIdentifier => TryGetActivationResolvedValue(
                 operation,
                 identifierConstants,
-                activationSlots),
+                activationSlots) ||
+                allowsDynamicIdentifiers &&
+                !operation.IsArguments,
             ExpressionOpKind.LoadThis => true,
             ExpressionOpKind.LoadNewTarget => true,
             _ => false

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -5354,28 +5354,6 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
         2d)]
     [InlineData(
         """
-        var externalKey = "value";
-        function readDynamic(box) {
-            return box[externalKey];
-        }
-
-        readDynamic({ value: 2 });
-        """,
-        "readDynamic",
-        2d)]
-    [InlineData(
-        """
-        var externalValue = 42;
-        function dynamicValueWrite(box) {
-            return box.value = externalValue;
-        }
-
-        dynamicValueWrite({});
-        """,
-        "dynamicValueWrite",
-        42d)]
-    [InlineData(
-        """
         function readComputedSpreadKey(box, source) {
             return box[{ ...source }];
         }
@@ -5396,6 +5374,46 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
         Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             record => record.Message.Contains(
                 $"unified-bytecode-production-fast-path func={functionName}",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ComputedPropertyReadWithOrdinaryDynamicKey_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var externalKey = "value";
+            function readDynamic(box) {
+                return box[externalKey];
+            }
+
+            readDynamic({ value: 2 });
+            """);
+
+        Assert.Equal(2d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=readDynamic argc=1",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task NamedPropertyWriteWithOrdinaryDynamicValue_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var externalValue = 42;
+            function dynamicValueWrite(box) {
+                return box.value = externalValue;
+            }
+
+            dynamicValueWrite({});
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=dynamicValueWrite argc=1",
                 StringComparison.Ordinal));
     }
 


### PR DESCRIPTION
## Summary
- allow ordinary dynamic identifier operands in the validated property-read/write production boundaries
- move computed property reads with global dynamic keys and named property writes with global dynamic values from fallback proofs to route-hit proofs
- keep default-descriptor dynamic decline tests and unsupported spread/super fallback rows intact

## Verification
- focused dynamic property operand proof: 18 tests passed
- broad bytecode proof: 889 tests passed
- engine build: 2 projects, 0 errors, 0 warnings
- AST seam scan: no EvaluateExpression/ProfileEvaluateExpression hits in execution-plan runner files
- git diff --check: clean