### PR TITLE
Admit simple literal default parameters to bytecode

### DIFF
--- a/docs/bytecode-progress.md
+++ b/docs/bytecode-progress.md
@@ -54,7 +54,7 @@ flowchart TB
     end
 
     subgraph RedRemaining["Needs handling before full bytecode execution"]
-        R1["Activation model gaps\nasync-like, broad generators, lexical-this arrows,\nreal arguments object, remaining non-simple params"]
+        R1["Activation model gaps\nasync-like, broad generators, lexical-this arrows,\nreal arguments object, remaining non-simple/default params"]
         R2["Wider call invocation\ncomplex receivers, keys, eval, private-adjacent targets,\nreceiver-binding-sensitive families"]
         R3["Dynamic lookup beyond admitted ordinary/direct-eval/with-backed lanes"]
         R4["Property and assignment neighbors\nricher computed keys, optional/super/private mutation,\nunsupported RHS spans"]

--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -386,8 +386,9 @@ predicates and proof tests.
   shapes, unsupported resumable opcodes, and unknown production opcode defaults.
 - Pre-gates: class constructor invokers outside bounded constructor routes;
   arrow functions whose lowered body still has an unowned dependency;
-  identifier-cache disabled outside ordinary/with-backed lanes; super
-  constructor/prototype state outside admitted paths.
+  non-literal default and destructured parameter expressions; identifier-cache
+  disabled outside ordinary/with-backed lanes; super constructor/prototype state
+  outside admitted paths.
 
 ### Eligibility Decline Rows
 
@@ -429,8 +430,8 @@ not always have a `UnifiedBytecodeProductionDeclineCode`.
 | `pre-gate:IsArrowFunction` | Arrow functions outside the admitted simple-return route whose lowered body proves no super, unadmitted call-target, nested function/class literal, or other unowned dependency. Captured lexical `this` / `new.target`, statically resolved flat-slot reads, ordinary environment identifier reads/calls, captured identifier assignment/compound assignment/update/delete, and named/computed property reads, simple property writes, compound/logical property writes, property updates, or property deletes from those dynamic identifier bases are VM-owned; lexical-this environments remain a separate pre-gate. | Existing arrow invocation route | Arrow route lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:IsAsyncLike` | Async and formerly-async ordinary invokers | Async route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_AsyncLikeActivation_DeclinesBeforePlanInspection"` |
 | `pre-gate:IsGenerator` | Generator functions before ordinary sync production routing | Generator route | Resumable async/generator lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_GeneratorActivation_DeclinesBeforePlanInspection"` |
-| `pre-gate:hasParameterExpressions` | Default and destructured parameter expressions; final rest identifier parameters are admitted when the surrounding activation is otherwise production-owned | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
-| `pre-gate:hasOnlySimpleIdentifierParameters` | Non-simple parameter lists outside the admitted final-rest identifier route | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
+| `pre-gate:hasParameterExpressions` | Default parameter expressions outside the admitted simple literal-default identifier route, plus destructured parameter expressions; final rest identifier parameters are admitted when the surrounding activation is otherwise production-owned | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
+| `pre-gate:hasOnlySimpleIdentifierParameters` | Non-simple parameter lists outside the admitted final-rest identifier and simple literal-default identifier routes | Existing parameter environment route | Parameter semantics lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:usesArguments` | Functions that read, assign, update, call, or `typeof` the real implicit `arguments` object through bounded identifier use; shadowing parameter/lexical `arguments` reads, `typeof`, assignments, updates, and calls are activation-slot traffic | Existing arguments-object route | Arguments object lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_CallImplicitArgumentsObject_AcceptsDynamicIdentifierCallTarget"` |
 | `pre-gate:needsArgumentsBinding` | Sloppy mapped arguments binding when an implicit arguments object is needed and not admitted by with-backed dynamic-name routing | Existing arguments-object route | Arguments object lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionInvocationTests"` |
 | `pre-gate:allowIdentifierCache` | Identifier cache disabled outside the ordinary and with-backed dynamic-name lanes, including the admitted mixed `with` plus outside ordinary dynamic-name path | Existing environment lookup route | Dynamic-name lane | `rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests&FullyQualifiedName~Evaluate_WithThenOutsideDynamicIdentifier_AcceptsMixedDynamicNameProgram"` |
@@ -890,8 +891,9 @@ support today.
    functions, generators, arrows needing lexical-this environments or super
    bindings, closure or dynamic identifier dependencies, or non-simple bodies,
    real `arguments` object and sloppy mapped-arguments dependencies, non-simple
