### PR TITLE
Prove logical spread literal sources

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -632,7 +632,8 @@ the final post-compile production subset check before VM entry.
   `{[left && right]: value}`, `{[condition ? yes : no]: value}`,
   `{kind: typeof x}`, ``{label: `hello ${name}`}``) and object literal spread entries
   whose spread source is a simple operand (`{...source}`) or admitted
-  simple-control expression (`{...(condition ? left : right)}`,
+  simple-control expression (`{...(left && right)}`,
+  `{...(condition ? left : right)}`, `[...(left && right)]`,
   `[...(condition ? left : right)]`), with no name inference in that restricted
   simple-span form (gh2705, ADR 0290). General object method/accessor literal
   construction is VM-owned outside that restricted span. Computed member keys

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -6776,6 +6776,54 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
+    public void Evaluate_CallWithLogicalObjectSpreadSourceArg_Accepts()
+    {
+        var plan = GetFunctionPlan("""
+            function sendNested(receiver, left, right) {
+                return receiver({ ...(left && right) });
+            }
+            """,
+            "sendNested");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.JumpIfShortCircuitFalse);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.ObjectSpread);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.CallInvocationBoundary);
+    }
+
+    [Fact]
+    public void Evaluate_CallWithLogicalArraySpreadSourceArg_Accepts()
+    {
+        var plan = GetFunctionPlan("""
+            function sendNested(receiver, left, right) {
+                return receiver([...(left && right)]);
+            }
+            """,
+            "sendNested");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.JumpIfShortCircuitFalse);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.ArraySpread);
+        Assert.Contains(result.Program.Instructions,
+            instruction => instruction.OpCode == UnifiedBytecodeOpCode.CallInvocationBoundary);
+    }
+
+    [Fact]
     public void Evaluate_CallWithNestedBinaryTemplateArrayLiteralArg_Accepts()
     {
         var plan = GetFunctionPlan("""

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -9017,6 +9017,44 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task CallWithLogicalObjectSpreadSourceArg_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function sendNested(receiver, left, right) {
+                return receiver({ ...(left && right) });
+            }
+
+            sendNested(function(obj) { return obj.answer; }, true, { answer: 42 });
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=sendNested argc=3",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task CallWithLogicalArraySpreadSourceArg_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function sendNested(receiver, left, right) {
+                return receiver([...(left && right)]);
+            }
+
+            sendNested(function(items) { return items[0]; }, true, [42]);
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=sendNested argc=3",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task CallWithNestedBinaryTemplateArrayLiteralArg_UsesUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- add selector proof for logical object and array spread sources in literal call arguments
- add invocation proof that those logical spread-source functions use the production unified-bytecode fast path
- update the expansion contract examples to name logical spread-source forms explicitly

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~LogicalObjectSpreadSourceArg|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~LogicalArraySpreadSourceArg|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests&FullyQualifiedName~LogicalObjectSpreadSourceArg|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests&FullyQualifiedName~LogicalArraySpreadSourceArg" (4 passed; unrelated existing nullable warnings in DurationFormatDebugTest, IrLoopEnvironmentTests, ExpressionProgramLoweringTests)
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProduction" (928 passed)
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests&FullyQualifiedName~UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums" (1 passed)
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ActivationSemanticsProofPackTests" (48 passed)
- rtk rg "EvaluateExpression\\(|ProfileEvaluateExpression\\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner* (no matches)
- rtk git diff --check
- rtk ./tools/profile forloop --memory (Total allocated 6.86 MB)