### PR TITLE
Admit nested property-read literal call arguments

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -324,6 +324,65 @@ pre-gates fall through to the existing sync route before eligibility runs,
 eligibility declines keep the plan out of the production VM, and accepted rows
 must still obey the no-mixed-execution rule.
 
+The decline-family list above is a coarse taxonomy, not a sub-gate burn-down
+counter. A family such as `CallDependency` or `PropertyWriteDependency` remains
+listed until every concrete shape in that family is VM-owned; individual
+widening slices reduce the text in the ledger row and the associated proof
+surface before the family itself can disappear.
+
+### Concrete Remaining Gate View
+
+This is the current human-maintained burn-down view beneath the coarse decline
+families. It is intentionally phrased as testable shapes rather than enum names;
+the next audit step is to generate this list from the selector/compiler
+predicates and proof tests.
+
+- Async-like ordinary functions, generator functions, awaited with-object plans,
+  and resumable opcode shapes outside the small `EvaluateResumable` subset.
+- Captured function scopes outside the simple-return captured-closure route,
+  unresolved non-with dynamic activation, arrow lexical `this` / `new.target`,
+  and class-constructor activation outside the bounded constructor routes.
+- Unbounded real `arguments` object dependency.
+- Direct eval outside the one-argument non-spread eval-identifier boundary.
+- Out-of-boundary call-target preparation, complex receiver/key/call-target
+  shapes, complex call arguments outside admitted simple/binary/unary/`typeof`/
+  property-read/literal spans, and remaining receiver-binding-sensitive adjacent
+  call families.
+- Unresolved identifier loads/stores/updates outside ordinary, with-backed,
+  direct-eval-backed, and simple-return captured-closure dynamic-name paths.
+- Named/computed property reads outside activation-resolved and read-only
+  dynamic-identifier-base boundaries, especially captured-closure dynamic bases
+  and richer computed-key spans.
+- Property writes and compound/logical writes outside direct property-write
+  shapes, supported computed expression-key mutation shapes, simple-return
+  dynamic-base writes, and current nested named receiver shapes.
+- Property/identifier updates outside direct update, computed expression-key
+  update, simple-return dynamic-base update, and the current simple nested named
+  receiver update boundary.
+- Delete expressions outside ordinary named/computed property delete,
+  simple-return dynamic-base delete, ordinary dynamic-key computed delete, and
+  with-backed dynamic-name delete.
+- Out-of-boundary super call targets and remaining class/constructor
+  super-adjacent call shapes.
+- Optional-chain shapes outside admitted optional property-read, optional-call,
+  and exact optional named/computed delete boundaries.
+- Object/array spread sources outside simple operands and admitted member-call
+  spans; richer computed object keys/values; object methods/accessors outside
+  restricted simple literal spans.
+- Private-name operations outside admitted `#name in obj`, direct private
+  reads/writes/updates, direct private compound/logical writes, and direct
+  private named method calls.
+- Awaited for-in sources, async iterator drivers, unsupported for-in driver
+  state, and labeled break/continue crossing intervening driver loops.
+- Awaited destructuring binding values, unsupported destructuring driver shapes,
+  and destructuring targets outside direct-slot or descriptor-backed lanes.
+- Missing slot metadata, unsupported instruction families, unsupported compiler
+  shapes, unsupported resumable opcodes, and unknown production opcode defaults.
+- Pre-gates: class constructor invokers outside bounded constructor routes;
+  arrow functions whose lowered body still has an unowned dependency;
+  identifier-cache disabled outside ordinary/with-backed lanes; super
+  constructor/prototype state outside admitted paths.
+
 ### Eligibility Decline Rows
 
 | Decline code | Owning source / current example | Current fallback route | Planned batch / lane | Proof command |
@@ -335,7 +394,7 @@ must still obey the no-mixed-execution rule.
 | `ArgumentsObjectDependency` | Activation descriptor gate for unbounded real `arguments` object dependency; implicit `arguments` reads/assignments/updates/calls materialize the existing arguments object and use the bounded identifier route, while parameter/lexical `arguments` reads, `typeof`, assignments, updates, and call targets route as activation slots | Existing sync IR / arguments-object route | Arguments object lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_CallImplicitArgumentsObject_AcceptsDynamicIdentifierCallTarget"` |
 | `ArrowLexicalThisDependency` | Activation descriptor gate for arrow lexical `this` / `new.target` ownership before ordinary sync routing | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_OrdinarySyncActivationDescriptorBlockers_DeclineBeforeCompile"` |
 | `ClassConstructorActivation` | Activation descriptor gate for class constructor activation outside the admitted simple base constructor route, explicit derived-constructor `super(...)` route with post-super `this` body reads/writes, and default-derived constructor `super(...args)` forwarding route | Constructor route | Constructor boundary lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionConstructCallTests&FullyQualifiedName~Constructor"` |
