### PR TITLE
Bind final rest parameters in bytecode environments

### DIFF
--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -151,10 +151,10 @@ statement interpretation.
   state/result shapes therefore compile and route without borrowing parameter
   slots.
 - Ordinary sync functions with plain leading identifier parameters and a final
-  rest identifier parameter can route through production unified bytecode when
-  the compiled program does not require a materialized call/dynamic environment.
-  The invocation bridge materializes the rest array directly into the rest
-  parameter slot before VM entry.
+  rest identifier parameter can route through production unified bytecode. The
+  invocation bridge materializes the rest array into the rest parameter slot and
+  mirrors that binding into materialized call/dynamic environments before VM
+  entry.
 - `ApplyBindingTarget` is the one explicit bridge inside accepted VM execution:
   the VM owns dispatch and stack/slot state, then applies an already-lowered
   `BindingTargetProgram` for assignment destructuring parity. This is not a
@@ -429,7 +429,7 @@ not always have a `UnifiedBytecodeProductionDeclineCode`.
 | `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no super, unadmitted call-target, nested function/class literal, or other unowned dependency. Captured lexical `this` / `new.target`, statically resolved flat-slot reads, ordinary environment identifier reads/calls, captured identifier assignment/compound assignment/update/delete, and named/computed property reads, simple property writes, compound/logical property writes, property updates, or property deletes from those dynamic identifier bases are VM-owned; lexical-this environments remain a separate pre-gate. | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:IsAsyncLike` | Async and formerly-async ordinary invokers | Async route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_AsyncLikeActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:IsGenerator` | Generator functions before ordinary sync production routing | Generator route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_GeneratorActivation_DeclinesBeforePlanInspection"` |
-| `pre-gate:hasParameterExpressions` | Default and destructured parameter expressions; final rest identifier parameters are admitted only when the compiled program does not require a materialized call/dynamic environment | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
+| `pre-gate:hasParameterExpressions` | Default and destructured parameter expressions; final rest identifier parameters are admitted when the surrounding activation is otherwise production-owned | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:hasOnlySimpleIdentifierParameters` | Non-simple parameter lists outside the admitted final-rest identifier route | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:usesArguments` | Functions that read, assign, update, call, or `typeof` the real implicit `arguments` object through bounded identifier use; shadowing parameter/lexical `arguments` reads, `typeof`, assignments, updates, and calls are activation-slot traffic | Existing arguments-object route | Arguments object lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_CallImplicitArgumentsObject_AcceptsDynamicIdentifierCallTarget"` |
 | `pre-gate:needsArgumentsBinding` | Sloppy mapped arguments binding when an implicit arguments object is needed and not admitted by with-backed dynamic-name routing | Existing arguments-object route | Arguments object lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -3124,12 +3124,6 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                 var defaultDerivedRestArguments = _function.IsDefaultDerivedConstructor
                     ? CreateDefaultDerivedConstructorRestArguments(arguments)
                     : (JsValue?)null;
-                if (CanUseProductionUnifiedBytecodeFinalRestParameterPath() &&
-                    (_hasFunctionDeclarations || RequiresProductionUnifiedBytecodeCallEnvironment(program)))
-                {
-                    return false;
-                }
-
                 PopulateProductionUnifiedBytecodeParameterSlots(
                     arguments,
                     slots,
@@ -4455,11 +4449,17 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
             where TArgs : IReadOnlyList<JsValue>
         {
             var parameterSlotIndices = activationSlots.ParameterSlotIndices;
+            var hasFinalRestParameter =
+                TryGetProductionUnifiedBytecodeFinalRestParameterIndex(out var finalRestParameterIndex);
             if (parameterSlotIndices.IsDefault)
             {
                 for (var i = 0; i < _parameterNames.Length; i++)
                 {
-                    var value = i < arguments.Count ? arguments[i] : JsValue.Undefined;
+                    var value = hasFinalRestParameter && i == finalRestParameterIndex
+                        ? CreateRestArguments(arguments, finalRestParameterIndex)
+                        : i < arguments.Count
+                            ? arguments[i]
+                            : JsValue.Undefined;
                     executionEnvironment.DefineParameterFast(_parameterNames[i], value);
                 }
 
@@ -4468,7 +4468,11 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
 
             for (var i = 0; i < _parameterNames.Length; i++)
             {
-                var value = i < arguments.Count ? arguments[i] : JsValue.Undefined;
+                var value = hasFinalRestParameter && i == finalRestParameterIndex
+                    ? CreateRestArguments(arguments, finalRestParameterIndex)
+                    : i < arguments.Count
+                        ? arguments[i]
+                        : JsValue.Undefined;
                 executionEnvironment.SetSlotDirect(parameterSlotIndices[i], value);
             }
         }

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -854,7 +854,30 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
-    public async Task FinalRestParameter_CallBody_DoesNotUseUnifiedBytecodeProductionFastPath()
+    public async Task FinalRestParameter_NestedFunctionCapture_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function outer(prefix, ...items) {
+                function inner() {
+                    return items;
+                }
+
+                return inner();
+            }
+
+            outer(40, 1, 2).length;
+            """);
+
+        Assert.Equal(2d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=outer argc=3",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task FinalRestParameter_ComputedCallBody_UsesUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();
         var result = await engine.Evaluate("""
@@ -866,7 +889,7 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
             """);
 
         Assert.Equal(42d, result);
-        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(
                 "unified-bytecode-production-fast-path func=callFirst",
                 StringComparison.Ordinal));


### PR DESCRIPTION
## Summary
- remove the final-rest production-route limitation for programs that need a materialized activation environment
- bind final rest parameters as collected rest arrays in `CreateSimpleIrActivationEnvironment` so nested functions and call-boundary routes see the same value as VM slots
- update final-rest docs and convert the previous computed-call negative proof into a positive fast-path proof

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~Evaluate_FinalRestParameterPlan_Accepts|FullyQualifiedName~FinalRestParameter"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProduction"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests&FullyQualifiedName~UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ActivationSemanticsProofPackTests"
- rtk rg "EvaluateExpression\\(|ProfileEvaluateExpression\\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk git diff --check
- rtk ./tools/profile forloop --memory
