### PR TITLE
Admit binary RHS for computed logical assignment

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -6851,39 +6851,60 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
-        var suffixStart = expressionProgram.OperationCount - 13;
-        if (suffixStart <= 1)
+        var propertySetIndex = expressionProgram.OperationCount - 6;
+        var suffixStart = -1;
+        var matchedLayout = false;
+        PackedExpressionOp propertyRead = default;
+        PackedExpressionOp jump = default;
+        PackedExpressionOp propertySet = default;
+        for (var rhsLength = 1; rhsLength <= 3; rhsLength += 2)
         {
-            reason = string.Empty;
-            return false;
+            var candidateSuffixStart = propertySetIndex - 6 - rhsLength;
+            if (candidateSuffixStart <= 1 ||
+                !IsSupportedComputedPropertyKeySpan(
+                    expressionProgram,
+                    activationSlots,
+                    startInclusive: 1,
+                    endExclusive: candidateSuffixStart))
+            {
+                continue;
+            }
+
+            var requireObjectCoercible = expressionProgram.GetOperation(candidateSuffixStart);
+            var resolvePropertyKey = expressionProgram.GetOperation(candidateSuffixStart + 1);
+            var duplicateTargetAndKey = expressionProgram.GetOperation(candidateSuffixStart + 2);
+            propertyRead = expressionProgram.GetOperation(candidateSuffixStart + 3);
+            jump = expressionProgram.GetOperation(candidateSuffixStart + 4);
+            var pop = expressionProgram.GetOperation(candidateSuffixStart + 5);
+            propertySet = expressionProgram.GetOperation(propertySetIndex);
+            var duplicateAssignedValue = expressionProgram.GetOperation(propertySetIndex + 1);
+            var duplicateAssignedValueAgain = expressionProgram.GetOperation(propertySetIndex + 2);
+            var rotateTopThreeRight = expressionProgram.GetOperation(propertySetIndex + 3);
+            var cleanupPop = expressionProgram.GetOperation(propertySetIndex + 4);
+            var cleanupPop2 = expressionProgram.GetOperation(propertySetIndex + 5);
+            if (requireObjectCoercible.Kind != ExpressionOpKind.RequireObjectCoercible ||
+                requireObjectCoercible.Depth != 1 ||
+                resolvePropertyKey.Kind != ExpressionOpKind.ResolvePropertyKey ||
+                duplicateTargetAndKey.Kind != ExpressionOpKind.DuplicateTopTwo ||
+                propertyRead.Kind != ExpressionOpKind.GetComputedProperty ||
+                jump.Kind is not (ExpressionOpKind.JumpIfFalse or ExpressionOpKind.JumpIfTrue or ExpressionOpKind.JumpIfNotNullish) ||
+                pop.Kind != ExpressionOpKind.Pop ||
+                propertySet.Kind != ExpressionOpKind.SetComputedProperty ||
+                duplicateAssignedValue.Kind != ExpressionOpKind.DuplicateTop ||
+                duplicateAssignedValueAgain.Kind != ExpressionOpKind.DuplicateTop ||
+                rotateTopThreeRight.Kind != ExpressionOpKind.RotateTopThreeRight ||
+                cleanupPop.Kind != ExpressionOpKind.Pop ||
+                cleanupPop2.Kind != ExpressionOpKind.Pop)
+            {
+                continue;
+            }
+
+            suffixStart = candidateSuffixStart;
+            matchedLayout = true;
+            break;
         }
 