-| `CallDependency` | Direct eval outside the one-argument non-spread eval-identifier boundary, out-of-boundary call-target preparation, and complex call arguments excluding admitted simple/binary template-literal substitutions, simple/binary computed object keys, zero-argument activation-resolved identifier-call computed object keys, simple activation or dynamic identifier-call arguments, simple-binary arguments, nested simple, simple-binary, simple-unary, and simple-`typeof` array/object/template literal values/elements, and dynamic operands inside simple array/object/template call arguments for admitted identifier-call and member-call targets | Existing sync IR call route | Wider call invocation lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests"` |
+| `CallDependency` | Direct eval outside the one-argument non-spread eval-identifier boundary, out-of-boundary call-target preparation, and complex call arguments excluding admitted simple/binary template-literal substitutions, simple/binary computed object keys, zero-argument activation-resolved identifier-call computed object keys, simple activation or dynamic identifier-call arguments, simple-binary arguments, nested simple, simple-binary, simple-unary, simple-property-read, and simple-`typeof` array/object/template literal values/elements, and dynamic operands inside simple array/object/template call arguments for admitted identifier-call and member-call targets | Existing sync IR call route | Wider call invocation lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests"` |
 | `DynamicLookupDependency` | Unresolved identifier loads/stores/update outside the admitted ordinary, with-backed, direct-eval-backed, and simple-return captured-closure dynamic-name paths; plans that need direct eval plus post-eval dynamic identifier reads now route when captured activation, with-chain, and arguments-object dependencies are absent | Existing sync IR / environment lookup route | Dynamic-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_DirectEvalDeclaredVarRead_AcceptsOrdinaryDynamicNameProgram"` |
 | `PropertyReadBoundaryOutOfScope` | Named/computed property reads outside the admitted activation-resolved and read-only dynamic-identifier-base boundaries, including captured closure dynamic bases | Existing sync IR property route | Property read widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_ComputedPropertyReadOutsideFirstBoundary_DeclinesWithBoundaryCode"` |
 | `PropertyWriteDependency` | Property writes and compound/logical property writes outside the admitted direct property-write shapes, supported computed expression-key mutation shapes, simple-return dynamic-base named/computed property writes and compound/logical writes, simple nested named receiver assignment shape, nested named compound-write shape, and nested named logical-write shape | Existing sync IR property-write route | Property write widening lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_LogicalAndAssignment_UnsupportedShapes_DeclineWithExplicitCodes"` |
@@ -564,9 +623,11 @@ the final post-compile production subset check before VM entry.
   member calls whose receiver chain remains inside the shallow computed-call
   boundary. Arguments may be simple literal or slot operands, or simple
   array/object literal spans (`[a, b]`, `{x: a, y: b}`), including nested
-  simple, simple-binary, simple-unary, or simple-`typeof` array/object/template literal values or elements
+  simple, simple-binary, simple-unary, simple-property-read, or
+  simple-`typeof` array/object/template literal values or elements
   (`{items: [a, b]}`, `[{x}]`, `{total: a + b}`,
-  `{value: -x}`, `{kind: typeof x}`, ``{label: `hello ${name}`}``) and object literal spread entries
+  `{value: -x}`, `{value: box.count}`, `{value: box[key]}`,
+  `{kind: typeof x}`, ``{label: `hello ${name}`}``) and object literal spread entries
   whose spread source is a simple operand (`{...source}`), with no computed keys or name inference in that restricted
   simple-span form (gh2705, ADR 0290). General object method/accessor literal
   construction is VM-owned outside that restricted span. Computed member keys

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -6966,6 +6966,21 @@ internal static class UnifiedBytecodeCompiler
             return true;
         }
 
