### PR TITLE
Admit captured property update and delete bytecode

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -1,6 +1,6 @@
 # Unified Bytecode Expansion Contract
 
-Date: 2026-06-01
+Date: 2026-06-02
 Scope: Shared contract for parallel unified-bytecode lane work.
 
 ## Source-Of-Truth Surfaces
@@ -126,9 +126,10 @@ statement interpretation.
 - Simple-return arrows can route with captured lexical `this` / `new.target`
   values and read-only captured environment reads, including named and computed
   property reads from those dynamic identifier bases. Simple-return named and
-  computed property writes to captured dynamic identifier bases are also
-  VM-owned. The production invocation bridge resolves those captured values
-  before entering the VM and avoids sloppy-call `this` coercion for arrows.
+  computed property writes, updates, and deletes to captured dynamic identifier
+  bases are also VM-owned. The production invocation bridge resolves those
+  captured values before entering the VM and avoids sloppy-call `this` coercion
+  for arrows.
   Arrows that need a lexical-this environment or super binding still decline.
 - Simple base class constructors with public or private instance fields and
   simple derived constructors with public or private instance fields can route through
@@ -335,8 +336,8 @@ must still obey the no-mixed-execution rule.
 | `DynamicLookupDependency` | Unresolved identifier loads/stores/update outside the admitted ordinary, with-backed, and direct-eval-backed dynamic-name paths; plans that need direct eval plus post-eval dynamic identifier reads now route when captured activation, with-chain, and arguments-object dependencies are absent | Existing sync IR / environment lookup route | Dynamic-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_DirectEvalDeclaredVarRead_AcceptsOrdinaryDynamicNameProgram"` |
 | `PropertyReadBoundaryOutOfScope` | Named/computed property reads outside the admitted activation-resolved and read-only dynamic-identifier-base boundaries, including captured closure dynamic bases | Existing sync IR property route | Property read widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_ComputedPropertyReadOutsideFirstBoundary_DeclinesWithBoundaryCode"` |
 | `PropertyWriteDependency` | Property writes and compound/logical property writes outside the admitted direct property-write shapes, supported computed expression-key mutation shapes, simple-return dynamic-base named/computed property writes, simple nested named receiver assignment shape, nested named compound-write shape, and nested named logical-write shape | Existing sync IR property-write route | Property write widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_LogicalAndAssignment_UnsupportedShapes_DeclineWithExplicitCodes"` |
-| `PropertyUpdateDependency` | Property and identifier update expressions outside the admitted direct update, computed expression-key update, and simple nested named receiver update boundary | Existing sync IR update route | Property update lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedNamedPropertyUpdate_AcceptsOwnedPropertyOpcodes"` |
-| `DeleteDependency` | `delete` expressions outside the admitted ordinary named/computed property delete lane, ordinary dynamic-key computed delete lane, and with-backed dynamic-name delete lane | Existing sync IR delete route | Delete semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedComputedPropertyDeleteDynamicKey_AcceptsOrdinaryDynamicNameOpcode"` |
+| `PropertyUpdateDependency` | Property and identifier update expressions outside the admitted direct update, computed expression-key update, simple-return dynamic-base named/computed property update, and simple nested named receiver update boundary | Existing sync IR update route | Property update lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedNamedPropertyUpdate_AcceptsOwnedPropertyOpcodes"` |
+| `DeleteDependency` | `delete` expressions outside the admitted ordinary named/computed property delete lane, simple-return dynamic-base named/computed property delete lane, ordinary dynamic-key computed delete lane, and with-backed dynamic-name delete lane | Existing sync IR delete route | Delete semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedComputedPropertyDeleteDynamicKey_AcceptsOrdinaryDynamicNameOpcode"` |
 | `SuperPropertyDependency` | Out-of-boundary super call targets; super property reads/writes/updates are admitted by dedicated VM opcodes | Existing class / constructor route for remaining call-target shapes | Super semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperPropertyAccess_AcceptsOwnedOpcodes"` |
 | `OptionalChainDependency` | Optional chains outside the admitted optional property-read, optional-call, and exact optional named/computed delete boundaries | Existing sync IR optional-chain route | Optional-chain widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_OptionalChainNamedPrefixPlainCallExpressionPlan_AcceptsExecutableInvocationBoundary"` |
 | `ObjectLiteralOrSpreadDependency` | Object/array spread sources outside simple operands and direct named member-call spread sources, and object methods/accessors only when they appear inside restricted simple literal spans | Existing sync IR literal/spread route for remaining spans | Literal/spread lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_ObjectLiteralUnsupportedFeatures_DeclineWithExplicitCodes"` |
