### PR TITLE
Admit final rest parameter slots to bytecode

### DIFF
--- a/docs/bytecode-progress.md
+++ b/docs/bytecode-progress.md
@@ -54,7 +54,7 @@ flowchart TB
     end
 
     subgraph RedRemaining["Needs handling before full bytecode execution"]
-        R1["Activation model gaps\nasync-like, broad generators, lexical-this arrows,\nreal arguments object, non-simple params"]
+        R1["Activation model gaps\nasync-like, broad generators, lexical-this arrows,\nreal arguments object, remaining non-simple params"]
         R2["Wider call invocation\ncomplex receivers, keys, eval, private-adjacent targets,\nreceiver-binding-sensitive families"]
         R3["Dynamic lookup beyond admitted ordinary/direct-eval/with-backed lanes"]
         R4["Property and assignment neighbors\nricher computed keys, optional/super/private mutation,\nunsupported RHS spans"]

--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -150,6 +150,11 @@ statement interpretation.
   them. Parenthesized `yield (left && right)`, `return yield`, and `yield*`
   state/result shapes therefore compile and route without borrowing parameter
   slots.
+- Ordinary sync functions with plain leading identifier parameters and a final
+  rest identifier parameter can route through production unified bytecode when
+  the compiled program does not require a materialized call/dynamic environment.
+  The invocation bridge materializes the rest array directly into the rest
+  parameter slot before VM entry.
 - `ApplyBindingTarget` is the one explicit bridge inside accepted VM execution:
   the VM owns dispatch and stack/slot state, then applies an already-lowered
   `BindingTargetProgram` for assignment destructuring parity. This is not a
@@ -424,8 +429,8 @@ not always have a `UnifiedBytecodeProductionDeclineCode`.
 | `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no super, unadmitted call-target, nested function/class literal, or other unowned dependency. Captured lexical `this` / `new.target`, statically resolved flat-slot reads, ordinary environment identifier reads/calls, captured identifier assignment/compound assignment/update/delete, and named/computed property reads, simple property writes, compound/logical property writes, property updates, or property deletes from those dynamic identifier bases are VM-owned; lexical-this environments remain a separate pre-gate. | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:IsAsyncLike` | Async and formerly-async ordinary invokers | Async route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_AsyncLikeActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:IsGenerator` | Generator functions before ordinary sync production routing | Generator route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_GeneratorActivation_DeclinesBeforePlanInspection"` |
-| `pre-gate:hasParameterExpressions` | Default/rest/destructured parameter expressions | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
-| `pre-gate:hasOnlySimpleIdentifierParameters` | Non-simple parameter lists | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
+| `pre-gate:hasParameterExpressions` | Default and destructured parameter expressions; final rest identifier parameters are admitted only when the compiled program does not require a materialized call/dynamic environment | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
+| `pre-gate:hasOnlySimpleIdentifierParameters` | Non-simple parameter lists outside the admitted final-rest identifier route | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:usesArguments` | Functions that read, assign, update, call, or `typeof` the real implicit `arguments` object through bounded identifier use; shadowing parameter/lexical `arguments` reads, `typeof`, assignments, updates, and calls are activation-slot traffic | Existing arguments-object route | Arguments object lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_CallImplicitArgumentsObject_AcceptsDynamicIdentifierCallTarget"` |
 | `pre-gate:needsArgumentsBinding` | Sloppy mapped arguments binding when an implicit arguments object is needed and not admitted by with-backed dynamic-name routing | Existing arguments-object route | Arguments object lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:allowIdentifierCache` | Identifier cache disabled outside the ordinary and with-backed dynamic-name lanes, including the admitted mixed `with` plus outside ordinary dynamic-name path | Existing environment lookup route | Dynamic-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_WithThenOutsideDynamicIdentifier_AcceptsMixedDynamicNameProgram"` |
@@ -885,7 +890,8 @@ support today.
    functions, generators, arrows needing lexical-this environments or super
    bindings, closure or dynamic identifier dependencies, or non-simple bodies,
    real `arguments` object and sloppy mapped-arguments dependencies, non-simple
-   parameter lists, default/rest/destructured parameter expressions, broader
+   parameter lists outside the admitted final-rest identifier route,
+   default/destructured parameter expressions, broader
    class constructor routes beyond simple base constructors and the bounded
    explicit derived `super(...)` path, default derived constructors, and captured
    activation outside the explicit with-backed

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -3124,6 +3124,12 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                 var defaultDerivedRestArguments = _function.IsDefaultDerivedConstructor
                     ? CreateDefaultDerivedConstructorRestArguments(arguments)
                     : (JsValue?)null;