+        if (TryAppendSimplePropertyReadOperandSpan(
+                expressionProgram,
+                startIndex,
+                expressionProgram.OperationCount,
+                activationSlots,
+                allowsDynamicIdentifiers,
+                unified,
+                literalConstants,
+                stringConstants,
+                out spanLength,
+                out reason))
+        {
+            return true;
+        }
+
         if (TryAppendSimpleOperandLoadWithDynamic(
                 operation,
                 expressionProgram,
@@ -7242,6 +7257,21 @@ internal static class UnifiedBytecodeCompiler
             return true;
         }
 
+        if (TryAppendSimplePropertyReadOperandSpan(
+                expressionProgram,
+                startIndex,
+                endExclusive,
+                activationSlots,
+                allowsDynamicIdentifiers,
+                unified,
+                literalConstants,
+                stringConstants,
+                out spanLength,
+                out reason))
+        {
+            return true;
+        }
+
         if (TryAppendSimpleOperandLoadWithDynamic(
                 operation,
                 expressionProgram,
@@ -7258,6 +7288,313 @@ internal static class UnifiedBytecodeCompiler
 
         spanLength = 0;
         return false;
+    }
+
+    private static bool TryAppendSimplePropertyReadOperandSpan(
+        ExpressionProgram expressionProgram,
+        int startIndex,
+        int endExclusive,
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
+        ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
+        ImmutableArray<JsValue>.Builder literalConstants,
+        ImmutableArray<string>.Builder stringConstants,
+        out int spanLength,
+        out string reason)
+    {
+        if (TryMeasureSimpleComputedPropertyReadOperandSpan(
+                expressionProgram,
+                startIndex,
+                endExclusive,
+                activationSlots,
+                allowsDynamicIdentifiers,
+                out var keyStart,
+                out var keyEndExclusive,
+                out spanLength))
+        {
+            return TryAppendMeasuredSimpleComputedPropertyReadOperandSpan(
+                expressionProgram,
+                startIndex,
+                keyStart,
+                keyEndExclusive,
+                spanLength,
+                activationSlots,
+                allowsDynamicIdentifiers,
+                unified,
+                literalConstants,
+                stringConstants,
+                out reason);
+        }
+
+        if (TryMeasureSimpleNamedPropertyReadOperandSpan(
+                expressionProgram,
+                startIndex,
+                endExclusive,
+                activationSlots,
+                allowsDynamicIdentifiers,
+                out spanLength))
+        {
+            return TryAppendMeasuredSimpleNamedPropertyReadOperandSpan(
+                expressionProgram,
+                startIndex,
+                spanLength,
+                activationSlots,
+                allowsDynamicIdentifiers,
+                unified,
+                literalConstants,
+                stringConstants,
+                out reason);
+        }
+
+        spanLength = 0;
+        reason = string.Empty;
+        return false;
+    }
+
+    private static bool TryMeasureSimpleNamedPropertyReadOperandSpan(
+        ExpressionProgram expressionProgram,
+        int startIndex,
+        int endExclusive,
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
+        out int spanLength)
+    {
+        spanLength = 0;
+        if (startIndex + 1 >= endExclusive ||
+            !CanAppendSimpleOperandLoadWithDynamic(
+                expressionProgram.GetOperation(startIndex),
+                expressionProgram,
+                activationSlots,
+                allowsDynamicIdentifiers))
+        {
+            return false;
+        }
+
+        var expressionStringConstants = expressionProgram.StringConstants.AsSpan();
+        var index = startIndex + 1;
+        while (index < endExclusive &&
+               IsPlainNamedPropertyRead(expressionProgram.GetOperation(index), expressionStringConstants))
+        {
+            index++;
+        }
+
+        if (index == startIndex + 1)
+        {
+            return false;
+        }
+
+        spanLength = index - startIndex;
+        return true;
+    }
+
+    private static bool TryMeasureSimpleComputedPropertyReadOperandSpan(
+        ExpressionProgram expressionProgram,
+        int startIndex,
+        int endExclusive,
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
+        out int keyStart,
+        out int keyEndExclusive,
+        out int spanLength)
+    {
+        keyStart = 0;
+        keyEndExclusive = 0;
+        spanLength = 0;
+        if (startIndex + 4 >= endExclusive ||
+            !CanAppendSimpleOperandLoadWithDynamic(
+                expressionProgram.GetOperation(startIndex),
+                expressionProgram,
+                activationSlots,
+                allowsDynamicIdentifiers))
+        {
+            return false;
+        }
+
+        var expressionStringConstants = expressionProgram.StringConstants.AsSpan();
+        keyStart = startIndex + 1;
+        while (keyStart < endExclusive &&
+               IsPlainNamedPropertyRead(expressionProgram.GetOperation(keyStart), expressionStringConstants))
+        {
+            keyStart++;
+        }
+
+        for (var requireIndex = keyStart + 1; requireIndex + 2 < endExclusive; requireIndex++)
+        {
+            var requireObjectCoercible = expressionProgram.GetOperation(requireIndex);
+            if (requireObjectCoercible.Kind != ExpressionOpKind.RequireObjectCoercible ||
+                requireObjectCoercible.Depth != 1)
+            {
+                continue;
+            }
+
+            var resolvePropertyKey = expressionProgram.GetOperation(requireIndex + 1);
+            var getComputedProperty = expressionProgram.GetOperation(requireIndex + 2);
+            if (resolvePropertyKey.Kind != ExpressionOpKind.ResolvePropertyKey ||
+                getComputedProperty.Kind != ExpressionOpKind.GetComputedProperty ||
+                getComputedProperty.ShortCircuitOnNullishTarget)
+            {
+                continue;
+            }
+
+            if (!IsSupportedComputedPropertyKeySpan(
+                    expressionProgram,
+                    activationSlots,
+                    keyStart,
+                    requireIndex,
+                    allowsDynamicIdentifiers))
+            {
+                continue;
+            }
+
+            var end = requireIndex + 3;
+            while (end < endExclusive &&
+                   IsPlainNamedPropertyRead(expressionProgram.GetOperation(end), expressionStringConstants))
+            {
+                end++;
+            }
+
+            keyEndExclusive = requireIndex;
+            spanLength = end - startIndex;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryAppendMeasuredSimpleNamedPropertyReadOperandSpan(
+        ExpressionProgram expressionProgram,
+        int startIndex,
+        int spanLength,
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
+        ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
+        ImmutableArray<JsValue>.Builder literalConstants,
+        ImmutableArray<string>.Builder stringConstants,
+        out string reason)
+    {
+        var unifiedCount = unified.Count;
+        var literalCount = literalConstants.Count;
+        var stringCount = stringConstants.Count;
+        if (!TryAppendSimpleOperandLoadWithDynamic(
+                expressionProgram.GetOperation(startIndex),
+                expressionProgram,
+                activationSlots,
+                allowsDynamicIdentifiers,
+                unified,
+                literalConstants,
+                stringConstants,
+                out reason))
+        {
+            return false;
+        }
+
+        var expressionStringConstants = expressionProgram.StringConstants.AsSpan();
+        for (var index = startIndex + 1; index < startIndex + spanLength; index++)
+        {
+            AppendPlainNamedPropertyRead(
+                expressionProgram.GetOperation(index),
+                expressionStringConstants,
+                unified,
+                stringConstants);
+        }
+
+        if (unified.Count > unifiedCount &&
+            literalConstants.Count >= literalCount &&
+            stringConstants.Count >= stringCount)
+        {
+            reason = string.Empty;
+            return true;
+        }
+
+        RollBackUnifiedBuilder(unified, unifiedCount);
+        RollBackUnifiedBuilder(literalConstants, literalCount);
+        RollBackUnifiedBuilder(stringConstants, stringCount);
+        reason = "Failed to emit measured named property read span.";
+        return false;
+    }
+
+    private static bool TryAppendMeasuredSimpleComputedPropertyReadOperandSpan(
+        ExpressionProgram expressionProgram,
+        int startIndex,
+        int keyStart,
+        int keyEndExclusive,
+        int spanLength,
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers,
+        ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
+        ImmutableArray<JsValue>.Builder literalConstants,
+        ImmutableArray<string>.Builder stringConstants,
+        out string reason)
+    {
+        var unifiedCount = unified.Count;
+        var literalCount = literalConstants.Count;
+        var stringCount = stringConstants.Count;
+        if (!TryAppendSimpleOperandLoadWithDynamic(
+                expressionProgram.GetOperation(startIndex),
+                expressionProgram,
+                activationSlots,
+                allowsDynamicIdentifiers,
+                unified,
+                literalConstants,
+                stringConstants,
+                out reason))
+        {
+            return false;
+        }
+
+        var expressionStringConstants = expressionProgram.StringConstants.AsSpan();
+        for (var index = startIndex + 1; index < keyStart; index++)
+        {
+            AppendPlainNamedPropertyRead(
+                expressionProgram.GetOperation(index),
+                expressionStringConstants,
+                unified,
+                stringConstants);
+        }
+
+        if (!TryAppendComputedPropertyKeySpan(
+                expressionProgram,
+                activationSlots,
+                unified,
+                literalConstants,
+                stringConstants,
+                keyStart,
+                keyEndExclusive,
+                out reason,
+                allowsDynamicIdentifiers))
+        {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
+            return false;
+        }
+
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.RequireObjectCoercible, 1));
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.ResolvePropertyKey));
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.GetComputedProperty));
+
+        for (var index = keyEndExclusive + 3; index < startIndex + spanLength; index++)
+        {
+            AppendPlainNamedPropertyRead(
+                expressionProgram.GetOperation(index),
+                expressionStringConstants,
+                unified,
+                stringConstants);
+        }
+
+        reason = string.Empty;
+        return true;
+    }
+
+    private static void AppendPlainNamedPropertyRead(
+        PackedExpressionOp operation,
+        ReadOnlySpan<string> expressionStringConstants,
+        ImmutableArray<UnifiedBytecodeInstruction>.Builder unified,
+        ImmutableArray<string>.Builder stringConstants)
+    {
+        var propertyNameIndex = stringConstants.Count;
+        stringConstants.Add(operation.GetString(expressionStringConstants));
+        unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.GetNamedProperty, propertyNameIndex));
     }
 
     private static bool TryAppendSimpleUnaryOperandSpan(

--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -1321,6 +1321,16 @@ internal static class UnifiedBytecodeProductionEligibility
                         return true;
                     }
 
