### PR TITLE
Admit this and new.target computed keys

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -8621,6 +8621,8 @@ internal static class UnifiedBytecodeCompiler
             {
                 case ExpressionOpKind.LoadIdentifier:
                 case ExpressionOpKind.LoadLiteral:
+                case ExpressionOpKind.LoadThis:
+                case ExpressionOpKind.LoadNewTarget:
                     if (!TryAppendComputedPropertyKeyLoad(
                             operation,
                             expressionProgram,
@@ -8702,6 +8704,8 @@ internal static class UnifiedBytecodeCompiler
             switch (operation.Kind)
             {
                 case ExpressionOpKind.LoadLiteral:
+                case ExpressionOpKind.LoadThis:
+                case ExpressionOpKind.LoadNewTarget:
                     stackDepth++;
                     break;
 
@@ -9150,6 +9154,16 @@ internal static class UnifiedBytecodeCompiler
                 var literalIndex = literalConstants.Count;
                 literalConstants.Add(literal);
                 unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.LoadLiteral, literalIndex));
+                reason = string.Empty;
+                return true;
+
+            case ExpressionOpKind.LoadThis:
+                unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.LoadThis));
+                reason = string.Empty;
+                return true;
+
+            case ExpressionOpKind.LoadNewTarget:
+                unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.LoadNewTarget));
                 reason = string.Empty;
                 return true;
 

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -3251,6 +3251,8 @@ internal static class UnifiedBytecodeProductionEligibility
         return operation.Kind switch
         {
             ExpressionOpKind.LoadLiteral => true,
+            ExpressionOpKind.LoadThis => true,
+            ExpressionOpKind.LoadNewTarget => true,
             ExpressionOpKind.LoadIdentifier => TryGetActivationResolvedValue(
                 operation,
                 identifierConstants,
@@ -3274,6 +3276,8 @@ internal static class UnifiedBytecodeProductionEligibility
             {
                 case ExpressionOpKind.LoadLiteral:
                 case ExpressionOpKind.LoadIdentifier:
+                case ExpressionOpKind.LoadThis:
+                case ExpressionOpKind.LoadNewTarget:
                     if (!IsSimpleComputedPropertyKey(operation, identifierConstants, activationSlots))
                     {
                         return false;
@@ -4426,14 +4430,14 @@ internal static class UnifiedBytecodeProductionEligibility
         return operation.Kind switch
         {
             ExpressionOpKind.LoadLiteral => true,
+            ExpressionOpKind.LoadThis => true,
+            ExpressionOpKind.LoadNewTarget => true,
             ExpressionOpKind.LoadIdentifier => TryGetActivationResolvedValue(
                 operation,
                 identifierConstants,
                 activationSlots) ||
                 allowsDynamicIdentifiers &&
                 !operation.IsArguments,
-            ExpressionOpKind.LoadThis => true,
-            ExpressionOpKind.LoadNewTarget => true,
             _ => false
         };
     }
@@ -4446,6 +4450,8 @@ internal static class UnifiedBytecodeProductionEligibility
         return operation.Kind switch
         {
             ExpressionOpKind.LoadLiteral => true,
+            ExpressionOpKind.LoadThis => true,
+            ExpressionOpKind.LoadNewTarget => true,
             ExpressionOpKind.LoadIdentifier => TryGetActivationResolvedValue(
                 operation,
                 identifierConstants,

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -6619,8 +6619,7 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         }
         """,
         "logicalAndComputedThisKeyWrite",
-        null,
-        (int)UnifiedBytecodeProductionDeclineCode.PropertyWriteDependency)]
+        (int)UnifiedBytecodeOpCode.LoadThis)]
     [InlineData(
         """
         function logicalAndComputedNewTargetKeyWrite(box, value) {
@@ -6628,24 +6627,26 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         }
         """,
         "logicalAndComputedNewTargetKeyWrite",
-        null,
-        (int)UnifiedBytecodeProductionDeclineCode.PropertyWriteDependency)]
-    public void Evaluate_LogicalAndAssignment_UnsupportedShapes_DeclineWithExplicitCodes(
+        (int)UnifiedBytecodeOpCode.LoadNewTarget)]
+    public void Evaluate_LogicalAndAssignment_ThisAndNewTargetComputedKeys_AcceptWithOwnedOpcodes(
         string source,
-        string functionOrClassName,
-        string? methodName,
-        int expectedCode)
+        string functionName,
+        int expectedKeyLoadOpCode)
     {
-        var plan = methodName is null
-            ? GetFunctionPlan(source, functionOrClassName)
-            : GetClassMethodPlan(source, functionOrClassName, methodName);
+        var plan = GetFunctionPlan(source, functionName);
 
         var result = UnifiedBytecodeProductionEligibility.Evaluate(
             plan,
             new UnifiedBytecodeProductionActivationDescriptor());
 
-        Assert.False(result.IsEligible);
-        Assert.Equal((UnifiedBytecodeProductionDeclineCode)expectedCode, result.Code);
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == (UnifiedBytecodeOpCode)expectedKeyLoadOpCode);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.GetComputedPropertyForCompoundSet);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.SetComputedProperty);
     }
 
     [Fact]

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -4604,6 +4604,49 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
                 StringComparison.Ordinal));
     }
 
+    [Fact(Timeout = 5000)]
+    public async Task ComputedLogicalPropertyWriteWithThisKey_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var box = {};
+            box[this] = 1;
+
+            function write(box, value) {
+                return box[this] &&= value;
+            }
+
+            String(write(box, 7)) + ":" + box[this];
+            """);
+
+        Assert.Equal("7:7", result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=write argc=2",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ComputedLogicalPropertyWriteWithNewTargetKey_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var box = { undefined: 1 };
+
+            function write(box, value) {
+                return box[new.target] &&= value;
+            }
+
+            String(write(box, 7)) + ":" + box.undefined;
+            """);
+
+        Assert.Equal("7:7", result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=write argc=2",
+                StringComparison.Ordinal));
+    }
+
     [Theory(Timeout = 5000)]
     [InlineData("&&=", "1", "0", "7", "7", "0")]
     [InlineData("||=", "0", "5", "7", "7", "5")]


### PR DESCRIPTION
## Summary
- allow `this` and `new.target` loads inside computed property key spans
- emit the matching unified bytecode load instructions from computed key compilation
- move the previous logical `&&=` computed-key decline rows to accepted opcode and route-hit coverage

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_LogicalAndAssignment_ThisAndNewTargetComputedKeys_AcceptWithOwnedOpcodes|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ComputedLogicalPropertyWriteWithThisKey_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ComputedLogicalPropertyWriteWithNewTargetKey_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ComputedLogicalPropertyWrite_UsesUnifiedBytecodeProductionFastPathAndPreservesShortCircuitSemantics|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ComputedLogicalPropertyWriteWithExpressionKey_UsesUnifiedBytecodeProductionFastPathAndPreservesShortCircuitSemantics|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ComputedLogicalPropertyWriteWithBinaryRhs_UsesUnifiedBytecodeProductionFastPath'\n- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~UnifiedBytecodeProductionSpreadCallTests|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramLoweringTests|FullyQualifiedName~ExpressionProgramCoverageMapTests|FullyQualifiedName~AstFreeExecutionAssertionTests'\n- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release\n- rtk rg "EvaluateExpression\\\\(|ProfileEvaluateExpression\\\\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*\n- rtk git diff --check