-        var requireObjectCoercible = expressionProgram.GetOperation(suffixStart);
-        var resolvePropertyKey = expressionProgram.GetOperation(suffixStart + 1);
-        var duplicateTargetAndKey = expressionProgram.GetOperation(suffixStart + 2);
-        var propertyRead = expressionProgram.GetOperation(suffixStart + 3);
-        var jump = expressionProgram.GetOperation(suffixStart + 4);
-        var pop = expressionProgram.GetOperation(suffixStart + 5);
-        var rhs = expressionProgram.GetOperation(suffixStart + 6);
-        var propertySet = expressionProgram.GetOperation(suffixStart + 7);
-        var duplicateAssignedValue = expressionProgram.GetOperation(suffixStart + 8);
-        var duplicateAssignedValueAgain = expressionProgram.GetOperation(suffixStart + 9);
-        var rotateTopThreeRight = expressionProgram.GetOperation(suffixStart + 10);
-        var cleanupPop = expressionProgram.GetOperation(suffixStart + 11);
-        var cleanupPop2 = expressionProgram.GetOperation(suffixStart + 12);
-        if (requireObjectCoercible.Kind != ExpressionOpKind.RequireObjectCoercible ||
-            requireObjectCoercible.Depth != 1 ||
-            resolvePropertyKey.Kind != ExpressionOpKind.ResolvePropertyKey ||
-            duplicateTargetAndKey.Kind != ExpressionOpKind.DuplicateTopTwo ||
-            propertyRead.Kind != ExpressionOpKind.GetComputedProperty ||
-            jump.Kind is not (ExpressionOpKind.JumpIfFalse or ExpressionOpKind.JumpIfTrue or ExpressionOpKind.JumpIfNotNullish) ||
-            pop.Kind != ExpressionOpKind.Pop ||
-            propertySet.Kind != ExpressionOpKind.SetComputedProperty ||
-            duplicateAssignedValue.Kind != ExpressionOpKind.DuplicateTop ||
-            duplicateAssignedValueAgain.Kind != ExpressionOpKind.DuplicateTop ||
-            rotateTopThreeRight.Kind != ExpressionOpKind.RotateTopThreeRight ||
-            cleanupPop.Kind != ExpressionOpKind.Pop ||
-            cleanupPop2.Kind != ExpressionOpKind.Pop)
+        if (!matchedLayout)
         {
             reason = string.Empty;
             return false;
@@ -6901,19 +6922,9 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
-        if (jump.Target != suffixStart + 10)
+        if (jump.Target != propertySetIndex + 3)
         {
             reason = "Logical computed property writes require jump target at cleanup start.";
-            return false;
-        }
-
-        if (!IsSupportedComputedPropertyKeySpan(
-                expressionProgram,
-                activationSlots,
-                startInclusive: 1,
-                endExclusive: suffixStart))
-        {
-            reason = "Unsupported computed property key span.";
             return false;
         }
 
@@ -6959,12 +6970,13 @@ internal static class UnifiedBytecodeCompiler
         stagedUnified.Add(new UnifiedBytecodeInstruction(jumpOpCode, 0));
         stagedUnified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.Pop));
 
