### PR TITLE
Admit dynamic adjacent property operands

### DIFF
--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -2476,7 +2476,7 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         }
         """,
         "readDynamic",
-        (int)UnifiedBytecodeProductionDeclineCode.DynamicLookupDependency)]
+        (int)UnifiedBytecodeProductionDeclineCode.None)]
     [InlineData(
         """
         function readBinaryTarget(a, b) {
@@ -2533,7 +2533,7 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         }
         """,
         "dynamicValueWrite",
-        (int)UnifiedBytecodeProductionDeclineCode.DynamicLookupDependency)]
+        (int)UnifiedBytecodeProductionDeclineCode.None)]
     [InlineData(
         """
         function computedExpressionWrite(box, key, suffix, value) {
@@ -2559,7 +2559,8 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
 
         var result = UnifiedBytecodeProductionEligibility.Evaluate(
             plan,
-            new UnifiedBytecodeProductionActivationDescriptor());
+            new UnifiedBytecodeProductionActivationDescriptor(
+                AllowsOrdinaryDynamicIdentifierEnvironmentOperations: true));
 
         var expectedDeclineCode = (UnifiedBytecodeProductionDeclineCode)expectedCode;
         if (expectedDeclineCode == UnifiedBytecodeProductionDeclineCode.None)


### PR DESCRIPTION
## Summary
- align adjacent property eligibility coverage with the ordinary dynamic-name descriptor path
- convert computed-property read dynamic key and named-property write dynamic value expectations from stale DynamicLookupDependency rows to accepted coverage
- rely on existing runtime route-hit tests for both shapes

## Verification
- Focused proof: 16 tests passed
- Broad unified-bytecode/lowering pack: 901 tests passed
- Build: 0 errors, 0 warnings
- AST seam scan: no EvaluateExpression/ProfileEvaluateExpression matches
- git diff --check clean