-   parameter lists outside the admitted final-rest identifier route,
-   default/destructured parameter expressions, broader
+   parameter lists outside the admitted final-rest identifier and simple
+   literal-default identifier routes, non-literal default/destructured parameter
+   expressions, broader
    class constructor routes beyond simple base constructors and the bounded
    explicit derived `super(...)` path, default derived constructors, and captured
    activation outside the explicit with-backed

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -3381,8 +3381,11 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                 CanUseProductionUnifiedBytecodeImplicitArgumentsObjectReadPath(plan);
             var canUseFinalRestParameterPath =
                 CanUseProductionUnifiedBytecodeFinalRestParameterPath();
+            var canUseSimpleLiteralDefaultParameterPath =
+                CanUseProductionUnifiedBytecodeSimpleLiteralDefaultParameterPath();
             var hasAdmittedParameterShape =
                 _hasOnlySimpleIdentifierParameters ||
+                canUseSimpleLiteralDefaultParameterPath ||
                 canUseFinalRestParameterPath ||
                 _function.IsDefaultDerivedConstructor && canUseDerivedClassConstructorPath;
             var activation = CreateProductionUnifiedBytecodeActivationDescriptor(
@@ -3397,7 +3400,7 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                     activation,
                     out _,
                     out _) ||
-                _hasParameterExpressions ||
+                _hasParameterExpressions && !canUseSimpleLiteralDefaultParameterPath ||
                 !hasAdmittedParameterShape ||
                 !_instanceFields.IsDefaultOrEmpty &&
                 !canUseDerivedClassConstructorPath &&
@@ -3516,12 +3519,63 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                     }
                     else
                     {
-                        value = i < arguments.Count ? arguments[i] : JsValue.Undefined;
+                        value = GetProductionUnifiedBytecodeParameterValue(
+                            arguments,
+                            i,
+                            hasFinalRestParameter,
+                            finalRestParameterIndex);
                     }
 
                     slots[parameterSlotIndex] = value;
                 }
             }
+        }
+
+        private bool CanUseProductionUnifiedBytecodeSimpleLiteralDefaultParameterPath()
+        {
+            return !IsClassConstructor &&
+                   !IsArrowFunction &&
+                   !IsAsyncLike &&
+                   !_function.IsGenerator &&
+                   !_function.IsDefaultDerivedConstructor &&
+                   _hasParameterExpressions &&
+                   !_usesArguments &&
+                   !_needsArgumentsBinding &&
+                   _allowIdentifierCache &&
+                   _lexicalThisEnvironment is null &&
+                   _homeObject is null &&
+                   PrivateNameScope is null &&
+                   _capturedPrivateNameScopes.IsDefaultOrEmpty &&
+                   _superConstructor is null &&
+                   _superPrototype is null &&
+                   _instanceFields.IsDefaultOrEmpty &&
+                   HasOnlySimpleIdentifierOrLiteralDefaultParameters();
+        }
+
+        private bool HasOnlySimpleIdentifierOrLiteralDefaultParameters()
+        {
+            var sawLiteralDefault = false;
+            foreach (var parameter in _function.Parameters)
+            {
+                if (parameter is not { IsRest: false, Pattern: null, Name: not null })
+                {
+                    return false;
+                }
+
+                if (parameter.DefaultValue is null)
+                {
+                    continue;
+                }
+
+                if (parameter.DefaultValue is not LiteralExpression)
+                {
+                    return false;
+                }
+
+                sawLiteralDefault = true;
+            }
+
+            return sawLiteralDefault;
         }
 
         private bool CanUseProductionUnifiedBytecodeFinalRestParameterPath()
@@ -3789,8 +3843,8 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                    !IsAsyncLike &&
                    !_function.IsGenerator &&
                    !_function.IsDefaultDerivedConstructor &&
-                   !_hasParameterExpressions &&
-                   _hasOnlySimpleIdentifierParameters &&
+                   (!_hasParameterExpressions && _hasOnlySimpleIdentifierParameters ||
+                    CanUseProductionUnifiedBytecodeSimpleLiteralDefaultParameterPath()) &&
                    !_usesArguments &&
                    !_needsArgumentsBinding &&
                    _allowIdentifierCache &&
