### PR TITLE
Admit direct eval dynamic reads

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -329,7 +329,7 @@ must still obey the no-mixed-execution rule.
 | `ArrowLexicalThisDependency` | Activation descriptor gate for arrow lexical `this` / `new.target` ownership before ordinary sync routing | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_OrdinarySyncActivationDescriptorBlockers_DeclineBeforeCompile"` |
 | `ClassConstructorActivation` | Activation descriptor gate for class constructor activation outside the admitted simple base constructor route and explicit derived-constructor `super(...)` route with post-super `this` body reads/writes | Constructor route | Constructor boundary lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests&FullyQualifiedName~Constructor"` |
 | `CallDependency` | Direct eval outside the one-argument non-spread eval-identifier boundary, out-of-boundary call-target preparation, and complex call arguments excluding admitted simple/binary template-literal substitutions, simple/binary computed object keys, and zero-argument activation-resolved identifier-call computed object keys | Existing sync IR call route | Wider call invocation lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests"` |
-| `DynamicLookupDependency` | Unresolved identifier loads/stores/update outside the admitted ordinary and with-backed dynamic-name paths; plans that need both lanes now route when direct eval, captured activation, and arguments-object dependencies are absent | Existing sync IR / environment lookup route | Dynamic-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_WithThenOutsideDynamicIdentifier_AcceptsMixedDynamicNameProgram"` |
+| `DynamicLookupDependency` | Unresolved identifier loads/stores/update outside the admitted ordinary, with-backed, and direct-eval-backed dynamic-name paths; plans that need direct eval plus post-eval dynamic identifier reads now route when captured activation, with-chain, and arguments-object dependencies are absent | Existing sync IR / environment lookup route | Dynamic-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_DirectEvalDeclaredVarRead_AcceptsOrdinaryDynamicNameProgram"` |
 | `PropertyReadBoundaryOutOfScope` | Named/computed property reads outside the admitted activation-resolved boundaries | Existing sync IR property route | Property read widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_ComputedPropertyReadOutsideFirstBoundary_DeclinesWithBoundaryCode"` |
 | `PropertyWriteDependency` | Property writes and compound/logical property writes outside the admitted direct property-write shapes, supported computed expression-key mutation shapes, simple nested named receiver assignment shape, nested named compound-write shape, and nested named logical-write shape | Existing sync IR property-write route | Property write widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_LogicalAndAssignment_UnsupportedShapes_DeclineWithExplicitCodes"` |
 | `PropertyUpdateDependency` | Property and identifier update expressions outside the admitted direct update, computed expression-key update, and simple nested named receiver update boundary | Existing sync IR update route | Property update lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedNamedPropertyUpdate_AcceptsOwnedPropertyOpcodes"` |
@@ -512,9 +512,8 @@ the final post-compile production subset check before VM entry.
   name fallback, or calls back into `ExpressionProgram`, `ExecutionPlanRunner`,
   or AST evaluation.
 - Unsupported binding declaration shapes, unsupported object/array destructuring
-  driver instructions, direct eval / unsupported dynamic lookup, captured
-  activation, per-iteration bindings, and `using` / `await using` remain pre-VM
-  declines.
+  driver instructions, unsupported dynamic lookup, captured activation,
+  per-iteration bindings, and `using` / `await using` remain pre-VM declines.
 
 ## Production With-Backed Dynamic Name Boundary
 - Current production dynamic-name support is with-backed and compiler-gated.
@@ -838,10 +837,11 @@ support today.
    (`DestructuringDependency`).
 6. Dynamic lookup families remain outside the admitted boundary
    (`DynamicLookupDependency`) except for the ordinary dynamic-name environment
-   path and the explicit with-backed dynamic name slice above. Direct eval
-   outside the admitted one-argument non-spread eval-identifier boundary,
-   unresolved dynamic activation, and unsupported unresolved lookup shapes still
-   decline before VM execution.
+   path, the direct-eval-backed ordinary dynamic-name path, and the explicit
+   with-backed dynamic name slice above. Direct eval outside the admitted
+   one-argument non-spread eval-identifier boundary, unresolved dynamic
+   activation, and unsupported unresolved lookup shapes still decline before VM
+   execution.
 7. Label-dependent control flow is now admitted (ADR 0285): labeled statements,
    labeled loops, labeled block `break`, and labeled `break`/`continue` route
    through the compiler-owned resolved-target path. The remaining

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -3136,7 +3136,7 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                 {
                     executionEnvironment = IsClassConstructor && _isDerivedClassConstructor
                         ? CreateSimpleDerivedClassConstructorEnvironment(arguments, vmNewTarget, plan)
-                        : CreateSimpleIrActivationEnvironment(arguments, vmThisValue, plan, context);
+                        : CreateSimpleIrActivationEnvironment(arguments, vmThisValue, plan, context, vmNewTarget);
                 }
 
                 if (IsClassConstructor &&
@@ -3930,8 +3930,7 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
 
         private bool CanUseProductionUnifiedBytecodeOrdinaryDynamicNameFastPath(ExecutionPlan plan)
         {
-            return !_hasDirectEvalInBodyOrParameters &&
-                   !_hasClosureWithObject &&
+            return !_hasClosureWithObject &&
                    !_hasCapturedActivationInClosure &&
                    !_usesArguments &&
                    UnifiedBytecodeProductionEligibility.ContainsOrdinaryDynamicIdentifierDependency(plan);
@@ -4002,7 +4001,8 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
             TArgs arguments,
             JsValue thisValue,
             ExecutionPlan plan,
-            EvaluationContext context)
+            EvaluationContext context,
+            JsValue newTarget = default)
             where TArgs : IReadOnlyList<JsValue>
         {
             var functionEnvironment = JsEnvironmentPool.Rent(_closure, true, _isStrict, _function.Source,
@@ -4032,6 +4032,15 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
             functionEnvironment._thisValue = boundThis;
             functionEnvironment._hasThisValue = true;
             functionEnvironment.DefineJsValue(Symbol.This, boundThis);
+            if (!IsArrowFunction)
+            {
+                var newTargetValue = newTarget.IsUndefined ? JsValue.Undefined : newTarget;
+                functionEnvironment.DefineJsValue(Symbol.NewTarget, newTargetValue, true, isLexicalBinding: true,
+                    blocksFunctionScopeOverride: true);
+                functionEnvironment.DefineJsValue(Symbol.ActiveFunction, _cachedJsValue, true,
+                    isLexicalBinding: true, blocksFunctionScopeOverride: true);
+            }
+
             functionEnvironment.SetThisInitializationStatus(true);
 
             IJsPropertyAccessor? prototypeForSuper = null;

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -1972,30 +1972,30 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
                 or UnifiedBytecodeOpCode.CallInvocationBoundary);
     }
 
