### PR TITLE
Admit captured computed reads to production bytecode

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -124,9 +124,11 @@ statement interpretation.
   Private member deletes are parser early errors, so they no longer enter
   production eligibility.
 - Simple-return arrows can route with captured lexical `this` / `new.target`
-  values. The production invocation bridge resolves those captured values before
-  entering the VM and avoids sloppy-call `this` coercion for arrows. Arrows that
-  need a lexical-this environment or super binding still decline.
+  values and read-only captured environment reads, including named and computed
+  property reads from those dynamic identifier bases. The production invocation
+  bridge resolves those captured values before entering the VM and avoids
+  sloppy-call `this` coercion for arrows. Arrows that need a lexical-this
+  environment or super binding still decline.
 - Simple base class constructors with public or private instance fields and
   simple derived constructors with public or private instance fields can route through
   production unified bytecode. The production constructor bridge performs the
@@ -330,7 +332,7 @@ must still obey the no-mixed-execution rule.
 | `ClassConstructorActivation` | Activation descriptor gate for class constructor activation outside the admitted simple base constructor route, explicit derived-constructor `super(...)` route with post-super `this` body reads/writes, and default-derived constructor `super(...args)` forwarding route | Constructor route | Constructor boundary lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests&FullyQualifiedName~Constructor"` |
 | `CallDependency` | Direct eval outside the one-argument non-spread eval-identifier boundary, out-of-boundary call-target preparation, and complex call arguments excluding admitted simple/binary template-literal substitutions, simple/binary computed object keys, and zero-argument activation-resolved identifier-call computed object keys | Existing sync IR call route | Wider call invocation lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests"` |
 | `DynamicLookupDependency` | Unresolved identifier loads/stores/update outside the admitted ordinary, with-backed, and direct-eval-backed dynamic-name paths; plans that need direct eval plus post-eval dynamic identifier reads now route when captured activation, with-chain, and arguments-object dependencies are absent | Existing sync IR / environment lookup route | Dynamic-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_DirectEvalDeclaredVarRead_AcceptsOrdinaryDynamicNameProgram"` |
-| `PropertyReadBoundaryOutOfScope` | Named/computed property reads outside the admitted activation-resolved and read-only dynamic-identifier-base boundaries | Existing sync IR property route | Property read widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_ComputedPropertyReadOutsideFirstBoundary_DeclinesWithBoundaryCode"` |
+| `PropertyReadBoundaryOutOfScope` | Named/computed property reads outside the admitted activation-resolved and read-only dynamic-identifier-base boundaries, including captured closure dynamic bases | Existing sync IR property route | Property read widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_ComputedPropertyReadOutsideFirstBoundary_DeclinesWithBoundaryCode"` |
 | `PropertyWriteDependency` | Property writes and compound/logical property writes outside the admitted direct property-write shapes, supported computed expression-key mutation shapes, simple nested named receiver assignment shape, nested named compound-write shape, and nested named logical-write shape | Existing sync IR property-write route | Property write widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_LogicalAndAssignment_UnsupportedShapes_DeclineWithExplicitCodes"` |
 | `PropertyUpdateDependency` | Property and identifier update expressions outside the admitted direct update, computed expression-key update, and simple nested named receiver update boundary | Existing sync IR update route | Property update lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedNamedPropertyUpdate_AcceptsOwnedPropertyOpcodes"` |
 | `DeleteDependency` | `delete` expressions outside the admitted ordinary named/computed property delete lane, ordinary dynamic-key computed delete lane, and with-backed dynamic-name delete lane | Existing sync IR delete route | Delete semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedComputedPropertyDeleteDynamicKey_AcceptsOrdinaryDynamicNameOpcode"` |
@@ -354,7 +356,7 @@ not always have a `UnifiedBytecodeProductionDeclineCode`.
 | Pre-gate key | Owning source / current example | Current fallback route | Planned batch / lane | Proof command |
 |---|---|---|---|---|
 | `pre-gate:IsClassConstructor` | Class constructor invokers outside the admitted simple base constructor route and explicit derived-constructor `super(...)` route with post-super `this` body reads/writes | Constructor route | Constructor boundary lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
