### PR TITLE
Admit object literal named property reads

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -1053,6 +1053,11 @@ internal static class UnifiedBytecodeProductionEligibility
                         break;
                     }
 
+                    if (TryIsFirstBoundaryObjectLiteralNamedPropertyReadCandidate(program, identifierConstants, activationSlots))
+                    {
+                        break;
+                    }
+
                     if (TryIsFirstBoundaryOptionalNamedChainCandidate(program, identifierConstants, activationSlots))
                     {
                         break;
@@ -1811,6 +1816,38 @@ internal static class UnifiedBytecodeProductionEligibility
             if (operation.Kind != ExpressionOpKind.GetNamedProperty ||
                 operation.IsOptional ||
                 operation.ShortCircuitOnNullishTarget)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryIsFirstBoundaryObjectLiteralNamedPropertyReadCandidate(
+        ExpressionProgram program,
+        ReadOnlySpan<IdentifierOperand> identifierConstants,
+        ActivationSlotShape activationSlots)
+    {
+        if (!TryMeasureSimpleObjectLiteralSpan(
+                program,
+                startIndex: 0,
+                identifierConstants,
+                activationSlots,
+                out var objectSpanLength) ||
+            objectSpanLength >= program.OperationCount)
+        {
+            return false;
+        }
+
+        var stringConstants = program.StringConstants.AsSpan();
+        for (var index = objectSpanLength; index < program.OperationCount; index++)
+        {
+            var operation = program.GetOperation(index);
+            if (operation.Kind != ExpressionOpKind.GetNamedProperty ||
+                operation.IsOptional ||
+                operation.ShortCircuitOnNullishTarget ||
+                operation.GetString(stringConstants).IsPrivateName())
             {
                 return false;
             }

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -2462,7 +2462,7 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         }
         """,
         "readLiteral",
-        (int)UnifiedBytecodeProductionDeclineCode.PropertyReadBoundaryOutOfScope)]
+        (int)UnifiedBytecodeProductionDeclineCode.None)]
     [InlineData(
         """
         function readDynamic(box) {

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -7103,6 +7103,25 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task ObjectLiteralSpreadNamedPropertyRead_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function readLiteral(box) {
+                return { ...box }.value;
+            }
+
+            readLiteral({ value: 42 });
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=readLiteral argc=1",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task ObjectLiteralSpread_PreservesOverwriteOrder_OnFastPath()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit simple object-literal spans followed by named property read chains in production eligibility
- move `{ ...box }.value` out of the property-read boundary decline row
- add route-hit coverage for object-spread literal property reads

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_PropertyReadAdjacentFamilies_DeclineWithExplicitCodes|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ObjectLiteralSpreadNamedPropertyRead_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ObjectLiteralSpread_UsesUnifiedBytecodeProductionFastPathAndCopiesSymbolKeys|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ObjectLiteralSpread_PreservesOverwriteOrder_OnFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ObjectLiteralConstruction_UsesUnifiedBytecodeProductionFastPathAndCoercesComputedKeys'\n- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~UnifiedBytecodeProductionSpreadCallTests|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramLoweringTests|FullyQualifiedName~ExpressionProgramCoverageMapTests|FullyQualifiedName~AstFreeExecutionAssertionTests'\n- rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release\n- rtk rg "EvaluateExpression\\\\(|ProfileEvaluateExpression\\\\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*\n- rtk git diff --check