### PR TITLE
Admit deep computed member calls

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -5410,7 +5410,7 @@ internal static class UnifiedBytecodeCompiler
                 unified,
                 stringConstants,
                 keyStartIndex,
-                allowDeepChain: false,
+                allowDeepChain: true,
                 out reason))
         {
             return false;

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -2813,7 +2813,7 @@ internal static class UnifiedBytecodeProductionEligibility
                        stringConstants,
                        activationSlots,
                        keyStartIndex,
-                       allowDeepChain: false) &&
+                       allowDeepChain: true) &&
                    IsSupportedComputedPropertyKeySpan(
                        program,
                        startInclusive: keyStartIndex,

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -2454,7 +2454,7 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         }
         """,
         "invokeDeepComputedCallee",
-        (int)UnifiedBytecodeProductionDeclineCode.PropertyReadBoundaryOutOfScope)]
+        (int)UnifiedBytecodeProductionDeclineCode.None)]
     [InlineData(
         """
         function readLiteral(box) {

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -2021,6 +2021,38 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task DeepComputedMemberCall_UsesUnifiedBytecodeProductionFastPathAndPreservesThis()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var root = {
+                child: {
+                    branch: {
+                        leaf: {
+                            offset: 1,
+                            read(value) {
+                                return this === root.child.branch.leaf ? value + this.offset : -1;
+                            }
+                        }
+                    }
+                }
+            };
+
+            function invoke(root, key, value) {
+                return root.child.branch.leaf[key](value);
+            }
+
+            invoke(root, "read", 41);
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=invoke argc=3",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task ComputedMemberCall_NullishReceiverThrowsBeforeKeyCoercion()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- allow computed member-call preparation to use the existing deep named receiver-chain support
- convert `root.child.branch.leaf[key](value)` from a stale property-read boundary decline to an admitted production shape
- add a runtime route-hit proof that preserves the deepest receiver as `this`

## Verification
- `rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_PropertyReadAdjacentFamilies_DeclineWithExplicitCodes|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_DeeperNamedMemberCallExpressionPlan_AcceptsExecutableInvocationBoundary|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.DeepComputedMemberCall_UsesUnifiedBytecodeProductionFastPathAndPreservesThis|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.DeeperNamedMemberCall_BindsThisToDeepestReceiver|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.ComputedMemberCallWithExpressionKey_UsesUnifiedBytecodeProductionFastPathAndPreservesThis'`\n- `rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests|FullyQualifiedName~UnifiedBytecodeProductionSpreadCallTests|FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests|FullyQualifiedName~ExpressionProgramLoweringTests|FullyQualifiedName~ExpressionProgramCoverageMapTests|FullyQualifiedName~AstFreeExecutionAssertionTests'`\n- `rtk dotnet build src/Asynkron.JsEngine/Asynkron.JsEngine.csproj -c Release`\n- `rtk rg "EvaluateExpression\\(|ProfileEvaluateExpression\\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*`\n- `rtk git diff --check`