### PR TITLE
Admit captured compound property writes to bytecode

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -126,10 +126,10 @@ statement interpretation.
 - Simple-return arrows can route with captured lexical `this` / `new.target`
   values and read-only captured environment reads, including named and computed
   property reads from those dynamic identifier bases. Simple-return named and
-  computed property writes, updates, and deletes to captured dynamic identifier
-  bases are also VM-owned. The production invocation bridge resolves those
-  captured values before entering the VM and avoids sloppy-call `this` coercion
-  for arrows.
+  computed property writes, compound/logical writes, updates, and deletes to
+  captured dynamic identifier bases are also VM-owned. The production invocation
+  bridge resolves those captured values before entering the VM and avoids
+  sloppy-call `this` coercion for arrows.
   Arrows that need a lexical-this environment or super binding still decline.
 - Simple base class constructors with public or private instance fields and
   simple derived constructors with public or private instance fields can route through
@@ -335,7 +335,7 @@ must still obey the no-mixed-execution rule.
 | `CallDependency` | Direct eval outside the one-argument non-spread eval-identifier boundary, out-of-boundary call-target preparation, and complex call arguments excluding admitted simple/binary template-literal substitutions, simple/binary computed object keys, and zero-argument activation-resolved identifier-call computed object keys | Existing sync IR call route | Wider call invocation lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests"` |
 | `DynamicLookupDependency` | Unresolved identifier loads/stores/update outside the admitted ordinary, with-backed, and direct-eval-backed dynamic-name paths; plans that need direct eval plus post-eval dynamic identifier reads now route when captured activation, with-chain, and arguments-object dependencies are absent | Existing sync IR / environment lookup route | Dynamic-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_DirectEvalDeclaredVarRead_AcceptsOrdinaryDynamicNameProgram"` |
 | `PropertyReadBoundaryOutOfScope` | Named/computed property reads outside the admitted activation-resolved and read-only dynamic-identifier-base boundaries, including captured closure dynamic bases | Existing sync IR property route | Property read widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_ComputedPropertyReadOutsideFirstBoundary_DeclinesWithBoundaryCode"` |
-| `PropertyWriteDependency` | Property writes and compound/logical property writes outside the admitted direct property-write shapes, supported computed expression-key mutation shapes, simple-return dynamic-base named/computed property writes, simple nested named receiver assignment shape, nested named compound-write shape, and nested named logical-write shape | Existing sync IR property-write route | Property write widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_LogicalAndAssignment_UnsupportedShapes_DeclineWithExplicitCodes"` |
+| `PropertyWriteDependency` | Property writes and compound/logical property writes outside the admitted direct property-write shapes, supported computed expression-key mutation shapes, simple-return dynamic-base named/computed property writes and compound/logical writes, simple nested named receiver assignment shape, nested named compound-write shape, and nested named logical-write shape | Existing sync IR property-write route | Property write widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_LogicalAndAssignment_UnsupportedShapes_DeclineWithExplicitCodes"` |
 | `PropertyUpdateDependency` | Property and identifier update expressions outside the admitted direct update, computed expression-key update, simple-return dynamic-base named/computed property update, and simple nested named receiver update boundary | Existing sync IR update route | Property update lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedNamedPropertyUpdate_AcceptsOwnedPropertyOpcodes"` |
 | `DeleteDependency` | `delete` expressions outside the admitted ordinary named/computed property delete lane, simple-return dynamic-base named/computed property delete lane, ordinary dynamic-key computed delete lane, and with-backed dynamic-name delete lane | Existing sync IR delete route | Delete semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_NestedComputedPropertyDeleteDynamicKey_AcceptsOrdinaryDynamicNameOpcode"` |
 | `SuperPropertyDependency` | Out-of-boundary super call targets; super property reads/writes/updates are admitted by dedicated VM opcodes | Existing class / constructor route for remaining call-target shapes | Super semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_SuperPropertyAccess_AcceptsOwnedOpcodes"` |
@@ -358,7 +358,7 @@ not always have a `UnifiedBytecodeProductionDeclineCode`.
 | Pre-gate key | Owning source / current example | Current fallback route | Planned batch / lane | Proof command |
 |---|---|---|---|---|
 | `pre-gate:IsClassConstructor` | Class constructor invokers outside the admitted simple base constructor route and explicit derived-constructor `super(...)` route with post-super `this` body reads/writes | Constructor route | Constructor boundary lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