@@ -357,7 +358,7 @@ not always have a `UnifiedBytecodeProductionDeclineCode`.
 | Pre-gate key | Owning source / current example | Current fallback route | Planned batch / lane | Proof command |
 |---|---|---|---|---|
 | `pre-gate:IsClassConstructor` | Class constructor invokers outside the admitted simple base constructor route and explicit derived-constructor `super(...)` route with post-super `this` body reads/writes | Constructor route | Constructor boundary lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
-| `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no super, call-target, assignment, update, delete, nested function/class literal, or other unowned dependency. Captured lexical `this` / `new.target`, statically resolved flat-slot reads, ordinary environment identifier reads, and named/computed property reads or simple property writes from those dynamic identifier bases are VM-owned; lexical-this environments remain a separate pre-gate. | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
+| `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no super, call-target, unadmitted identifier assignment/update/delete, compound/logical assignment, nested function/class literal, or other unowned dependency. Captured lexical `this` / `new.target`, statically resolved flat-slot reads, ordinary environment identifier reads, and named/computed property reads, simple property writes, property updates, or property deletes from those dynamic identifier bases are VM-owned; lexical-this environments remain a separate pre-gate. | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:IsAsyncLike` | Async and formerly-async ordinary invokers | Async route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_AsyncLikeActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:IsGenerator` | Generator functions before ordinary sync production routing | Generator route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_GeneratorActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:hasParameterExpressions` | Default/rest/destructured parameter expressions | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
@@ -465,17 +466,20 @@ the final post-compile production subset check before VM entry.
   computed via `CoerceThisValueForNonStrict` in `TryInvokeProductionUnifiedBytecode`,
   so the VM's `LoadThis` opcode always receives the correctly coerced value.
 - Simple-return arrow functions whose lowered body has no super, call-target,
-  assignment, update, delete, nested function/class literal, or other unowned
-  dependency may route. Captured lexical `this` / `new.target`, flat-slot reads,
-  ordinary environment identifier reads, and named/computed property reads or
-  simple property writes from those dynamic identifier bases are VM-owned.
+  unadmitted identifier assignment/update/delete, compound/logical assignment,
+  nested function/class literal, or other unowned dependency may route.
+  Captured lexical `this` / `new.target`, flat-slot reads, ordinary environment
+  identifier reads, and named/computed property reads, simple property writes,
+  property updates, or property deletes from those dynamic identifier bases are
+  VM-owned.
   Dependency-bearing arrows still decline via the `IsArrowFunction`,
   captured-activation, or `_lexicalThisEnvironment is not null` pre-gates.
 - Simple-return ordinary function expressions that capture an outer activation
   may route when the body uses the same ordinary environment identifier,
-  named/computed property read, or simple property write subset. Captured
-  identifier writes, updates, deletes, calls, `arguments`, eval, with-backed
-  closures, super/private/home-object shapes, block-body mutations, and nested
+  named/computed property read, simple property write, property update, or
+  property delete subset. Captured identifier writes, identifier updates,
+  identifier deletes, calls, `arguments`, eval, with-backed closures,
+  super/private/home-object shapes, block-body mutations, and nested
   function/class literals remain outside this route.
 - There is no retained `this` decline in the production activation descriptor;
   future shapes that cannot thread `this` through the VM should introduce a

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -3705,6 +3705,7 @@ internal static class UnifiedBytecodeCompiler
         if (TryAppendFirstBoundaryNamedPropertyUpdate(
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
                 stringConstants,
                 out reason))
@@ -3735,6 +3736,7 @@ internal static class UnifiedBytecodeCompiler
         if (TryAppendFirstBoundaryComputedPropertyUpdate(
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
                 literalConstants,
                 stringConstants,
@@ -7881,6 +7883,7 @@ internal static class UnifiedBytecodeCompiler
     private static bool TryAppendFirstBoundaryNamedPropertyUpdate(
         ExpressionProgram expressionProgram,
         ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
         ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
         ImmutableArray<string>.Builder stringConstants,
         out string reason)
@@ -7898,11 +7901,13 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
-        if (!TryAppendActivationValueLoad(
+        if (!TryAppendActivationOrPlainDynamicIdentifierReadValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
+                stringConstants,
                 out reason))
         {
             return false;
@@ -7996,6 +8001,7 @@ internal static class UnifiedBytecodeCompiler
     private static bool TryAppendFirstBoundaryComputedPropertyUpdate(
         ExpressionProgram expressionProgram,
         ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
         ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
         ImmutableArray<JsValue>.Builder literalConstants,
         ImmutableArray<string>.Builder stringConstants,
@@ -8019,7 +8025,8 @@ internal static class UnifiedBytecodeCompiler
                 expressionProgram,
                 activationSlots,
                 startInclusive: 1,
-                endExclusive: propertyUpdateIndex))
+                endExclusive: propertyUpdateIndex,
+                allowsDynamicIdentifiers))
         {
             reason = "Unsupported computed property key span.";
             return false;
@@ -8034,11 +8041,13 @@ internal static class UnifiedBytecodeCompiler
         var stagedStrings = ImmutableArray.CreateBuilder<string>();
         stagedStrings.AddRange(stringConstants);
 
-        if (!TryAppendActivationValueLoad(
+        if (!TryAppendActivationOrPlainDynamicIdentifierReadValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 stagedUnified,
+                stagedStrings,
                 out reason))
         {
             return false;
@@ -8052,7 +8061,8 @@ internal static class UnifiedBytecodeCompiler
                 stagedStrings,
                 startInclusive: 1,
                 endExclusive: propertyUpdateIndex,
-                out reason))
+                out reason,
+                allowsDynamicIdentifiers))
         {
             return false;
         }
@@ -10018,6 +10028,48 @@ internal static class UnifiedBytecodeCompiler
             activationSlots,
             unified,
             out reason);
+    }
+
+    private static bool TryAppendActivationOrPlainDynamicIdentifierReadValueLoad(
+        PackedExpressionOp operation,
+        ExpressionProgram expressionProgram,
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
+        ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
+        ImmutableArray<string>.Builder stringConstants,
+        out string reason)
+    {
+        if (TryAppendActivationValueLoad(
+                operation,
+                expressionProgram,
+                activationSlots,
+                unified,
+                out reason))
+        {
+            return true;
+        }
+
+        if (!allowsDynamicIdentifiers ||
+            operation.Kind != ExpressionOpKind.LoadIdentifier ||
+            operation.IsArguments)
+        {
+            return false;
+        }
+
+        var identifier = operation.GetIdentifier(expressionProgram.IdentifierConstants.AsSpan());
+        if (identifier.FlatSlotId >= 0 ||
+            TryResolveActivationSlot(identifier, activationSlots, out _))
+        {
+            return false;
+        }
+
+        var identifierNameIndex = stringConstants.Count;
+        stringConstants.Add(identifier.Name.Name ?? string.Empty);
+        unified.Add(new UnifiedBytecodeInstruction(
+            UnifiedBytecodeOpCode.LoadDynamicIdentifier,
+            identifierNameIndex));
+        reason = string.Empty;
+        return true;
     }
 
     private static bool IsSupportedBinaryOperator(BinaryOperator binaryOperator) =>

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -768,7 +768,7 @@ internal static class UnifiedBytecodeProductionEligibility
         var isFirstBoundaryPropertyWriteCandidate =
             TryIsFirstBoundaryPropertyWriteCandidate(program, identifierConstants, activationSlots, allowsDynamicIdentifiers);
         var isFirstBoundaryPropertyUpdateCandidate =
-            TryIsFirstBoundaryPropertyUpdateCandidate(program, identifierConstants, activationSlots);
+            TryIsFirstBoundaryPropertyUpdateCandidate(program, identifierConstants, activationSlots, allowsDynamicIdentifiers);
         var isFirstBoundaryNamedCompoundPropertyWriteCandidate =
             TryIsFirstBoundaryNamedCompoundPropertyWriteCandidate(program, identifierConstants, activationSlots);
         var isFirstBoundaryNamedLogicalPropertyWriteCandidate =
@@ -1187,7 +1187,11 @@ internal static class UnifiedBytecodeProductionEligibility
                         break;
                     }
 
-                    if (TryIsFirstBoundaryNamedPropertyDeleteCandidate(program, identifierConstants, activationSlots))
+                    if (TryIsFirstBoundaryNamedPropertyDeleteCandidate(
+                            program,
+                            identifierConstants,
+                            activationSlots,
+                            allowsDynamicIdentifiers))
                     {
                         break;
                     }
@@ -1355,7 +1359,11 @@ internal static class UnifiedBytecodeProductionEligibility
 
                 case ExpressionOpKind.UpdateNamedProperty:
                 case ExpressionOpKind.UpdateComputedProperty:
-                    if (TryIsFirstBoundaryPropertyUpdateCandidate(program, identifierConstants, activationSlots) ||
+                    if (TryIsFirstBoundaryPropertyUpdateCandidate(
+                            program,
+                            identifierConstants,
+                            activationSlots,
+                            allowsDynamicIdentifiers) ||
                         TryIsFirstBoundaryNestedNamedPropertyUpdateCandidate(program, identifierConstants, activationSlots))
                     {
                         break;
@@ -1390,7 +1398,11 @@ internal static class UnifiedBytecodeProductionEligibility
                         return true;
                     }
 
-                    if (TryIsFirstBoundaryNamedPropertyDeleteCandidate(program, identifierConstants, activationSlots))
+                    if (TryIsFirstBoundaryNamedPropertyDeleteCandidate(
+                            program,
+                            identifierConstants,
+                            activationSlots,
+                            allowsDynamicIdentifiers))
                     {
                         break;
                     }
@@ -2188,14 +2200,19 @@ internal static class UnifiedBytecodeProductionEligibility
     private static bool TryIsFirstBoundaryNamedPropertyDeleteCandidate(
         ExpressionProgram program,
         ReadOnlySpan<IdentifierOperand> identifierConstants,
-        ActivationSlotShape activationSlots)
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers)
     {
         if (program.OperationCount < 2)
         {
             return false;
         }
 
-        if (!TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
+        if (!TryGetActivationOrPlainDynamicIdentifierReadValue(
+                program.GetOperation(0),
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers))
         {
             return false;
         }
@@ -2229,7 +2246,11 @@ internal static class UnifiedBytecodeProductionEligibility
             return false;
         }
 
-        if (!TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
+        if (!TryGetActivationOrPlainDynamicIdentifierReadValue(
+                program.GetOperation(0),
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers))
         {
             return false;
         }
@@ -4697,13 +4718,18 @@ internal static class UnifiedBytecodeProductionEligibility
     private static bool TryIsFirstBoundaryPropertyUpdateCandidate(
         ExpressionProgram program,
         ReadOnlySpan<IdentifierOperand> identifierConstants,
-        ActivationSlotShape activationSlots)
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers)
     {
         if (program.OperationCount == 2)
         {
             var propertyUpdate = program.GetOperation(1);
             return propertyUpdate.Kind == ExpressionOpKind.UpdateNamedProperty &&
-                   TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots);
+                   TryGetActivationOrPlainDynamicIdentifierReadValue(
+                       program.GetOperation(0),
+                       identifierConstants,
+                       activationSlots,
+                       allowsDynamicIdentifiers);
         }
 
         if (program.OperationCount < 3)
@@ -4713,13 +4739,18 @@ internal static class UnifiedBytecodeProductionEligibility
 
         var propertyUpdateIndex = program.OperationCount - 1;
         return program.GetOperation(propertyUpdateIndex).Kind == ExpressionOpKind.UpdateComputedProperty &&
-               TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots) &&
+               TryGetActivationOrPlainDynamicIdentifierReadValue(
+                   program.GetOperation(0),
+                   identifierConstants,
+                   activationSlots,
+                   allowsDynamicIdentifiers) &&
                IsSupportedComputedPropertyKeySpan(
                    program,
                    startInclusive: 1,
                    endExclusive: propertyUpdateIndex,
                    identifierConstants,
-                   activationSlots);
+                   activationSlots,
+                   allowsDynamicIdentifiers);
     }
 
     private static bool TryIsFirstBoundaryNestedNamedPropertyUpdateCandidate(

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -1486,6 +1486,30 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
+    public void Evaluate_NamedPropertyDeleteWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted()
+    {
+        var plan = GetFunctionPlan("""
+            function remove() {
+                return delete outer.value;
+            }
+            """,
+            "remove");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor(
+                AllowsOrdinaryDynamicIdentifierEnvironmentOperations: true));
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.LoadDynamicIdentifier);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.DeleteNamedProperty);
+        Assert.Equal(new[] { "outer", "value" }, result.Program.StringConstants);
+    }
+
+    [Fact]
     public void Evaluate_NestedNamedPropertyDeleteCandidate_AcceptsOwnedPropertyOpcode()
     {
         var plan = GetFunctionPlan("""
@@ -1525,6 +1549,30 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
         Assert.Contains(result.Program.Instructions, instruction =>
             instruction.OpCode == UnifiedBytecodeOpCode.DeleteComputedProperty);
+    }
+
+    [Fact]
+    public void Evaluate_ComputedPropertyDeleteWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted()
+    {
+        var plan = GetFunctionPlan("""
+            function remove(key) {
+                return delete outer[key];
+            }
+            """,
+            "remove");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor(
+                AllowsOrdinaryDynamicIdentifierEnvironmentOperations: true));
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.LoadDynamicIdentifier);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.DeleteComputedProperty);
+        Assert.Equal(new[] { "outer" }, result.Program.StringConstants);
     }
 
     [Fact]
@@ -1794,6 +1842,30 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
+    public void Evaluate_NamedPropertyUpdateWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted()
+    {
+        var plan = GetFunctionPlan("""
+            function update() {
+                return outer.value++;
+            }
+            """,
+            "update");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor(
+                AllowsOrdinaryDynamicIdentifierEnvironmentOperations: true));
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.LoadDynamicIdentifier);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.UpdateNamedProperty);
+        Assert.Equal(new[] { "outer", "value" }, result.Program.StringConstants);
+    }
+
+    [Fact]
     public void Evaluate_ComputedPropertyUpdateCandidate_AcceptsOwnedPropertyOpcode()
     {
         var plan = GetFunctionPlan("""
@@ -1811,6 +1883,30 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
         Assert.Contains(result.Program.Instructions, instruction =>
             instruction.OpCode == UnifiedBytecodeOpCode.UpdateComputedProperty);
+    }
+
+    [Fact]
+    public void Evaluate_ComputedPropertyUpdateWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted()
+    {
+        var plan = GetFunctionPlan("""
+            function update(key) {
+                return outer[key]++;
+            }
+            """,
+            "update");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor(
+                AllowsOrdinaryDynamicIdentifierEnvironmentOperations: true));
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.LoadDynamicIdentifier);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.UpdateComputedProperty);
+        Assert.Equal(new[] { "outer" }, result.Program.StringConstants);
     }
 
     [Fact]

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -6825,6 +6825,182 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task ArrowFunction_CapturedPropertyUpdateExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeUpdater(obj) {
+                return () => obj.value++;
+            }
+
+            var box = { value: 40 };
+            var update = makeUpdater(box);
+            update() + box.value;
+            """);
+
+        Assert.Equal(81d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous>",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FunctionExpression_CapturedPropertyUpdateExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeUpdater(obj) {
+                return function update() {
+                    return obj.value++;
+                };
+            }
+
+            var box = { value: 40 };
+            var update = makeUpdater(box);
+            update() + box.value;
+            """);
+
+        Assert.Equal(81d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=update",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ArrowFunction_CapturedComputedPropertyUpdateExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeUpdater(obj, key) {
+                return () => obj[key]++;
+            }
+
+            var box = { value: 40 };
+            var update = makeUpdater(box, "value");
+            update() + box.value;
+            """);
+
+        Assert.Equal(81d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous>",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FunctionExpression_CapturedComputedPropertyUpdateExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeUpdater(obj, key) {
+                return function update() {
+                    return obj[key]++;
+                };
+            }
+
+            var box = { value: 40 };
+            var update = makeUpdater(box, "value");
+            update() + box.value;
+            """);
+
+        Assert.Equal(81d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=update",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ArrowFunction_CapturedPropertyDeleteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeRemover(obj) {
+                return () => delete obj.value;
+            }
+
+            var box = { value: 42 };
+            var remove = makeRemover(box);
+            remove() && !Object.prototype.hasOwnProperty.call(box, "value");
+            """);
+
+        Assert.Equal(true, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous>",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FunctionExpression_CapturedPropertyDeleteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeRemover(obj) {
+                return function remove() {
+                    return delete obj.value;
+                };
+            }
+
+            var box = { value: 42 };
+            var remove = makeRemover(box);
+            remove() && !Object.prototype.hasOwnProperty.call(box, "value");
+            """);
+
+        Assert.Equal(true, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=remove",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ArrowFunction_CapturedComputedPropertyDeleteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeRemover(obj, key) {
+                return () => delete obj[key];
+            }
+
+            var box = { value: 42 };
+            var remove = makeRemover(box, "value");
+            remove() && !Object.prototype.hasOwnProperty.call(box, "value");
+            """);
+
+        Assert.Equal(true, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous>",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FunctionExpression_CapturedComputedPropertyDeleteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeRemover(obj, key) {
+                return function remove() {
+                    return delete obj[key];
+                };
+            }
+
+            var box = { value: 42 };
+            var remove = makeRemover(box, "value");
+            remove() && !Object.prototype.hasOwnProperty.call(box, "value");
+            """);
+
+        Assert.Equal(true, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=remove",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task FunctionExpression_CapturedOuterEnvironmentWrite_DoesNotUseUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit captured dynamic-identifier bases for first-boundary named/computed property updates and deletes
- update compiler helper routing so admitted captured property updates emit LoadDynamicIdentifier instead of declining before the general loop
- add eligibility and public invocation route tests for captured arrow/function-expression property update/delete shapes
- refresh the unified bytecode expansion contract for the new captured property mutation surface

## Proof
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~Evaluate_NamedPropertyUpdateWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted|FullyQualifiedName~Evaluate_ComputedPropertyUpdateWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted|FullyQualifiedName~Evaluate_NamedPropertyDeleteWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted|FullyQualifiedName~Evaluate_ComputedPropertyDeleteWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted|FullyQualifiedName~ArrowFunction_CapturedPropertyUpdateExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~FunctionExpression_CapturedPropertyUpdateExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~ArrowFunction_CapturedComputedPropertyUpdateExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~FunctionExpression_CapturedComputedPropertyUpdateExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~ArrowFunction_CapturedPropertyDeleteExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~FunctionExpression_CapturedPropertyDeleteExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~ArrowFunction_CapturedComputedPropertyDeleteExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~FunctionExpression_CapturedComputedPropertyDeleteExpression_UsesUnifiedBytecodeProductionFastPath" — 12 passed
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests" — 384 passed
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests" — 350 passed
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProduction" — 776 passed
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ActivationSemanticsProofPackTests" — 48 passed
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests&FullyQualifiedName~UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums" — 1 passed
- rtk dotnet build -c Release — 11 projects, 0 errors, existing nullable warnings
- rtk rg "EvaluateExpression\\(|ProfileEvaluateExpression\\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner* — no matches
- rtk ./tools/profile forloop --memory — Total allocated 6.86 MB
- rtk git diff --check