### PR TITLE
Admit captured property writes to production bytecode

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -125,10 +125,11 @@ statement interpretation.
   production eligibility.
 - Simple-return arrows can route with captured lexical `this` / `new.target`
   values and read-only captured environment reads, including named and computed
-  property reads from those dynamic identifier bases. The production invocation
-  bridge resolves those captured values before entering the VM and avoids
-  sloppy-call `this` coercion for arrows. Arrows that need a lexical-this
-  environment or super binding still decline.
+  property reads from those dynamic identifier bases. Simple-return named and
+  computed property writes to captured dynamic identifier bases are also
+  VM-owned. The production invocation bridge resolves those captured values
+  before entering the VM and avoids sloppy-call `this` coercion for arrows.
+  Arrows that need a lexical-this environment or super binding still decline.
 - Simple base class constructors with public or private instance fields and
   simple derived constructors with public or private instance fields can route through
   production unified bytecode. The production constructor bridge performs the
@@ -333,7 +334,7 @@ must still obey the no-mixed-execution rule.
 | `CallDependency` | Direct eval outside the one-argument non-spread eval-identifier boundary, out-of-boundary call-target preparation, and complex call arguments excluding admitted simple/binary template-literal substitutions, simple/binary computed object keys, and zero-argument activation-resolved identifier-call computed object keys | Existing sync IR call route | Wider call invocation lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests"` |
 | `DynamicLookupDependency` | Unresolved identifier loads/stores/update outside the admitted ordinary, with-backed, and direct-eval-backed dynamic-name paths; plans that need direct eval plus post-eval dynamic identifier reads now route when captured activation, with-chain, and arguments-object dependencies are absent | Existing sync IR / environment lookup route | Dynamic-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_DirectEvalDeclaredVarRead_AcceptsOrdinaryDynamicNameProgram"` |
 | `PropertyReadBoundaryOutOfScope` | Named/computed property reads outside the admitted activation-resolved and read-only dynamic-identifier-base boundaries, including captured closure dynamic bases | Existing sync IR property route | Property read widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_ComputedPropertyReadOutsideFirstBoundary_DeclinesWithBoundaryCode"` |
-| `PropertyWriteDependency` | Property writes and compound/logical property writes outside the admitted direct property-write shapes, supported computed expression-key mutation shapes, simple nested named receiver assignment shape, nested named compound-write shape, and nested named logical-write shape | Existing sync IR property-write route | Property write widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_LogicalAndAssignment_UnsupportedShapes_DeclineWithExplicitCodes"` |
+| `PropertyWriteDependency` | Property writes and compound/logical property writes outside the admitted direct property-write shapes, supported computed expression-key mutation shapes, simple-return dynamic-base named/computed property writes, simple nested named receiver assignment shape, nested named compound-write shape, and nested named logical-write shape | Existing sync IR property-write route | Property write widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_LogicalAndAssignment_UnsupportedShapes_DeclineWithExplicitCodes"` |
 | `PropertyUpdateDependency` | Property and identifier update expressions outside the admitted direct update, computed expression-key update, and simple nested named receiver update boundary | Existing sync IR update route | Property update lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedNamedPropertyUpdate_AcceptsOwnedPropertyOpcodes"` |
 | `DeleteDependency` | `delete` expressions outside the admitted ordinary named/computed property delete lane, ordinary dynamic-key computed delete lane, and with-backed dynamic-name delete lane | Existing sync IR delete route | Delete semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedComputedPropertyDeleteDynamicKey_AcceptsOrdinaryDynamicNameOpcode"` |
 | `SuperPropertyDependency` | Out-of-boundary super call targets; super property reads/writes/updates are admitted by dedicated VM opcodes | Existing class / constructor route for remaining call-target shapes | Super semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperPropertyAccess_AcceptsOwnedOpcodes"` |
@@ -356,7 +357,7 @@ not always have a `UnifiedBytecodeProductionDeclineCode`.
 | Pre-gate key | Owning source / current example | Current fallback route | Planned batch / lane | Proof command |
 |---|---|---|---|---|
 | `pre-gate:IsClassConstructor` | Class constructor invokers outside the admitted simple base constructor route and explicit derived-constructor `super(...)` route with post-super `this` body reads/writes | Constructor route | Constructor boundary lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