-| `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no super, call-target, unadmitted identifier assignment/update/delete, compound/logical assignment, nested function/class literal, or other unowned dependency. Captured lexical `this` / `new.target`, statically resolved flat-slot reads, ordinary environment identifier reads, and named/computed property reads, simple property writes, property updates, or property deletes from those dynamic identifier bases are VM-owned; lexical-this environments remain a separate pre-gate. | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
+| `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no super, call-target, unadmitted identifier assignment/update/delete, nested function/class literal, or other unowned dependency. Captured lexical `this` / `new.target`, statically resolved flat-slot reads, ordinary environment identifier reads, and named/computed property reads, simple property writes, compound/logical property writes, property updates, or property deletes from those dynamic identifier bases are VM-owned; lexical-this environments remain a separate pre-gate. | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:IsAsyncLike` | Async and formerly-async ordinary invokers | Async route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_AsyncLikeActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:IsGenerator` | Generator functions before ordinary sync production routing | Generator route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_GeneratorActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:hasParameterExpressions` | Default/rest/destructured parameter expressions | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
@@ -466,20 +466,20 @@ the final post-compile production subset check before VM entry.
   computed via `CoerceThisValueForNonStrict` in `TryInvokeProductionUnifiedBytecode`,
   so the VM's `LoadThis` opcode always receives the correctly coerced value.
 - Simple-return arrow functions whose lowered body has no super, call-target,
-  unadmitted identifier assignment/update/delete, compound/logical assignment,
-  nested function/class literal, or other unowned dependency may route.
+  unadmitted identifier assignment/update/delete, nested function/class literal,
+  or other unowned dependency may route.
   Captured lexical `this` / `new.target`, flat-slot reads, ordinary environment
   identifier reads, and named/computed property reads, simple property writes,
-  property updates, or property deletes from those dynamic identifier bases are
-  VM-owned.
+  compound/logical property writes, property updates, or property deletes from
+  those dynamic identifier bases are VM-owned.
   Dependency-bearing arrows still decline via the `IsArrowFunction`,
   captured-activation, or `_lexicalThisEnvironment is not null` pre-gates.
 - Simple-return ordinary function expressions that capture an outer activation
   may route when the body uses the same ordinary environment identifier,
-  named/computed property read, simple property write, property update, or
-  property delete subset. Captured identifier writes, identifier updates,
-  identifier deletes, calls, `arguments`, eval, with-backed closures,
-  super/private/home-object shapes, block-body mutations, and nested
+  named/computed property read, simple property write, compound/logical property
+  write, property update, or property delete subset. Captured identifier writes,
+  identifier updates, identifier deletes, calls, `arguments`, eval, with-backed
+  closures, super/private/home-object shapes, block-body mutations, and nested
   function/class literals remain outside this route.
 - There is no retained `this` decline in the production activation descriptor;
   future shapes that cannot thread `this` through the VM should introduce a

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -3591,6 +3591,7 @@ internal static class UnifiedBytecodeCompiler
         if (TryAppendFirstBoundaryNamedCompoundPropertySet(
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
                 literalConstants,
                 stringConstants,
@@ -3607,6 +3608,7 @@ internal static class UnifiedBytecodeCompiler
         if (TryAppendFirstBoundaryNamedLogicalPropertySet(
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
                 literalConstants,
                 stringConstants,
@@ -3623,6 +3625,7 @@ internal static class UnifiedBytecodeCompiler
         if (TryAppendFirstBoundaryComputedCompoundPropertySet(
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
                 literalConstants,
                 stringConstants,
@@ -3639,6 +3642,7 @@ internal static class UnifiedBytecodeCompiler
         if (TryAppendFirstBoundaryComputedLogicalPropertySet(
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
                 literalConstants,
                 stringConstants,
@@ -6895,6 +6899,7 @@ internal static class UnifiedBytecodeCompiler
     private static bool TryAppendFirstBoundaryNamedCompoundPropertySet(
         ExpressionProgram expressionProgram,
         ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
         ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
         ImmutableArray<JsValue>.Builder literalConstants,
         ImmutableArray<string>.Builder stringConstants,
@@ -6977,11 +6982,13 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
-        if (!TryAppendActivationValueLoad(
+        if (!TryAppendActivationOrPlainDynamicIdentifierReadValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
+                stringConstants,
                 out reason))
         {
             return false;
@@ -7006,12 +7013,14 @@ internal static class UnifiedBytecodeCompiler
 
         if (rhsStart == rhsEnd)
         {
-            if (!TryAppendSimpleOperandLoad(
+            if (!TryAppendSimpleOperandLoadWithDynamic(
                     expressionProgram.GetOperation(rhsStart),
                     expressionProgram,
                     activationSlots,
+                    allowsDynamicIdentifiers,
                     unified,
                     literalConstants,
+                    stringConstants,
                     out reason))
             {
                 return false;
@@ -7049,6 +7058,7 @@ internal static class UnifiedBytecodeCompiler
     private static bool TryAppendFirstBoundaryComputedCompoundPropertySet(
         ExpressionProgram expressionProgram,
         ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
         ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
         ImmutableArray<JsValue>.Builder literalConstants,
         ImmutableArray<string>.Builder stringConstants,
@@ -7108,7 +7118,8 @@ internal static class UnifiedBytecodeCompiler
                 expressionProgram,
                 activationSlots,
                 startInclusive: 1,
-                endExclusive: suffixStart))
+                endExclusive: suffixStart,
+                allowsDynamicIdentifiers))
         {
             reason = "Unsupported computed property key span.";
             return false;
@@ -7123,11 +7134,13 @@ internal static class UnifiedBytecodeCompiler
         var stagedStrings = ImmutableArray.CreateBuilder<string>();
         stagedStrings.AddRange(stringConstants);
 
-        if (!TryAppendActivationValueLoad(
+        if (!TryAppendActivationOrPlainDynamicIdentifierReadValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 stagedUnified,
+                stagedStrings,
                 out reason))
         {
             return false;
@@ -7141,7 +7154,8 @@ internal static class UnifiedBytecodeCompiler
                 stagedStrings,
                 startInclusive: 1,
                 endExclusive: suffixStart,
-                out reason))
+                out reason,
+                allowsDynamicIdentifiers))
         {
             return false;
         }
@@ -7150,12 +7164,14 @@ internal static class UnifiedBytecodeCompiler
         stagedUnified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.ResolvePropertyKey));
         stagedUnified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.GetComputedPropertyForCompoundSet));
 
-        if (!TryAppendSimpleOperandLoad(
+        if (!TryAppendSimpleOperandLoadWithDynamic(
                 rhs,
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 stagedUnified,
                 stagedLiterals,
+                stagedStrings,
                 out reason))
         {
             return false;
@@ -7176,6 +7192,7 @@ internal static class UnifiedBytecodeCompiler
     private static bool TryAppendFirstBoundaryNamedLogicalPropertySet(
         ExpressionProgram expressionProgram,
         ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
         ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
         ImmutableArray<JsValue>.Builder literalConstants,
         ImmutableArray<string>.Builder stringConstants,
@@ -7275,11 +7292,13 @@ internal static class UnifiedBytecodeCompiler
         var stagedStrings = ImmutableArray.CreateBuilder<string>();
         stagedStrings.AddRange(stringConstants);
 
-        if (!TryAppendActivationValueLoad(
+        if (!TryAppendActivationOrPlainDynamicIdentifierReadValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 stagedUnified,
+                stagedStrings,
                 out reason))
         {
             return false;
@@ -7309,12 +7328,14 @@ internal static class UnifiedBytecodeCompiler
         stagedUnified.Add(new UnifiedBytecodeInstruction(jumpOpCode, 0));
         stagedUnified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.Pop));
 
-        if (!TryAppendSimpleOperandLoad(
+        if (!TryAppendSimpleOperandLoadWithDynamic(
                 rhs,
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 stagedUnified,
                 stagedLiterals,
+                stagedStrings,
                 out reason))
         {
             return false;
@@ -7344,6 +7365,7 @@ internal static class UnifiedBytecodeCompiler
     private static bool TryAppendFirstBoundaryComputedLogicalPropertySet(
         ExpressionProgram expressionProgram,
         ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
         ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
         ImmutableArray<JsValue>.Builder literalConstants,
         ImmutableArray<string>.Builder stringConstants,
@@ -7369,7 +7391,8 @@ internal static class UnifiedBytecodeCompiler
                     expressionProgram,
                     activationSlots,
                     startInclusive: 1,
-                    endExclusive: candidateSuffixStart))
+                    endExclusive: candidateSuffixStart,
+                    allowsDynamicIdentifiers))
             {
                 continue;
             }
@@ -7441,11 +7464,13 @@ internal static class UnifiedBytecodeCompiler
         var stagedStrings = ImmutableArray.CreateBuilder<string>();
         stagedStrings.AddRange(stringConstants);
 
-        if (!TryAppendActivationValueLoad(
+        if (!TryAppendActivationOrPlainDynamicIdentifierReadValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 stagedUnified,
+                stagedStrings,
                 out reason))
         {
             return false;
@@ -7459,7 +7484,8 @@ internal static class UnifiedBytecodeCompiler
                 stagedStrings,
                 startInclusive: 1,
                 endExclusive: suffixStart,
-                out reason))
+                out reason,
+                allowsDynamicIdentifiers))
         {
             return false;
         }
@@ -7483,6 +7509,8 @@ internal static class UnifiedBytecodeCompiler
                 activationSlots,
                 stagedUnified,
                 stagedLiterals,
+                stagedStrings,
+                allowsDynamicIdentifiers,
                 startInclusive: suffixStart + 6,
                 endExclusive: propertySetIndex,
                 out reason))
@@ -7518,6 +7546,8 @@ internal static class UnifiedBytecodeCompiler
         ActivationSlotShape activationSlots,
         ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
         ImmutableArray<JsValue>.Builder literalConstants,
+        ImmutableArray<string>.Builder stringConstants,
+        bool allowsDynamicIdentifiers,
         int startInclusive,
         int endExclusive,
         out string reason)
@@ -7530,12 +7560,14 @@ internal static class UnifiedBytecodeCompiler
 
         if (endExclusive - startInclusive == 1)
         {
-            return TryAppendSimpleOperandLoad(
+            return TryAppendSimpleOperandLoadWithDynamic(
                 expressionProgram.GetOperation(startInclusive),
                 expressionProgram,
                 activationSlots,
+                allowsDynamicIdentifiers,
                 unified,
                 literalConstants,
+                stringConstants,
                 out reason);
         }
 
@@ -7555,8 +7587,24 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
-        if (!TryAppendSimpleOperandLoad(left, expressionProgram, activationSlots, unified, literalConstants, out reason) ||
-            !TryAppendSimpleOperandLoad(right, expressionProgram, activationSlots, unified, literalConstants, out reason))
+        if (!TryAppendSimpleOperandLoadWithDynamic(
+                left,
+                expressionProgram,
+                activationSlots,
+                allowsDynamicIdentifiers,
+                unified,
+                literalConstants,
+                stringConstants,
+                out reason) ||
+            !TryAppendSimpleOperandLoadWithDynamic(
+                right,
+                expressionProgram,
+                activationSlots,
+                allowsDynamicIdentifiers,
+                unified,
+                literalConstants,
+                stringConstants,
+                out reason))
         {
             return false;
         }

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -770,9 +770,17 @@ internal static class UnifiedBytecodeProductionEligibility
         var isFirstBoundaryPropertyUpdateCandidate =
             TryIsFirstBoundaryPropertyUpdateCandidate(program, identifierConstants, activationSlots, allowsDynamicIdentifiers);
         var isFirstBoundaryNamedCompoundPropertyWriteCandidate =
-            TryIsFirstBoundaryNamedCompoundPropertyWriteCandidate(program, identifierConstants, activationSlots);
+            TryIsFirstBoundaryNamedCompoundPropertyWriteCandidate(
+                program,
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers);
         var isFirstBoundaryNamedLogicalPropertyWriteCandidate =
-            TryIsFirstBoundaryNamedLogicalPropertyWriteCandidate(program, identifierConstants, activationSlots);
+            TryIsFirstBoundaryNamedLogicalPropertyWriteCandidate(
+                program,
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers);
         var isPrivateNamedMutationCandidate =
             isFirstBoundaryPropertyWriteCandidate ||
             isFirstBoundaryPropertyUpdateCandidate ||
@@ -1302,11 +1310,19 @@ internal static class UnifiedBytecodeProductionEligibility
                         break;
                     }
 
-                    if (TryIsFirstBoundaryComputedCompoundPropertyWriteCandidate(program, identifierConstants, activationSlots))
+                    if (TryIsFirstBoundaryComputedCompoundPropertyWriteCandidate(
+                            program,
+                            identifierConstants,
+                            activationSlots,
+                            allowsDynamicIdentifiers))
                     {
                         break;
                     }
-                    if (TryIsFirstBoundaryComputedLogicalPropertyWriteCandidate(program, identifierConstants, activationSlots))
+                    if (TryIsFirstBoundaryComputedLogicalPropertyWriteCandidate(
+                            program,
+                            identifierConstants,
+                            activationSlots,
+                            allowsDynamicIdentifiers))
                     {
                         break;
                     }
@@ -1330,8 +1346,16 @@ internal static class UnifiedBytecodeProductionEligibility
                         TryIsFirstBoundaryNestedNamedPropertyWriteCandidate(program, identifierConstants, activationSlots) ||
                         isFirstBoundaryNamedCompoundPropertyWriteCandidate ||
                         isFirstBoundaryNamedLogicalPropertyWriteCandidate ||
-                        TryIsFirstBoundaryComputedCompoundPropertyWriteCandidate(program, identifierConstants, activationSlots) ||
-                        TryIsFirstBoundaryComputedLogicalPropertyWriteCandidate(program, identifierConstants, activationSlots))
+                        TryIsFirstBoundaryComputedCompoundPropertyWriteCandidate(
+                            program,
+                            identifierConstants,
+                            activationSlots,
+                            allowsDynamicIdentifiers) ||
+                        TryIsFirstBoundaryComputedLogicalPropertyWriteCandidate(
+                            program,
+                            identifierConstants,
+                            activationSlots,
+                            allowsDynamicIdentifiers))
                     {
                         break;
                     }
@@ -4277,7 +4301,8 @@ internal static class UnifiedBytecodeProductionEligibility
     private static bool TryIsFirstBoundaryNamedCompoundPropertyWriteCandidate(
         ExpressionProgram program,
         ReadOnlySpan<IdentifierOperand> identifierConstants,
-        ActivationSlotShape activationSlots)
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers)
     {
         // Shape: [base, GetNamedProperty(non-optional, non-private)*, DuplicateTop, GetNamedProperty, rhs..., Binary, SetNamedProperty]
         // The final target may be private; receiver-chain hops stay ordinary only.
@@ -4287,7 +4312,11 @@ internal static class UnifiedBytecodeProductionEligibility
             return false;
         }
 
-        if (!TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
+        if (!TryGetActivationOrPlainDynamicIdentifierReadValue(
+                program.GetOperation(0),
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers))
         {
             return false;
         }
@@ -4344,7 +4373,11 @@ internal static class UnifiedBytecodeProductionEligibility
 
         if (rhsStart == rhsEnd)
         {
-            return IsSimpleOperand(program.GetOperation(rhsStart), identifierConstants, activationSlots);
+            return IsSimpleOperand(
+                program.GetOperation(rhsStart),
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers);
         }
 
         // Multi-op RHS — try template literal span.
@@ -4357,14 +4390,19 @@ internal static class UnifiedBytecodeProductionEligibility
     private static bool TryIsFirstBoundaryComputedCompoundPropertyWriteCandidate(
         ExpressionProgram program,
         ReadOnlySpan<IdentifierOperand> identifierConstants,
-        ActivationSlotShape activationSlots)
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers)
     {
         if (program.OperationCount < 9)
         {
             return false;
         }
 
-        if (!TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
+        if (!TryGetActivationOrPlainDynamicIdentifierReadValue(
+                program.GetOperation(0),
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers))
         {
             return false;
         }
@@ -4376,7 +4414,8 @@ internal static class UnifiedBytecodeProductionEligibility
                 startInclusive: 1,
                 endExclusive: suffixStart,
                 identifierConstants,
-                activationSlots))
+                activationSlots,
+                allowsDynamicIdentifiers))
         {
             return false;
         }
@@ -4394,7 +4433,7 @@ internal static class UnifiedBytecodeProductionEligibility
                duplicateTargetAndKey.Kind == ExpressionOpKind.DuplicateTopTwo &&
                propertyRead.Kind == ExpressionOpKind.GetComputedProperty &&
                !propertyRead.ShortCircuitOnNullishTarget &&
-               IsSimpleOperand(rhs, identifierConstants, activationSlots) &&
+               IsSimpleOperand(rhs, identifierConstants, activationSlots, allowsDynamicIdentifiers) &&
                binary.Kind == ExpressionOpKind.Binary &&
                IsProductionBinaryOperator(binary.Operator) &&
                propertyWrite.Kind == ExpressionOpKind.SetComputedProperty &&
@@ -4404,7 +4443,8 @@ internal static class UnifiedBytecodeProductionEligibility
     private static bool TryIsFirstBoundaryNamedLogicalPropertyWriteCandidate(
         ExpressionProgram program,
         ReadOnlySpan<IdentifierOperand> identifierConstants,
-        ActivationSlotShape activationSlots)
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers)
     {
         // Shape: [base, GetNamedProperty(non-optional, non-private)*, DuplicateTop, GetNamedProperty,
         // JumpIf*, Pop, rhs, SetNamedProperty, DuplicateTop, SwapTopTwo, Pop]
@@ -4414,7 +4454,11 @@ internal static class UnifiedBytecodeProductionEligibility
             return false;
         }
 
-        if (!TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
+        if (!TryGetActivationOrPlainDynamicIdentifierReadValue(
+                program.GetOperation(0),
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers))
         {
             return false;
         }
@@ -4465,7 +4509,7 @@ internal static class UnifiedBytecodeProductionEligibility
             propertyRead.IsOptional ||
             propertyRead.ShortCircuitOnNullishTarget ||
             jump.Target != duplicateIndex + 7 ||
-            !IsSimpleOperand(rhs, identifierConstants, activationSlots))
+            !IsSimpleOperand(rhs, identifierConstants, activationSlots, allowsDynamicIdentifiers))
         {
             return false;
         }
@@ -4477,7 +4521,8 @@ internal static class UnifiedBytecodeProductionEligibility
     private static bool TryIsFirstBoundaryComputedLogicalPropertyWriteCandidate(
         ExpressionProgram program,
         ReadOnlySpan<IdentifierOperand> identifierConstants,
-        ActivationSlotShape activationSlots)
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers)
     {
         // Shape: [base, key..., RequireObjectCoercible, ResolvePropertyKey, DuplicateTopTwo, GetComputedProperty,
         // JumpIf*, Pop, rhs..., SetComputedProperty, DuplicateTop, DuplicateTop, RotateTopThreeRight, Pop, Pop]
@@ -4486,7 +4531,11 @@ internal static class UnifiedBytecodeProductionEligibility
             return false;
         }
 
-        if (!TryGetActivationResolvedValue(program.GetOperation(0), identifierConstants, activationSlots))
+        if (!TryGetActivationOrPlainDynamicIdentifierReadValue(
+                program.GetOperation(0),
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers))
         {
             return false;
         }
@@ -4501,7 +4550,8 @@ internal static class UnifiedBytecodeProductionEligibility
                     startInclusive: 1,
                     endExclusive: suffixStart,
                     identifierConstants,
-                    activationSlots))
+                    activationSlots,
+                    allowsDynamicIdentifiers))
             {
                 continue;
             }
@@ -4531,7 +4581,8 @@ internal static class UnifiedBytecodeProductionEligibility
                     suffixStart + 6,
                     propertyWriteIndex,
                     identifierConstants,
-                    activationSlots) &&
+                    activationSlots,
+                    allowsDynamicIdentifiers) &&
                 propertyWrite.Kind == ExpressionOpKind.SetComputedProperty &&
                 !propertyWrite.AllowNameInference &&
                 duplicateAssignedValue.Kind == ExpressionOpKind.DuplicateTop &&
@@ -4553,7 +4604,8 @@ internal static class UnifiedBytecodeProductionEligibility
         int startInclusive,
         int endExclusive,
         ReadOnlySpan<IdentifierOperand> identifierConstants,
-        ActivationSlotShape activationSlots)
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers)
     {
         if (startInclusive >= endExclusive)
         {
@@ -4562,7 +4614,11 @@ internal static class UnifiedBytecodeProductionEligibility
 
         if (endExclusive - startInclusive == 1)
         {
-            return IsSimpleOperand(program.GetOperation(startInclusive), identifierConstants, activationSlots);
+            return IsSimpleOperand(
+                program.GetOperation(startInclusive),
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers);
         }
 
         if (endExclusive - startInclusive != 3)
@@ -4573,8 +4629,8 @@ internal static class UnifiedBytecodeProductionEligibility
         var left = program.GetOperation(startInclusive);
         var right = program.GetOperation(startInclusive + 1);
         var binary = program.GetOperation(startInclusive + 2);
-        return IsSimpleOperand(left, identifierConstants, activationSlots) &&
-               IsSimpleOperand(right, identifierConstants, activationSlots) &&
+        return IsSimpleOperand(left, identifierConstants, activationSlots, allowsDynamicIdentifiers) &&
+               IsSimpleOperand(right, identifierConstants, activationSlots, allowsDynamicIdentifiers) &&
                binary.Kind == ExpressionOpKind.Binary &&
                IsProductionBinaryOperator(binary.Operator);
     }

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -1725,6 +1725,32 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
+    public void Evaluate_NamedCompoundPropertyWriteWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted()
+    {
+        var plan = GetFunctionPlan("""
+            function write() {
+                return outer.value += 2;
+            }
+            """,
+            "write");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor(
+                AllowsOrdinaryDynamicIdentifierEnvironmentOperations: true));
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.LoadDynamicIdentifier);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.GetNamedPropertyForCompoundSet);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.SetNamedProperty);
+        Assert.Equal(new[] { "outer", "value" }, result.Program.StringConstants);
+    }
+
+    [Fact]
     public void Evaluate_ComputedCompoundPropertyWriteCandidate_AcceptsOwnedPropertyOpcode()
     {
         var plan = GetFunctionPlan("""
@@ -1744,6 +1770,32 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
             instruction.OpCode == UnifiedBytecodeOpCode.GetComputedPropertyForCompoundSet);
         Assert.Contains(result.Program.Instructions, instruction =>
             instruction.OpCode == UnifiedBytecodeOpCode.SetComputedProperty);
+    }
+
+    [Fact]
+    public void Evaluate_ComputedCompoundPropertyWriteWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted()
+    {
+        var plan = GetFunctionPlan("""
+            function write() {
+                return outer[key] += 2;
+            }
+            """,
+            "write");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor(
+                AllowsOrdinaryDynamicIdentifierEnvironmentOperations: true));
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.LoadDynamicIdentifier);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.GetComputedPropertyForCompoundSet);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.SetComputedProperty);
+        Assert.Equal(new[] { "outer", "key" }, result.Program.StringConstants);
     }
 
     [Fact]
@@ -6676,6 +6728,34 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
+    public void Evaluate_LogicalAndAssignment_DynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted()
+    {
+        var plan = GetFunctionPlan("""
+            function write() {
+                return outer.value &&= 43;
+            }
+            """,
+            "write");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor(
+                AllowsOrdinaryDynamicIdentifierEnvironmentOperations: true));
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.LoadDynamicIdentifier);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.GetNamedPropertyForCompoundSet);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.JumpIfShortCircuitFalse);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.SetNamedProperty);
+        Assert.Equal(new[] { "outer", "value" }, result.Program.StringConstants);
+    }
+
+    [Fact]
     public void Evaluate_LogicalOrAssignment_ThisPropertyBase_AcceptsWithOwnedOpcodes()
     {
         var plan = GetClassMethodPlan("""
@@ -6700,6 +6780,34 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
             instruction.OpCode == UnifiedBytecodeOpCode.JumpIfShortCircuitTrue);
         Assert.Contains(result.Program.Instructions, instruction =>
             instruction.OpCode == UnifiedBytecodeOpCode.SetNamedProperty);
+    }
+
+    [Fact]
+    public void Evaluate_LogicalOrAssignment_ComputedDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted()
+    {
+        var plan = GetFunctionPlan("""
+            function write() {
+                return outer[key] ||= 43;
+            }
+            """,
+            "write");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor(
+                AllowsOrdinaryDynamicIdentifierEnvironmentOperations: true));
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.LoadDynamicIdentifier);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.GetComputedPropertyForCompoundSet);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.JumpIfShortCircuitTrue);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.SetComputedProperty);
+        Assert.Equal(new[] { "outer", "key" }, result.Program.StringConstants);
     }
 
     [Fact]

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -7001,6 +7001,182 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task ArrowFunction_CapturedPropertyCompoundWriteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeWriter(obj) {
+                return () => obj.value += 2;
+            }
+
+            var box = { value: 40 };
+            var write = makeWriter(box);
+            write() + box.value;
+            """);
+
+        Assert.Equal(84d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous>",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FunctionExpression_CapturedPropertyCompoundWriteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeWriter(obj) {
+                return function write() {
+                    return obj.value += 2;
+                };
+            }
+
+            var box = { value: 40 };
+            var write = makeWriter(box);
+            write() + box.value;
+            """);
+
+        Assert.Equal(84d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=write",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ArrowFunction_CapturedComputedPropertyCompoundWriteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeWriter(obj, key) {
+                return () => obj[key] += 2;
+            }
+
+            var box = { value: 40 };
+            var write = makeWriter(box, "value");
+            write() + box.value;
+            """);
+
+        Assert.Equal(84d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous>",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FunctionExpression_CapturedComputedPropertyCompoundWriteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeWriter(obj, key) {
+                return function write() {
+                    return obj[key] += 2;
+                };
+            }
+
+            var box = { value: 40 };
+            var write = makeWriter(box, "value");
+            write() + box.value;
+            """);
+
+        Assert.Equal(84d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=write",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ArrowFunction_CapturedPropertyLogicalWriteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeWriter(obj) {
+                return () => obj.value &&= 43;
+            }
+
+            var box = { value: 1 };
+            var write = makeWriter(box);
+            write() + box.value;
+            """);
+
+        Assert.Equal(86d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous>",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FunctionExpression_CapturedPropertyLogicalWriteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeWriter(obj) {
+                return function write() {
+                    return obj.value &&= 43;
+                };
+            }
+
+            var box = { value: 1 };
+            var write = makeWriter(box);
+            write() + box.value;
+            """);
+
+        Assert.Equal(86d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=write",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ArrowFunction_CapturedComputedPropertyLogicalWriteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeWriter(obj, key) {
+                return () => obj[key] ||= 43;
+            }
+
+            var box = { value: 0 };
+            var write = makeWriter(box, "value");
+            write() + box.value;
+            """);
+
+        Assert.Equal(86d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=<anonymous>",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FunctionExpression_CapturedComputedPropertyLogicalWriteExpression_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function makeWriter(obj, key) {
+                return function write() {
+                    return obj[key] ||= 43;
+                };
+            }
+
+            var box = { value: 0 };
+            var write = makeWriter(box, "value");
+            write() + box.value;
+            """);
+
+        Assert.Equal(86d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=write",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task FunctionExpression_CapturedOuterEnvironmentWrite_DoesNotUseUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit captured dynamic-identifier bases for first-boundary named/computed compound and logical property writes
- thread admitted dynamic bases/keys/RHS operands through the specialized compiler helpers without widening optional/private/super neighbors
- add eligibility and public invocation route tests for captured arrow/function-expression compound/logical property writes
- refresh the unified bytecode expansion contract for the new captured property mutation surface

## Proof
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~Evaluate_NamedCompoundPropertyWriteWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted|FullyQualifiedName~Evaluate_ComputedCompoundPropertyWriteWithDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted|FullyQualifiedName~Evaluate_LogicalAndAssignment_DynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted|FullyQualifiedName~Evaluate_LogicalOrAssignment_ComputedDynamicIdentifierBase_AcceptsWhenDynamicReadsAreAdmitted|FullyQualifiedName~ArrowFunction_CapturedPropertyCompoundWriteExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~FunctionExpression_CapturedPropertyCompoundWriteExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~ArrowFunction_CapturedComputedPropertyCompoundWriteExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~FunctionExpression_CapturedComputedPropertyCompoundWriteExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~ArrowFunction_CapturedPropertyLogicalWriteExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~FunctionExpression_CapturedPropertyLogicalWriteExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~ArrowFunction_CapturedComputedPropertyLogicalWriteExpression_UsesUnifiedBytecodeProductionFastPath|FullyQualifiedName~FunctionExpression_CapturedComputedPropertyLogicalWriteExpression_UsesUnifiedBytecodeProductionFastPath" — 12 passed
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests" — 388 passed
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests" — 358 passed
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProduction" — 788 passed
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ActivationSemanticsProofPackTests" — 48 passed
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests&FullyQualifiedName~UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums" — 1 passed
- rtk dotnet build -c Release — 11 projects, 0 errors, existing nullable warnings
- rtk rg "EvaluateExpression\\(|ProfileEvaluateExpression\\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner* — no matches
- rtk ./tools/profile forloop --memory — Total allocated 6.86 MB
- rtk git diff --check