+                if (CanUseProductionUnifiedBytecodeFinalRestParameterPath() &&
+                    (_hasFunctionDeclarations || RequiresProductionUnifiedBytecodeCallEnvironment(program)))
+                {
+                    return false;
+                }
+
                 PopulateProductionUnifiedBytecodeParameterSlots(
                     arguments,
                     slots,
@@ -3379,8 +3385,11 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                 CanUseProductionUnifiedBytecodeBaseClassConstructorActivation(plan, newTarget);
             var canUseImplicitArgumentsObjectReadPath =
                 CanUseProductionUnifiedBytecodeImplicitArgumentsObjectReadPath(plan);
+            var canUseFinalRestParameterPath =
+                CanUseProductionUnifiedBytecodeFinalRestParameterPath();
             var hasAdmittedParameterShape =
                 _hasOnlySimpleIdentifierParameters ||
+                canUseFinalRestParameterPath ||
                 _function.IsDefaultDerivedConstructor && canUseDerivedClassConstructorPath;
             var activation = CreateProductionUnifiedBytecodeActivationDescriptor(
                 canUseDynamicNamePath,
@@ -3493,21 +3502,85 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                 return;
             }
 
+            var hasFinalRestParameter =
+                TryGetProductionUnifiedBytecodeFinalRestParameterIndex(out var finalRestParameterIndex);
             for (var i = 0; i < _parameterNames.Length; i++)
             {
                 var parameterSlotIndex = parameterSlotIndices[i];
                 if (parameterSlotIndex >= 0)
                 {
-                    slots[parameterSlotIndex] =
-                        defaultDerivedRestArguments is { } restArguments &&
+                    JsValue value;
+                    if (defaultDerivedRestArguments is { } restArguments &&
                         TryGetDefaultDerivedConstructorRestParameter(out _) &&
-                        i == 0
-                            ? restArguments
-                            : i < arguments.Count
-                                ? arguments[i]
-                                : JsValue.Undefined;
+                        i == 0)
+                    {
+                        value = restArguments;
+                    }
+                    else if (hasFinalRestParameter && i == finalRestParameterIndex)
+                    {
+                        value = CreateRestArguments(arguments, finalRestParameterIndex);
+                    }
+                    else
+                    {
+                        value = i < arguments.Count ? arguments[i] : JsValue.Undefined;
+                    }
+
+                    slots[parameterSlotIndex] = value;
                 }
             }
+        }
+
+        private bool CanUseProductionUnifiedBytecodeFinalRestParameterPath()
+        {
+            return !IsClassConstructor &&
+                   !IsArrowFunction &&
+                   !IsAsyncLike &&
+                   !_function.IsGenerator &&
+                   !_function.IsDefaultDerivedConstructor &&
+                   !_hasParameterExpressions &&
+                   !_usesArguments &&
+                   !_needsArgumentsBinding &&
+                   _allowIdentifierCache &&
+                   _lexicalThisEnvironment is null &&
+                   _homeObject is null &&
+                   PrivateNameScope is null &&
+                   _capturedPrivateNameScopes.IsDefaultOrEmpty &&
+                   _superConstructor is null &&
+                   _superPrototype is null &&
+                   _instanceFields.IsDefaultOrEmpty &&
+                   TryGetProductionUnifiedBytecodeFinalRestParameterIndex(out _);
+        }
+
+        private bool TryGetProductionUnifiedBytecodeFinalRestParameterIndex(out int restIndex)
+        {
+            restIndex = -1;
+            if (_function.Parameters.IsDefaultOrEmpty)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < _function.Parameters.Length; i++)
+            {
+                var parameter = _function.Parameters[i];
+                var isFinal = i == _function.Parameters.Length - 1;
+                if (isFinal)
+                {
+                    if (parameter is { IsRest: true, Pattern: null, DefaultValue: null, Name: not null })
+                    {
+                        restIndex = i;
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                if (parameter is not { IsRest: false, Pattern: null, DefaultValue: null, Name: not null })
+                {
+                    return false;
+                }
+            }
+
+            return false;
         }
 
         [MethodImpl(JsEngineConstants.Inlining)]
@@ -4427,6 +4500,18 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
             where TArgs : IReadOnlyList<JsValue>
         {
             return JsValue.FromJsArray(new JsArray(arguments, RealmState));
+        }
+
+        private JsValue CreateRestArguments<TArgs>(TArgs arguments, int startIndex)
+            where TArgs : IReadOnlyList<JsValue>
+        {
+            var restArray = new JsArray(RealmState);
+            for (var i = startIndex; i < arguments.Count; i++)
+            {
+                restArray.Push(arguments[i]);
+            }
+
+            return JsValue.FromJsArray(restArray);
         }
 
         private bool TryGetDefaultDerivedConstructorRestParameter(out Symbol restName)

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -387,6 +387,24 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
+    public void Evaluate_FinalRestParameterPlan_Accepts()
+    {
+        var plan = GetFunctionPlan("""
+            function pick(prefix, ...items) {
+                return items;
+            }
+            """,
+            "pick");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+    }
+
+    [Fact]
     public void Evaluate_ClassDeclarationInstruction_AcceptsDescriptorOpcode()
     {
         var plan = GetFunctionPlan("""

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -816,6 +816,63 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task FinalRestParameter_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function pick(prefix, ...items) {
+                return items;
+            }
+
+            pick(40, 1, 2).length;
+            """);
+
+        Assert.Equal(2d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=pick argc=3",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FinalRestParameter_MissingRestArguments_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function count(prefix, ...items) {
+                return items;
+            }
+
+            count(42).length;
+            """);
+
+        Assert.Equal(0d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=count argc=1",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FinalRestParameter_CallBody_DoesNotUseUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function callFirst(...items) {
+                return items[0]();
+            }
+
+            callFirst(function() { return 42; });
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=callFirst",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task WithDynamicIdentifierOperations_UseUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit ordinary sync functions with plain leading parameters and a final rest identifier to the production unified-bytecode path when the compiled program does not need a materialized call/dynamic environment
- populate the rest parameter slot with a VM-owned rest array before execution
- preserve the existing default-derived constructor rest forwarding route and document the reduced parameter pre-gate

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~Evaluate_FinalRestParameterPlan_Accepts|FullyQualifiedName~FinalRestParameter"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~FinalRestParameter|FullyQualifiedName~DefaultDerivedConstructor_UsesProductionFastPath|FullyQualifiedName~DefaultDerivedConstructor_ForwardsArgumentsWithoutIteratorProtocol"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProduction"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests&FullyQualifiedName~UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ActivationSemanticsProofPackTests"
- rtk rg "EvaluateExpression\\(|ProfileEvaluateExpression\\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk git diff --check
- rtk ./tools/profile forloop --memory