-| `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no super, call-target, assignment, update, delete, nested function/class literal, or other unowned dependency. Captured lexical `this` / `new.target`, statically resolved flat-slot reads, read-only ordinary environment identifier reads, and named/computed property reads from those dynamic identifier bases are VM-owned; lexical-this environments remain a separate pre-gate. | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
+| `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no super, call-target, assignment, update, delete, nested function/class literal, or other unowned dependency. Captured lexical `this` / `new.target`, statically resolved flat-slot reads, ordinary environment identifier reads, and named/computed property reads or simple property writes from those dynamic identifier bases are VM-owned; lexical-this environments remain a separate pre-gate. | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:IsAsyncLike` | Async and formerly-async ordinary invokers | Async route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_AsyncLikeActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:IsGenerator` | Generator functions before ordinary sync production routing | Generator route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_GeneratorActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:hasParameterExpressions` | Default/rest/destructured parameter expressions | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
@@ -466,15 +467,16 @@ the final post-compile production subset check before VM entry.
 - Simple-return arrow functions whose lowered body has no super, call-target,
   assignment, update, delete, nested function/class literal, or other unowned
   dependency may route. Captured lexical `this` / `new.target`, flat-slot reads,
-  read-only ordinary environment identifier reads, and named/computed property
-  reads from those dynamic identifier bases are VM-owned. Dependency-bearing
-  arrows still decline via the `IsArrowFunction`, captured-activation, or
-  `_lexicalThisEnvironment is not null` pre-gates.
+  ordinary environment identifier reads, and named/computed property reads or
+  simple property writes from those dynamic identifier bases are VM-owned.
+  Dependency-bearing arrows still decline via the `IsArrowFunction`,
+  captured-activation, or `_lexicalThisEnvironment is not null` pre-gates.
 - Simple-return ordinary function expressions that capture an outer activation
-  may route when the body is read-only and uses the same ordinary environment
-  identifier / named or computed property read subset. Captured writes, updates,
-  deletes, calls, `arguments`, eval, with-backed closures, super/private/home-object
-  shapes, and nested function/class literals remain outside this route.
+  may route when the body uses the same ordinary environment identifier,
+  named/computed property read, or simple property write subset. Captured
+  identifier writes, updates, deletes, calls, `arguments`, eval, with-backed
+  closures, super/private/home-object shapes, block-body mutations, and nested
+  function/class literals remain outside this route.
 - There is no retained `this` decline in the production activation descriptor;
   future shapes that cannot thread `this` through the VM should introduce a
   concrete gate with a current failing example instead of carrying a placeholder.

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -3688,6 +3688,7 @@ internal static class UnifiedBytecodeCompiler
         if (TryAppendFirstBoundaryComputedPropertySet(
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
                 literalConstants,
                 stringConstants,
@@ -7591,11 +7592,14 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
-        if (!TryAppendActivationValueLoad(
+        if (!TryAppendSimpleOperandLoadWithDynamic(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
+                literalConstants,
+                stringConstants,
                 out reason))
         {
             return false;
@@ -7652,6 +7656,7 @@ internal static class UnifiedBytecodeCompiler
     private static bool TryAppendFirstBoundaryComputedPropertySet(
         ExpressionProgram expressionProgram,
         ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
         ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
         ImmutableArray<JsValue>.Builder literalConstants,
         ImmutableArray<string>.Builder stringConstants,
@@ -7681,7 +7686,8 @@ internal static class UnifiedBytecodeCompiler
                 expressionProgram,
                 activationSlots,
                 startInclusive: 1,
-                endExclusive: valueIndex))
+                endExclusive: valueIndex,
+                allowsDynamicIdentifiers))
         {
             reason = "Unsupported computed property key span.";
             return false;
@@ -7696,11 +7702,14 @@ internal static class UnifiedBytecodeCompiler
         var stagedStrings = ImmutableArray.CreateBuilder<string>();
         stagedStrings.AddRange(stringConstants);
 
-        if (!TryAppendActivationValueLoad(
+        if (!TryAppendSimpleOperandLoadWithDynamic(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 stagedUnified,
+                stagedLiterals,
+                stagedStrings,
                 out reason))
         {
             return false;
@@ -7714,17 +7723,20 @@ internal static class UnifiedBytecodeCompiler
                 stagedStrings,
                 startInclusive: 1,
                 endExclusive: valueIndex,
-                out reason))
+                out reason,
+                allowsDynamicIdentifiers))
         {
             return false;
         }
 
-        if (!TryAppendSimpleOperandLoad(
+        if (!TryAppendSimpleOperandLoadWithDynamic(
                 expressionProgram.GetOperation(valueIndex),
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 stagedUnified,
                 stagedLiterals,
+                stagedStrings,
                 out reason))
         {
             return false;
@@ -8992,7 +9004,8 @@ internal static class UnifiedBytecodeCompiler
         ImmutableArray<string>.Builder stringConstants,
         int startInclusive,
         int endExclusive,
-        out string reason)
+        out string reason,
+        bool allowsDynamicIdentifiers = false)
     {
         for (var index = startInclusive; index < endExclusive; index++)
         {
@@ -9007,8 +9020,10 @@ internal static class UnifiedBytecodeCompiler
                             operation,
                             expressionProgram,
                             activationSlots,
+                            allowsDynamicIdentifiers,
                             unified,
                             literalConstants,
+                            stringConstants,
                             out reason))
                     {
                         return false;
@@ -9077,7 +9092,8 @@ internal static class UnifiedBytecodeCompiler
         ExpressionProgram expressionProgram,
         ActivationSlotShape activationSlots,
         int startInclusive,
-        int endExclusive)
+        int endExclusive,
+        bool allowsDynamicIdentifiers = false)
     {
         var stackDepth = 0;
         for (var index = startInclusive; index < endExclusive; index++)
@@ -9092,10 +9108,8 @@ internal static class UnifiedBytecodeCompiler
                     break;
 
                 case ExpressionOpKind.LoadIdentifier:
-                    if (!TryResolveActivationSlot(
-                            operation.GetIdentifier(expressionProgram.IdentifierConstants.AsSpan()),
-                            activationSlots,
-                            out _))
+                    if (!CanAppendSimpleOperandLoad(operation, expressionProgram, activationSlots) &&
+                        !(allowsDynamicIdentifiers && !operation.IsArguments))
                     {
                         return false;
                     }

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -4575,7 +4575,11 @@ internal static class UnifiedBytecodeProductionEligibility
         // Named property write: [base, rhs..., SetNamedProperty]
         if (lastOp.Kind == ExpressionOpKind.SetNamedProperty &&
             !lastOp.AllowNameInference &&
-            TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
+            TryGetActivationOrPlainDynamicIdentifierReadValue(
+                program.GetOperation(0),
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers))
         {
             var rhsStart = 1;
             var rhsEnd = program.OperationCount - 2;
@@ -4599,19 +4603,39 @@ internal static class UnifiedBytecodeProductionEligibility
         // Computed property write: [base, key..., value, SetComputedProperty]
         if (lastOp.Kind == ExpressionOpKind.SetComputedProperty &&
             !lastOp.AllowNameInference &&
-            TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
+            TryGetActivationOrPlainDynamicIdentifierReadValue(
+                program.GetOperation(0),
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers))
         {
             var valueIndex = program.OperationCount - 2;
             return IsSupportedComputedPropertyKeySpan(
-                       program,
-                       startInclusive: 1,
-                       endExclusive: valueIndex,
+                   program,
+                   startInclusive: 1,
+                   endExclusive: valueIndex,
+                   identifierConstants,
+                   activationSlots,
+                   allowsDynamicIdentifiers) &&
+                   IsSimpleOperand(
+                       program.GetOperation(valueIndex),
                        identifierConstants,
-                       activationSlots) &&
-                   IsSimpleOperand(program.GetOperation(valueIndex), identifierConstants, activationSlots);
+                       activationSlots,
+                       allowsDynamicIdentifiers);
         }
 
         return false;
+    }
+
+    private static bool TryGetActivationOrPlainDynamicIdentifierReadValue(
+        PackedExpressionOp operation,
+        ReadOnlySpan<IdentifierOperand> identifierConstants,
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers)
+    {
+        return TryGetActivationResolvedValue(operation, identifierConstants, activationSlots) ||
+               allowsDynamicIdentifiers &&
+               TryGetPlainDynamicIdentifierReadValue(operation, identifierConstants, activationSlots);
     }
 
     private static bool TryIsFirstBoundaryNestedNamedPropertyWriteCandidate(

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -1397,6 +1397,30 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
+    public void Evaluate_NamedPropertyWriteWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted()
+    {
+        var plan = GetFunctionPlan("""
+            function write(value) {
+                return outer.value = value;
+            }
+            """,
+            "write");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor(
+                AllowsOrdinaryDynamicIdentifierEnvironmentOperations: true));
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.LoadDynamicIdentifier);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.SetNamedProperty);
+        Assert.Equal(new[] { "outer", "value" }, result.Program.StringConstants);
+    }
+
+    [Fact]
     public void Evaluate_ComputedPropertyWriteCandidate_AcceptsOwnedPropertyOpcode()
     {
         var plan = GetFunctionPlan("""
@@ -1414,6 +1438,30 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
         Assert.Contains(result.Program.Instructions, instruction =>
             instruction.OpCode == UnifiedBytecodeOpCode.SetComputedProperty);
+    }
+
+    [Fact]
+    public void Evaluate_ComputedPropertyWriteWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted()
+    {
+        var plan = GetFunctionPlan("""
+            function write(key, value) {
+                return outer[key] = value;
+            }
+            """,
+            "write");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor(
+                AllowsOrdinaryDynamicIdentifierEnvironmentOperations: true));
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.LoadDynamicIdentifier);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.SetComputedProperty);
+        Assert.Equal(new[] { "outer" }, result.Program.StringConstants);
     }
 
     [Fact]

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -6741,6 +6741,90 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task ArrowFunction_CapturedPropertyWriteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeSetter(obj) {
+                return () => obj.value = 43;
+            }
+
+            var set = makeSetter({ value: 42 });
+            set();
+            """);
+
+        Assert.Equal(43d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous>",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FunctionExpression_CapturedPropertyWriteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeSetter(obj) {
+                return function set() {
+                    return obj.value = 43;
+                };
+            }
+
+            var set = makeSetter({ value: 42 });
+            set();
+            """);
+
+        Assert.Equal(43d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=set",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ArrowFunction_CapturedComputedPropertyWriteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeSetter(obj, key) {
+                return () => obj[key] = 43;
+            }
+
+            var set = makeSetter({ value: 42 }, "value");
+            set();
+            """);
+
+        Assert.Equal(43d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous>",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FunctionExpression_CapturedComputedPropertyWriteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeSetter(obj, key) {
+                return function set() {
+                    return obj[key] = 43;
+                };
+            }
+
+            var set = makeSetter({ value: 42 }, "value");
+            set();
+            """);
+
+        Assert.Equal(43d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=set",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task FunctionExpression_CapturedOuterEnvironmentWrite_DoesNotUseUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit simple-return named and computed property writes from captured ordinary dynamic identifier bases
- thread dynamic identifier admission through first-boundary property-set eligibility/compiler helpers without adding fallback execution
- add eligibility and public route-hit coverage for captured arrow and ordinary closure property write expressions
- update the unified bytecode expansion contract to describe the new captured property write boundary

## Proof
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~Evaluate_NamedPropertyWriteWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted|FullyQualifiedName~Evaluate_ComputedPropertyWriteWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted|FullyQualifiedName~ArrowFunction_CapturedPropertyWriteExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~FunctionExpression_CapturedPropertyWriteExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~ArrowFunction_CapturedComputedPropertyWriteExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~FunctionExpression_CapturedComputedPropertyWriteExpression_UsesUnifiedBytecodeProductionFastPath"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProduction"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ActivationSemanticsProofPackTests"
- rtk dotnet build -c Release
- rtk rg "EvaluateExpression\\(|ProfileEvaluateExpression\\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner* (no matches)
- rtk ./tools/profile forloop --memory (6.86 MB)
- rtk git diff --check