-| `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no super, call-target, assignment, update, delete, nested function/class literal, or other unowned dependency. Captured lexical `this` / `new.target`, statically resolved flat-slot reads, read-only ordinary environment identifier reads, and named property reads from those dynamic identifier bases are VM-owned; lexical-this environments remain a separate pre-gate. | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
+| `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no super, call-target, assignment, update, delete, nested function/class literal, or other unowned dependency. Captured lexical `this` / `new.target`, statically resolved flat-slot reads, read-only ordinary environment identifier reads, and named/computed property reads from those dynamic identifier bases are VM-owned; lexical-this environments remain a separate pre-gate. | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:IsAsyncLike` | Async and formerly-async ordinary invokers | Async route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_AsyncLikeActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:IsGenerator` | Generator functions before ordinary sync production routing | Generator route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_GeneratorActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:hasParameterExpressions` | Default/rest/destructured parameter expressions | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
@@ -464,14 +466,14 @@ the final post-compile production subset check before VM entry.
 - Simple-return arrow functions whose lowered body has no super, call-target,
   assignment, update, delete, nested function/class literal, or other unowned
   dependency may route. Captured lexical `this` / `new.target`, flat-slot reads,
-  read-only ordinary environment identifier reads, and named property reads from
-  those dynamic identifier bases are VM-owned. Dependency-bearing arrows still
-  decline via the `IsArrowFunction`, captured-activation, or
+  read-only ordinary environment identifier reads, and named/computed property
+  reads from those dynamic identifier bases are VM-owned. Dependency-bearing
+  arrows still decline via the `IsArrowFunction`, captured-activation, or
   `_lexicalThisEnvironment is not null` pre-gates.
 - Simple-return ordinary function expressions that capture an outer activation
   may route when the body is read-only and uses the same ordinary environment
-  identifier / named property read subset. Captured writes, updates, deletes,
-  calls, `arguments`, eval, with-backed closures, super/private/home-object
+  identifier / named or computed property read subset. Captured writes, updates,
+  deletes, calls, `arguments`, eval, with-backed closures, super/private/home-object
   shapes, and nested function/class literals remain outside this route.
 - There is no retained `this` decline in the production activation descriptor;
   future shapes that cannot thread `this` through the VM should introduce a

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -9982,17 +9982,20 @@ internal static class UnifiedBytecodeCompiler
         out string reason)
     {
         if (operation.Kind == ExpressionOpKind.LoadIdentifier &&
-            operation.IsArguments &&
             allowsDynamicIdentifiers)
         {
             var identifier = operation.GetIdentifier(expressionProgram.IdentifierConstants.AsSpan());
-            var identifierNameIndex = stringConstants.Count;
-            stringConstants.Add(identifier.Name.Name ?? string.Empty);
-            unified.Add(new UnifiedBytecodeInstruction(
-                UnifiedBytecodeOpCode.LoadDynamicIdentifier,
-                identifierNameIndex));
-            reason = string.Empty;
-            return true;
+            if (operation.IsArguments ||
+                !TryResolveActivationSlot(identifier, activationSlots, out _))
+            {
+                var identifierNameIndex = stringConstants.Count;
+                stringConstants.Add(identifier.Name.Name ?? string.Empty);
+                unified.Add(new UnifiedBytecodeInstruction(
+                    UnifiedBytecodeOpCode.LoadDynamicIdentifier,
+                    identifierNameIndex));
+                reason = string.Empty;
+                return true;
+            }
         }
 
         return TryAppendActivationValueLoad(

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -1898,9 +1898,10 @@ internal static class UnifiedBytecodeProductionEligibility
         bool allowsDynamicIdentifiers)
     {
         return TryGetActivationResolvedValue(operation, identifierConstants, activationSlots) ||
-               allowsDynamicIdentifiers &&
-               operation.Kind == ExpressionOpKind.LoadIdentifier &&
-               operation.IsArguments;
+               allowsDynamicIdentifiers && (
+                   operation.Kind == ExpressionOpKind.LoadIdentifier &&
+                   operation.IsArguments ||
+                   TryGetPlainDynamicIdentifierReadValue(operation, identifierConstants, activationSlots));
     }
 
     private static bool TryIsFirstBoundaryNamedPropertyReadCandidate(

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -1176,6 +1176,30 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
+    public void Evaluate_ComputedPropertyReadWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted()
+    {
+        var plan = GetFunctionPlan("""
+            function read(key) {
+                return outer[key];
+            }
+            """,
+            "read");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor(
+                AllowsOrdinaryDynamicIdentifierEnvironmentOperations: true));
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.LoadDynamicIdentifier);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.GetComputedProperty);
+        Assert.Equal(new[] { "outer" }, result.Program.StringConstants);
+    }
+
+    [Fact]
     public void Evaluate_TwoHopNamedPropertyReadCandidate_AcceptsOwnedPropertyOpcodes()
     {
         var plan = GetFunctionPlan("""

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -6677,6 +6677,26 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task ArrowFunction_CapturedComputedPropertyRead_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeGetter(obj, key) {
+                return () => obj[key];
+            }
+
+            var get = makeGetter({ value: 42 }, "value");
+            get();
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous>",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task FunctionExpression_CapturedOuterEnvironmentRead_UsesUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();
@@ -6688,6 +6708,28 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
             }
 
             var get = makeGetter({ value: 42 });
+            get();
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=get",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FunctionExpression_CapturedComputedPropertyRead_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeGetter(obj, key) {
+                return function get() {
+                    return obj[key];
+                };
+            }
+
+            var get = makeGetter({ value: 42 }, "value");
             get();
             """);
 


### PR DESCRIPTION
## Summary
- admit first-boundary computed property reads from captured ordinary dynamic identifier bases when ordinary dynamic reads are already allowed
- add eligibility and public route-hit coverage for captured arrow and ordinary closure obj[key] reads
- update the unified bytecode expansion contract to include captured computed read coverage

## Proof
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~Evaluate_ComputedPropertyReadWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted|FullyQualifiedName~ArrowFunction_CapturedComputedPropertyRead_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~FunctionExpression_CapturedComputedPropertyRead_UsesUnifiedBytecodeProductionFastPath"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProduction"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ActivationSemanticsProofPackTests"
- rtk dotnet build -c Release
- rtk rg "EvaluateExpression\\(|ProfileEvaluateExpression\\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner* (no matches)
- rtk ./tools/profile forloop --memory (6.86 MB)
- rtk git diff --check