-        if (!TryAppendSimpleOperandLoad(
-                rhs,
+        if (!TryAppendComputedLogicalAssignmentRhsSpan(
                 expressionProgram,
                 activationSlots,
                 stagedUnified,
                 stagedLiterals,
+                startInclusive: suffixStart + 6,
+                endExclusive: propertySetIndex,
                 out reason))
         {
             return false;
@@ -6987,6 +6999,59 @@ internal static class UnifiedBytecodeCompiler
         unified.AddRange(stagedUnified);
         literalConstants.Clear();
         literalConstants.AddRange(stagedLiterals);
+        reason = string.Empty;
+        return true;
+    }
+
+    private static bool TryAppendComputedLogicalAssignmentRhsSpan(
+        ExpressionProgram expressionProgram,
+        ActivationSlotShape activationSlots,
+        ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
+        ImmutableArray<JsValue>.Builder literalConstants,
+        int startInclusive,
+        int endExclusive,
+        out string reason)
+    {
+        if (startInclusive >= endExclusive)
+        {
+            reason = "Computed logical property writes require an RHS expression.";
+            return false;
+        }
+
+        if (endExclusive - startInclusive == 1)
+        {
+            return TryAppendSimpleOperandLoad(
+                expressionProgram.GetOperation(startInclusive),
+                expressionProgram,
+                activationSlots,
+                unified,
+                literalConstants,
+                out reason);
+        }
+
+        if (endExclusive - startInclusive != 3)
+        {
+            reason = "Computed logical property writes only admit simple or simple-binary RHS spans.";
+            return false;
+        }
+
+        var left = expressionProgram.GetOperation(startInclusive);
+        var right = expressionProgram.GetOperation(startInclusive + 1);
+        var binary = expressionProgram.GetOperation(startInclusive + 2);
+        if (binary.Kind != ExpressionOpKind.Binary ||
+            !IsSupportedBinaryOperator(binary.Operator))
+        {
+            reason = "Computed logical property binary RHS uses an unsupported operator.";
+            return false;
+        }
+
+        if (!TryAppendSimpleOperandLoad(left, expressionProgram, activationSlots, unified, literalConstants, out reason) ||
+            !TryAppendSimpleOperandLoad(right, expressionProgram, activationSlots, unified, literalConstants, out reason))
+        {
+            return false;
+        }
+
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.Binary, (int)binary.Operator));
         reason = string.Empty;
         return true;
     }

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -3978,8 +3978,8 @@ internal static class UnifiedBytecodeProductionEligibility
         ReadOnlySpan<IdentifierOperand> identifierConstants,
         ActivationSlotShape activationSlots)
     {
-        // Shape: [base, key, RequireObjectCoercible, ResolvePropertyKey, DuplicateTopTwo, GetComputedProperty,
-        // JumpIf*, Pop, rhs, SetComputedProperty, DuplicateTop, DuplicateTop, RotateTopThreeRight, Pop, Pop]
+        // Shape: [base, key..., RequireObjectCoercible, ResolvePropertyKey, DuplicateTopTwo, GetComputedProperty,
+        // JumpIf*, Pop, rhs..., SetComputedProperty, DuplicateTop, DuplicateTop, RotateTopThreeRight, Pop, Pop]
         if (program.OperationCount < 15)
         {
             return false;
@@ -3990,48 +3990,92 @@ internal static class UnifiedBytecodeProductionEligibility
             return false;
         }
 
-        var suffixStart = program.OperationCount - 13;
-        if (suffixStart <= 1 ||
-            !IsSupportedComputedPropertyKeySpan(
-                program,
-                startInclusive: 1,
-                endExclusive: suffixStart,
-                identifierConstants,
-                activationSlots))
+        var propertyWriteIndex = program.OperationCount - 6;
+        for (var rhsLength = 1; rhsLength <= 3; rhsLength += 2)
+        {
+            var suffixStart = propertyWriteIndex - 6 - rhsLength;
+            if (suffixStart <= 1 ||
+                !IsSupportedComputedPropertyKeySpan(
+                    program,
+                    startInclusive: 1,
+                    endExclusive: suffixStart,
+                    identifierConstants,
+                    activationSlots))
+            {
+                continue;
+            }
+
+            var requireObjectCoercible = program.GetOperation(suffixStart);
+            var resolvePropertyKey = program.GetOperation(suffixStart + 1);
+            var duplicateTargetAndKey = program.GetOperation(suffixStart + 2);
+            var propertyRead = program.GetOperation(suffixStart + 3);
+            var jump = program.GetOperation(suffixStart + 4);
+            var pop = program.GetOperation(suffixStart + 5);
+            var propertyWrite = program.GetOperation(propertyWriteIndex);
+            var duplicateAssignedValue = program.GetOperation(propertyWriteIndex + 1);
+            var duplicateAssignedValueAgain = program.GetOperation(propertyWriteIndex + 2);
+            var rotateTopThreeRight = program.GetOperation(propertyWriteIndex + 3);
+            var cleanupPop = program.GetOperation(propertyWriteIndex + 4);
+            var cleanupPop2 = program.GetOperation(propertyWriteIndex + 5);
+            if (requireObjectCoercible.Kind == ExpressionOpKind.RequireObjectCoercible &&
+                requireObjectCoercible.Depth == 1 &&
+                resolvePropertyKey.Kind == ExpressionOpKind.ResolvePropertyKey &&
+                duplicateTargetAndKey.Kind == ExpressionOpKind.DuplicateTopTwo &&
+                propertyRead.Kind == ExpressionOpKind.GetComputedProperty &&
+                !propertyRead.ShortCircuitOnNullishTarget &&
+                jump.Kind is (ExpressionOpKind.JumpIfFalse or ExpressionOpKind.JumpIfTrue or ExpressionOpKind.JumpIfNotNullish) &&
+                pop.Kind == ExpressionOpKind.Pop &&
+                IsSupportedComputedLogicalAssignmentRhsSpan(
+                    program,
+                    suffixStart + 6,
+                    propertyWriteIndex,
+                    identifierConstants,
+                    activationSlots) &&
+                propertyWrite.Kind == ExpressionOpKind.SetComputedProperty &&
+                !propertyWrite.AllowNameInference &&
+                duplicateAssignedValue.Kind == ExpressionOpKind.DuplicateTop &&
+                duplicateAssignedValueAgain.Kind == ExpressionOpKind.DuplicateTop &&
+                rotateTopThreeRight.Kind == ExpressionOpKind.RotateTopThreeRight &&
+                cleanupPop.Kind == ExpressionOpKind.Pop &&
+                cleanupPop2.Kind == ExpressionOpKind.Pop &&
+                jump.Target == propertyWriteIndex + 3)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsSupportedComputedLogicalAssignmentRhsSpan(
+        ExpressionProgram program,
+        int startInclusive,
+        int endExclusive,
+        ReadOnlySpan<IdentifierOperand> identifierConstants,
+        ActivationSlotShape activationSlots)
+    {
+        if (startInclusive >= endExclusive)
         {
             return false;
         }
 
-        var requireObjectCoercible = program.GetOperation(suffixStart);
-        var resolvePropertyKey = program.GetOperation(suffixStart + 1);
-        var duplicateTargetAndKey = program.GetOperation(suffixStart + 2);
-        var propertyRead = program.GetOperation(suffixStart + 3);
-        var jump = program.GetOperation(suffixStart + 4);
-        var pop = program.GetOperation(suffixStart + 5);
-        var rhs = program.GetOperation(suffixStart + 6);
-        var propertyWrite = program.GetOperation(suffixStart + 7);
-        var duplicateAssignedValue = program.GetOperation(suffixStart + 8);
-        var duplicateAssignedValueAgain = program.GetOperation(suffixStart + 9);
-        var rotateTopThreeRight = program.GetOperation(suffixStart + 10);
-        var cleanupPop = program.GetOperation(suffixStart + 11);
-        var cleanupPop2 = program.GetOperation(suffixStart + 12);
-        return requireObjectCoercible.Kind == ExpressionOpKind.RequireObjectCoercible &&
-               requireObjectCoercible.Depth == 1 &&
-               resolvePropertyKey.Kind == ExpressionOpKind.ResolvePropertyKey &&
-               duplicateTargetAndKey.Kind == ExpressionOpKind.DuplicateTopTwo &&
-               propertyRead.Kind == ExpressionOpKind.GetComputedProperty &&
-               !propertyRead.ShortCircuitOnNullishTarget &&
-               jump.Kind is (ExpressionOpKind.JumpIfFalse or ExpressionOpKind.JumpIfTrue or ExpressionOpKind.JumpIfNotNullish) &&
-               pop.Kind == ExpressionOpKind.Pop &&
-               IsSimpleOperand(rhs, identifierConstants, activationSlots) &&
-               propertyWrite.Kind == ExpressionOpKind.SetComputedProperty &&
-               !propertyWrite.AllowNameInference &&
-               duplicateAssignedValue.Kind == ExpressionOpKind.DuplicateTop &&
-               duplicateAssignedValueAgain.Kind == ExpressionOpKind.DuplicateTop &&
-               rotateTopThreeRight.Kind == ExpressionOpKind.RotateTopThreeRight &&
-               cleanupPop.Kind == ExpressionOpKind.Pop &&
-               cleanupPop2.Kind == ExpressionOpKind.Pop &&
-               jump.Target == suffixStart + 10;
+        if (endExclusive - startInclusive == 1)
+        {
+            return IsSimpleOperand(program.GetOperation(startInclusive), identifierConstants, activationSlots);
+        }
+
+        if (endExclusive - startInclusive != 3)
+        {
+            return false;
+        }
+
+        var left = program.GetOperation(startInclusive);
+        var right = program.GetOperation(startInclusive + 1);
+        var binary = program.GetOperation(startInclusive + 2);
+        return IsSimpleOperand(left, identifierConstants, activationSlots) &&
+               IsSimpleOperand(right, identifierConstants, activationSlots) &&
+               binary.Kind == ExpressionOpKind.Binary &&
+               IsProductionBinaryOperator(binary.Operator);
     }
 
     private static bool TryIsFirstBoundaryPropertyWriteCandidate(

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -6614,15 +6614,6 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     [Theory]
     [InlineData(
         """
-        function logicalAndComputedComplexRhsWrite(box, key, value) {
-            return box[key] &&= (value + 1);
-        }
-        """,
-        "logicalAndComputedComplexRhsWrite",
-        null,
-        (int)UnifiedBytecodeProductionDeclineCode.PropertyWriteDependency)]
-    [InlineData(
-        """
         function logicalAndComputedThisKeyWrite(box, value) {
             return box[this] &&= value;
         }
@@ -6655,6 +6646,32 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
 
         Assert.False(result.IsEligible);
         Assert.Equal((UnifiedBytecodeProductionDeclineCode)expectedCode, result.Code);
+    }
+
+    [Fact]
+    public void Evaluate_ComputedLogicalAssignmentWithBinaryRhs_AcceptsWithOwnedOpcodes()
+    {
+        var plan = GetFunctionPlan(
+            """
+            function logicalAndComputedComplexRhsWrite(box, key, value) {
+                return box[key] &&= (value + 1);
+            }
+            """,
+            "logicalAndComputedComplexRhsWrite");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.GetComputedPropertyForCompoundSet);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.Binary &&
+            instruction.Operand == (int)BinaryOperator.Add);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.SetComputedProperty);
     }
 
     [Fact]

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -4562,6 +4562,48 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
                 StringComparison.Ordinal));
     }
 
+    [Fact(Timeout = 5000)]
+    public async Task ComputedLogicalPropertyWriteWithBinaryRhs_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var events = [];
+            function makeBox(initialValue) {
+                var store = initialValue;
+                var box = {};
+                Object.defineProperty(box, "value", {
+                    get() {
+                        events.push("get");
+                        return store;
+                    },
+                    set(value) {
+                        events.push("set:" + value);
+                        store = value;
+                    }
+                });
+                return box;
+            }
+            var key = {
+                toString() {
+                    events.push("key");
+                    return "value";
+                }
+            };
+            function write(box, key, value) {
+                return box[key] &&= (value + 1);
+            }
+
+            String(write(makeBox(0), key, 6)) + ":" +
+                String(write(makeBox(1), key, 6)) + ":" + events.join(",");
+            """);
+
+        Assert.Equal("0:7:key,get,key,get,set:7", result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=write argc=3",
+                StringComparison.Ordinal));
+    }
+
     [Theory(Timeout = 5000)]
     [InlineData("&&=", "1", "0", "7", "7", "0")]
     [InlineData("||=", "0", "5", "7", "7", "5")]


### PR DESCRIPTION
## Summary
- allow computed logical assignment production layouts with either simple RHS or simple binary RHS spans
- compile simple binary RHS spans to owned Binary unified bytecode before SetComputedProperty
- move box[key] &&= (value + 1) from explicit decline coverage to eligibility and runtime route-hit coverage

## Verification
- focused computed logical assignment proof: 9 tests passed
- broad bytecode/lowering proof: 890 tests passed
- engine build: 2 projects, 0 errors, 0 warnings
- AST-eval seam scan: no matches
- git diff --check: clean