@@ -4455,11 +4509,11 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
             {
                 for (var i = 0; i < _parameterNames.Length; i++)
                 {
-                    var value = hasFinalRestParameter && i == finalRestParameterIndex
-                        ? CreateRestArguments(arguments, finalRestParameterIndex)
-                        : i < arguments.Count
-                            ? arguments[i]
-                            : JsValue.Undefined;
+                    var value = GetProductionUnifiedBytecodeParameterValue(
+                        arguments,
+                        i,
+                        hasFinalRestParameter,
+                        finalRestParameterIndex);
                     executionEnvironment.DefineParameterFast(_parameterNames[i], value);
                 }
 
@@ -4468,13 +4522,48 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
 
             for (var i = 0; i < _parameterNames.Length; i++)
             {
-                var value = hasFinalRestParameter && i == finalRestParameterIndex
-                    ? CreateRestArguments(arguments, finalRestParameterIndex)
-                    : i < arguments.Count
-                        ? arguments[i]
-                        : JsValue.Undefined;
+                var value = GetProductionUnifiedBytecodeParameterValue(
+                    arguments,
+                    i,
+                    hasFinalRestParameter,
+                    finalRestParameterIndex);
                 executionEnvironment.SetSlotDirect(parameterSlotIndices[i], value);
             }
+        }
+
+        private JsValue GetProductionUnifiedBytecodeParameterValue<TArgs>(
+            TArgs arguments,
+            int parameterIndex,
+            bool hasFinalRestParameter,
+            int finalRestParameterIndex)
+            where TArgs : IReadOnlyList<JsValue>
+        {
+            if (hasFinalRestParameter && parameterIndex == finalRestParameterIndex)
+            {
+                return CreateRestArguments(arguments, finalRestParameterIndex);
+            }
+
+            var value = parameterIndex < arguments.Count ? arguments[parameterIndex] : JsValue.Undefined;
+            if (value.IsUndefined &&
+                TryGetSimpleLiteralDefaultParameterValue(parameterIndex, out var defaultValue))
+            {
+                return defaultValue;
+            }
+
+            return value;
+        }
+
+        private bool TryGetSimpleLiteralDefaultParameterValue(int parameterIndex, out JsValue value)
+        {
+            if ((uint)parameterIndex < (uint)_function.Parameters.Length &&
+                _function.Parameters[parameterIndex].DefaultValue is LiteralExpression literal)
+            {
+                value = literal.Value;
+                return true;
+            }
+
+            value = JsValue.Undefined;
+            return false;
         }
 
         private void BindDefaultDerivedConstructorRestParameter<TArgs>(

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -405,6 +405,25 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
     }
 
     [Fact]
+    public void Evaluate_SimpleLiteralDefaultParameterPlan_Accepts()
+    {
+        var plan = GetFunctionPlan("""
+            function pick(value = 42) {
+                return value;
+            }
+            """,
+            "pick");
+
+        var result = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(result.IsEligible, result.Reason);
+        Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        Assert.False(result.Program.ParameterSlotIndices.IsDefaultOrEmpty);
+    }
+
+    [Fact]
     public void Evaluate_ClassDeclarationInstruction_AcceptsDescriptorOpcode()
     {
         var plan = GetFunctionPlan("""

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -896,6 +896,106 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
+    public async Task SimpleLiteralDefaultParameter_MissingArgument_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function pick(value = 42) {
+                return value;
+            }
+
+            pick();
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=pick argc=0",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task SimpleLiteralDefaultParameter_ExplicitUndefined_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function pick(value = 42) {
+                return value;
+            }
+
+            pick(undefined);
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=pick argc=1",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task SimpleLiteralDefaultParameter_ProvidedArgument_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function pick(value = 42) {
+                return value;
+            }
+
+            pick(7);
+            """);
+
+        Assert.Equal(7d, result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=pick argc=1",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task SimpleStringDefaultParameter_NestedFunctionCapture_UsesUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function outer(value = "fallback") {
+                function inner() {
+                    return value;
+                }
+
+                return inner();
+            }
+
+            outer();
+            """);
+
+        Assert.Equal("fallback", result);
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=outer argc=0",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task NonLiteralDefaultParameter_DoesNotUseUnifiedBytecodeProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            var fallback = 42;
+            function pick(value = fallback) {
+                return value;
+            }
+
+            pick();
+            """);
+
+        Assert.Equal(42d, result);
+        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                "unified-bytecode-production-fast-path func=pick",
+                StringComparison.Ordinal));
+    }
+
+    [Fact(Timeout = 5000)]
     public async Task WithDynamicIdentifierOperations_UseUnifiedBytecodeProductionFastPath()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary
- admit ordinary sync functions with simple literal default identifier parameters to production unified bytecode
- initialize literal defaults directly into VM slots and materialized activation environments
- keep non-literal/default-expression parameter initializers on the existing fallback route
- update the bytecode expansion docs for the narrowed parameter pre-gate

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~SimpleLiteralDefaultParameter|FullyQualifiedName~SimpleStringDefaultParameter|FullyQualifiedName~NonLiteralDefaultParameter|FullyQualifiedName~Evaluate_SimpleLiteralDefaultParameterPlan_Accepts"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProduction"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests&FullyQualifiedName~UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums"
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ActivationSemanticsProofPackTests"
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner*
- rtk git diff --check
- rtk ./tools/profile forloop --memory