+                    if (TryIsEmbeddedSimpleLiteralPropertyReadOperandOperation(
+                            program,
+                            operationIndex,
+                            identifierConstants,
+                            activationSlots,
+                            allowsDynamicIdentifiers))
+                    {
+                        break;
+                    }
+
                     if (TryIsFirstBoundaryComputedPropertyReadChainCandidate(
                             program,
                             identifierConstants,
@@ -2838,6 +2848,53 @@ internal static class UnifiedBytecodeProductionEligibility
                TryIsEmbeddedOptionalComputedReadSpanOperation(program, operationIndex, identifierConstants, activationSlots);
     }
 
+    private static bool TryIsEmbeddedSimpleLiteralPropertyReadOperandOperation(
+        ExpressionProgram program,
+        int operationIndex,
+        ReadOnlySpan<IdentifierOperand> identifierConstants,
+        ActivationSlotShape activationSlots,
+        bool allowsDynamicIdentifiers)
+    {
+        if (operationIndex <= 0 || operationIndex >= program.OperationCount)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < operationIndex; index++)
+        {
+            var operation = program.GetOperation(index);
+            var isMeasuredLiteral = operation.Kind switch
+            {
+                ExpressionOpKind.CreateArray => TryMeasureSimpleArrayLiteralSpan(
+                    program,
+                    index,
+                    identifierConstants,
+                    activationSlots,
+                    out var spanLength,
+                    allowsDynamicIdentifiers) &&
+                    operationIndex < index + spanLength,
+
+                ExpressionOpKind.CreateObject => TryMeasureSimpleObjectLiteralSpan(
+                    program,
+                    index,
+                    identifierConstants,
+                    activationSlots,
+                    out var spanLength,
+                    allowsDynamicIdentifiers) &&
+                    operationIndex < index + spanLength,
+
+                _ => false
+            };
+
+            if (isMeasuredLiteral)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static bool HasOwningControlExpression(ExpressionProgram program)
     {
         for (var index = 0; index < program.OperationCount; index++)
@@ -4300,6 +4357,17 @@ internal static class UnifiedBytecodeProductionEligibility
             return true;
         }
 
+        if (TryMeasureSimplePropertyReadOperandSpan(
+                program,
+                startIndex,
+                identifierConstants,
+                activationSlots,
+                out spanLength,
+                allowsDynamicIdentifiers))
+        {
+            return true;
+        }
+
         if (IsSimpleOperand(
                 operation,
                 identifierConstants,
@@ -4311,6 +4379,140 @@ internal static class UnifiedBytecodeProductionEligibility
         }
 
         spanLength = 0;
+        return false;
+    }
+
+    private static bool TryMeasureSimplePropertyReadOperandSpan(
+        ExpressionProgram program,
+        int startIndex,
+        ReadOnlySpan<IdentifierOperand> identifierConstants,
+        ActivationSlotShape activationSlots,
+        out int spanLength,
+        bool allowsDynamicIdentifiers = false)
+    {
+        if (TryMeasureSimpleComputedPropertyReadOperandSpan(
+                program,
+                startIndex,
+                identifierConstants,
+                activationSlots,
+                out spanLength,
+                allowsDynamicIdentifiers))
+        {
+            return true;
+        }
+
+        return TryMeasureSimpleNamedPropertyReadOperandSpan(
+            program,
+            startIndex,
+            identifierConstants,
+            activationSlots,
+            out spanLength,
+            allowsDynamicIdentifiers);
+    }
+
+    private static bool TryMeasureSimpleNamedPropertyReadOperandSpan(
+        ExpressionProgram program,
+        int startIndex,
+        ReadOnlySpan<IdentifierOperand> identifierConstants,
+        ActivationSlotShape activationSlots,
+        out int spanLength,
+        bool allowsDynamicIdentifiers)
+    {
+        spanLength = 0;
+        if (startIndex + 1 >= program.OperationCount ||
+            !IsSimpleOperand(
+                program.GetOperation(startIndex),
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers))
+        {
+            return false;
+        }
+
+        var stringConstants = program.StringConstants.AsSpan();
+        var i = startIndex + 1;
+        while (i < program.OperationCount &&
+               IsPlainNamedPropertyRead(program.GetOperation(i), stringConstants))
+        {
+            i++;
+        }
+
+        if (i == startIndex + 1)
+        {
+            return false;
+        }
+
+        spanLength = i - startIndex;
+        return true;
+    }
+
+    private static bool TryMeasureSimpleComputedPropertyReadOperandSpan(
+        ExpressionProgram program,
+        int startIndex,
+        ReadOnlySpan<IdentifierOperand> identifierConstants,
+        ActivationSlotShape activationSlots,
+        out int spanLength,
+        bool allowsDynamicIdentifiers)
+    {
+        spanLength = 0;
+        if (startIndex + 4 >= program.OperationCount ||
+            !IsSimpleOperand(
+                program.GetOperation(startIndex),
+                identifierConstants,
+                activationSlots,
+                allowsDynamicIdentifiers))
+        {
+            return false;
+        }
+
+        var stringConstants = program.StringConstants.AsSpan();
+        var keyStart = startIndex + 1;
+        while (keyStart < program.OperationCount &&
+               IsPlainNamedPropertyRead(program.GetOperation(keyStart), stringConstants))
+        {
+            keyStart++;
+        }
+
+        for (var requireIndex = keyStart + 1; requireIndex + 2 < program.OperationCount; requireIndex++)
+        {
+            var requireObjectCoercible = program.GetOperation(requireIndex);
+            if (requireObjectCoercible.Kind != ExpressionOpKind.RequireObjectCoercible ||
+                requireObjectCoercible.Depth != 1)
+            {
+                continue;
+            }
+
+            var resolvePropertyKey = program.GetOperation(requireIndex + 1);
+            var getComputedProperty = program.GetOperation(requireIndex + 2);
+            if (resolvePropertyKey.Kind != ExpressionOpKind.ResolvePropertyKey ||
+                getComputedProperty.Kind != ExpressionOpKind.GetComputedProperty ||
+                getComputedProperty.ShortCircuitOnNullishTarget)
+            {
+                continue;
+            }
+
+            if (!IsSupportedComputedPropertyKeySpan(
+                    program,
+                    keyStart,
+                    requireIndex,
+                    identifierConstants,
+                    activationSlots,
+                    allowsDynamicIdentifiers))
+            {
+                continue;
+            }
+
+            var endExclusive = requireIndex + 3;
+            while (endExclusive < program.OperationCount &&
+                   IsPlainNamedPropertyRead(program.GetOperation(endExclusive), stringConstants))
+            {
+                endExclusive++;
+            }
+
+            spanLength = endExclusive - startIndex;
+            return true;
+        }
+
         return false;
     }
 
@@ -4423,6 +4625,17 @@ internal static class UnifiedBytecodeProductionEligibility
         }
 
         if (TryMeasureSimpleUnaryOperandSpan(
+                program,
+                startIndex,
+                identifierConstants,
+                activationSlots,
+                out spanLength,
+                allowsDynamicIdentifiers))
+        {
+            return true;
+        }
+
+        if (TryMeasureSimplePropertyReadOperandSpan(
                 program,
                 startIndex,
                 identifierConstants,

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -6478,6 +6478,108 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
+    public void Evaluate_CallWithNestedNamedPropertyReadObjectLiteralArg_Accepts()
+    {
+        var plan = GetFunctionPlan("""
+            function sendNested(receiver, box) {
+                return receiver({ value: box.count });
+            }
+            """,
+            "sendNested");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.GetNamedProperty);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.DefineObjectProperty);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.CallInvocationBoundary);
+    }
+
+    [Fact]
+    public void Evaluate_CallWithNestedNamedPropertyReadArrayLiteralArg_Accepts()
+    {
+        var plan = GetFunctionPlan("""
+            function sendNested(receiver, box) {
+                return receiver([box.count]);
+            }
+            """,
+            "sendNested");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.GetNamedProperty);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.ArrayPush);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.CallInvocationBoundary);
+    }
+
+    [Fact]
+    public void Evaluate_CallWithNestedComputedPropertyReadObjectLiteralArg_Accepts()
+    {
+        var plan = GetFunctionPlan("""
+            function sendNested(receiver, box, key) {
+                return receiver({ value: box[key] });
+            }
+            """,
+            "sendNested");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.RequireObjectCoercible);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.ResolvePropertyKey);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.GetComputedProperty);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.DefineObjectProperty);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.CallInvocationBoundary);
+    }
+
+    [Fact]
+    public void Evaluate_CallWithNestedComputedObjectPropertyReadValueArg_Accepts()
+    {
+        var plan = GetFunctionPlan("""
+            function sendNested(receiver, outKey, box, inKey) {
+                return receiver({ [outKey]: box[inKey] });
+            }
+            """,
+            "sendNested");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.ResolvePropertyKey);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.GetComputedProperty);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.DefineComputedObjectProperty);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.CallInvocationBoundary);
+    }
+
+    [Fact]
     public void Evaluate_CallWithNestedBinaryTemplateArrayLiteralArg_Accepts()
     {
         var plan = GetFunctionPlan("""

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -8789,6 +8789,82 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task CallWithNestedNamedPropertyReadObjectLiteralArg_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function sendNested(receiver, box) {
+                return receiver({ value: box.count });
+            }
+
+            sendNested(function(obj) { return obj.value; }, { count: 42 });
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=sendNested argc=2",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task CallWithNestedNamedPropertyReadArrayLiteralArg_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function sendNested(receiver, box) {
+                return receiver([box.count]);
+            }
+
+            sendNested(function(items) { return items[0]; }, { count: 42 });
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=sendNested argc=2",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task CallWithNestedComputedPropertyReadObjectLiteralArg_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function sendNested(receiver, box, key) {
+                return receiver({ value: box[key] });
+            }
+
+            sendNested(function(obj) { return obj.value; }, { count: 42 }, "count");
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=sendNested argc=3",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task CallWithNestedComputedObjectPropertyReadValueArg_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function sendNested(receiver, outKey, box, inKey) {
+                return receiver({ [outKey]: box[inKey] });
+            }
+
+            sendNested(function(obj) { return obj.answer; }, "answer", { count: 42 }, "count");
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=sendNested argc=4",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task CallWithNestedBinaryTemplateArrayLiteralArg_UsesUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit simple named/computed property-read spans inside production unified-bytecode literal call arguments
- allow the dependency scanner to recognize embedded property reads in admitted simple literal spans
- document the concrete remaining gate view beneath the coarse decline-family list

## Proof
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~NestedNamedPropertyRead|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~NestedComputedPropertyRead|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~NestedComputedObjectPropertyReadValue"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests&FullyQualifiedName~NestedNamedPropertyRead|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests&FullyQualifiedName~NestedComputedPropertyRead|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests&FullyQualifiedName~NestedComputedObjectPropertyReadValue"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProduction"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests&FullyQualifiedName~UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ActivationSemanticsProofPackTests"
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk git diff --check
- rtk ./tools/profile forloop --memory