### PR TITLE
Admit expression keys for computed member calls

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -5403,25 +5403,27 @@ internal static class UnifiedBytecodeCompiler
             }
         }
 
-        var keyIndex = callTargetIndexInProgram - 1;
+        var keyStartIndex = FindComputedCallKeyStart(expressionProgram, callTargetIndexInProgram);
         if (!TryAppendNamedReceiverOperations(
                 expressionProgram,
                 activationSlots,
                 unified,
                 stringConstants,
-                keyIndex,
+                keyStartIndex,
                 allowDeepChain: false,
                 out reason))
         {
             return false;
         }
 
-        if (!TryAppendComputedPropertyKeyLoad(
-                expressionProgram.GetOperation(keyIndex),
+        if (!TryAppendComputedPropertyKeySpan(
                 expressionProgram,
                 activationSlots,
                 unified,
                 literalConstants,
+                stringConstants,
+                startInclusive: keyStartIndex,
+                endExclusive: callTargetIndexInProgram,
                 out reason))
         {
             return false;
@@ -5443,6 +5445,31 @@ internal static class UnifiedBytecodeCompiler
             call,
             callIndex,
             out reason);
+    }
+
+    private static int FindComputedCallKeyStart(
+        ExpressionProgram expressionProgram,
+        int callTargetIndexInProgram)
+    {
+        var stringConstants = expressionProgram.StringConstants.AsSpan();
+        var keyStartIndex = 1;
+        while (keyStartIndex < callTargetIndexInProgram &&
+               IsPlainNamedPropertyRead(expressionProgram.GetOperation(keyStartIndex), stringConstants))
+        {
+            keyStartIndex++;
+        }
+
+        return keyStartIndex;
+    }
+
+    private static bool IsPlainNamedPropertyRead(
+        PackedExpressionOp operation,
+        ReadOnlySpan<string> stringConstants)
+    {
+        return operation.Kind == ExpressionOpKind.GetNamedProperty &&
+               !operation.IsOptional &&
+               !operation.ShortCircuitOnNullishTarget &&
+               !operation.GetString(stringConstants).IsPrivateName();
     }
 
     private static bool TryAppendNamedSuperCallTargetPreparation(

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -2730,7 +2730,7 @@ internal static class UnifiedBytecodeProductionEligibility
         if (computedCallTargetIndex >= 2)
         {
             var computedCallTarget = program.GetOperation(computedCallTargetIndex);
-            var keyIndex = computedCallTargetIndex - 1;
+            var keyStartIndex = FindComputedCallKeyStart(program, computedCallTargetIndex, stringConstants);
             return !computedCallTarget.IsOptional &&
                    !computedCallTarget.ShortCircuitOnNullishTarget &&
                    IsSupportedNamedReceiverChain(
@@ -2738,10 +2738,12 @@ internal static class UnifiedBytecodeProductionEligibility
                        identifierConstants,
                        stringConstants,
                        activationSlots,
-                       keyIndex,
+                       keyStartIndex,
                        allowDeepChain: false) &&
-                   IsSimpleComputedPropertyKey(
-                       program.GetOperation(keyIndex),
+                   IsSupportedComputedPropertyKeySpan(
+                       program,
+                       startInclusive: keyStartIndex,
+                       endExclusive: computedCallTargetIndex,
                        identifierConstants,
                        activationSlots) &&
                    HasSimpleCallArguments(
@@ -2753,6 +2755,21 @@ internal static class UnifiedBytecodeProductionEligibility
         }
 
         return false;
+    }
+
+    private static int FindComputedCallKeyStart(
+        ExpressionProgram program,
+        int computedCallTargetIndex,
+        ReadOnlySpan<string> stringConstants)
+    {
+        var keyStartIndex = 1;
+        while (keyStartIndex < computedCallTargetIndex &&
+               IsPlainNamedPropertyRead(program.GetOperation(keyStartIndex), stringConstants))
+        {
+            keyStartIndex++;
+        }
+
+        return keyStartIndex;
     }
 
     private static bool IsFirstBoundaryDirectEvalCallCandidate(

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -2446,7 +2446,7 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         }
         """,
         "invokeComputedExpressionKey",
-        (int)UnifiedBytecodeProductionDeclineCode.CallDependency)]
+        (int)UnifiedBytecodeProductionDeclineCode.None)]
     [InlineData(
         """
         function invokeDeepComputedCallee(root, key, value) {

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -1995,6 +1995,32 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task ComputedMemberCallWithExpressionKey_UsesUnifiedBytecodeProductionFastPathAndPreservesThis()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var box = {
+                offset: 1,
+                read(value) {
+                    return value + this.offset;
+                }
+            };
+
+            function invoke(box, left, right, value) {
+                return box[left + right](value);
+            }
+
+            invoke(box, "re", "ad", 41);
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=invoke argc=4",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task ComputedMemberCall_NullishReceiverThrowsBeforeKeyCoercion()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- split computed member call receivers from computed key spans instead of assuming the key is one op
- compile computed member call key spans through the existing computed-property key span emitter
- move `box[left + right]()` out of the CallDependency decline row and add route-hit coverage that preserves `this`

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_PropertyReadAdjacentFamilies_DeclineWithExplicitCodes|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_ComputedMemberCallExpressionPlan_AcceptsExecutableInvocationBoundary|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ComputedMemberCall_UsesUnifiedBytecodeProductionFastPathAndPreservesThis|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ComputedMemberCallWithExpressionKey_UsesUnifiedBytecodeProductionFastPathAndPreservesThis|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ComputedMemberCall_PreservesKeyConversionSideEffectsAndThisBinding'\n- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~UnifiedBytecodeProductionSpreadCallTests|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramLoweringTests|FullyQualifiedName~ExpressionProgramCoverageMapTests|FullyQualifiedName~AstFreeExecutionAssertionTests'\n- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release\n- rtk rg "EvaluateExpression\\\\(|ProfileEvaluateExpression\\\\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*\n- rtk git diff --check