-    [Theory]
-    [InlineData(
-        """
-        function directEval() {
-            eval("var value = 1");
-            return value;
-        }
-        """,
-        "directEval",
-        (int)UnifiedBytecodeProductionDeclineCode.DynamicLookupDependency)]
-    public void Evaluate_UnsupportedDynamicAndDestructuringBlockShapes_StayDeclined(
-        string source,
-        string functionName,
-        int expectedCode)
+    [Fact]
+    public void Evaluate_DirectEvalDeclaredVarRead_AcceptsOrdinaryDynamicNameProgram()
     {
-        var plan = GetFunctionPlan(source, functionName);
+        var plan = GetFunctionPlan("""
+            function directEval() {
+                eval("var value = 1");
+                return value;
+            }
+            """,
+            "directEval");
 
         var result = UnifiedBytecodeProductionEligibility.Evaluate(
             plan,
-            new UnifiedBytecodeProductionActivationDescriptor());
+            new UnifiedBytecodeProductionActivationDescriptor(
+                AllowsOrdinaryDynamicIdentifierEnvironmentOperations: true));
 
-        Assert.False(result.IsEligible);
-        Assert.Equal((UnifiedBytecodeProductionDeclineCode)expectedCode, result.Code);
-        Assert.NotEmpty(result.Reason);
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(
+            result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.CallInvocationBoundary);
+        Assert.Contains(
+            result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.LoadDynamicIdentifier);
     }
 
     [Fact]

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -991,7 +991,7 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
-    public async Task DirectEvalDeclarationDynamicLookup_DeclinesOrdinaryDynamicProductionFastPath()
+    public async Task DirectEvalDeclarationDynamicLookup_UsesUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();
         var result = await engine.Evaluate("""
@@ -1004,9 +1004,9 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
             """);
 
         Assert.Equal(42d, result);
-        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(
-                "unified-bytecode-production-fast-path func=run",
+                "unified-bytecode-production-fast-path func=run argc=0",
                 StringComparison.Ordinal));
     }
 
@@ -1822,6 +1822,30 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
         Assert.Contains(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(
                 "unified-bytecode-production-fast-path func=invokeEval argc=1",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task DirectEvalNewTarget_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var newTarget = null;
+            function getNewTarget() {
+                newTarget = eval("new.target;");
+            }
+
+            getNewTarget();
+            var callResult = newTarget === undefined;
+
+            new getNewTarget();
+            [callResult, newTarget === getNewTarget].join(",");
+            """);
+
+        Assert.Equal("true,true", result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=getNewTarget argc=0",
                 StringComparison.Ordinal));
     }
 


### PR DESCRIPTION
## Summary
- Admit direct-eval-backed ordinary dynamic identifier reads to production unified bytecode when captured activation, with-chain, and arguments-object blockers are absent.
- Populate ordinary production activation environments with new.target and active-function bindings so direct eval preserves caller context on the fast path.
- Convert the direct-eval declared-var decline row to an acceptance proof and update the expansion contract.

## Proof
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.DirectEvalNewTarget_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_DirectEvalDeclaredVarRead_AcceptsOrdinaryDynamicNameProgram|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.DirectEvalDeclarationDynamicLookup_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.DirectEvalIdentifierCall_UsesCallerEnvironmentOnProductionFastPath|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.DirectEvalIdentifierCall_SyncsMutatedCallerSlotsOnProductionFastPath'
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~EvalFunctionTests'
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~UnifiedBytecodeProduction'
- rtk dotnet test tests/Asynkron.JsEngine.Tests -c Release --filter 'FullyQualifiedName~ActivationSemanticsProofPackTests'
- rtk dotnet build Asynkron.JsEngine.sln -c Release
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner* (no matches)
- rtk ./tools/profile forloop --memory (Total allocated 6.85 MB)
- rtk git diff --check