### PR TITLE
Prefer bytecode for simple sync activation

### DIFF
--- a/docs/bytecode-progress.md
+++ b/docs/bytecode-progress.md
@@ -43,7 +43,7 @@ flowchart TB
     AstBridge --> Result
 
     subgraph GreenHandled["Handled production-bytecode areas"]
-        G1["Accepted ordinary sync functions route to VM before generic IR"]
+        G1["Accepted ordinary sync functions route to VM before simple IR and generic IR"]
         G2["Unified opcode inventory has VM switch coverage"]
         G3["General expression lowering gaps: none"]
         G4["Direct slot/literal/binary/control flow and loop shapes"]
@@ -100,6 +100,7 @@ is removed, or a proof gate becomes stricter.
 
 | Date | Gate surface | Concrete movement | Proof signal |
 |---|---|---|---|
+| 2026-06-02 | Ordinary sync simple-return / simple-binary route priority | Simple literal returns, simple parameter returns, parameter binary returns, and parameter binary-chain returns now defer their old caller-level and simple-IR shortcuts when the cached plan is production-bytecode eligible. The production VM is now attempted before `simple-ir-parameter-*`, `simple-ir-return-*`, `SyncIrCallTrampoline`, and generic `ExecutionPlanRunner` for admitted ordinary sync functions. | Activation proof pack now asserts production unified-bytecode route logs for simple literal, parameter, binary, and binary-chain functions; source gate locks production VM before simple IR fallbacks; route-hit probes moved `activation-noargs-lite` and `functioncalls-lite` out of the zero-hit bucket. |
 | 2026-06-02 | `PropertyReadBoundaryOutOfScope` inside `CallInvocationBoundary` | Identifier and named-member calls now keep production unified bytecode when argument values are simple named or computed property-read spans, for example `fn(box.value)`, `fn(box["value"])`, and `sink.add(box.value)`. The call argument span walker and compiler now count and emit those reads as one logical argument instead of declining the property read before the call boundary. | Focused eligibility proof for `GetNamedProperty` / `GetComputedProperty` plus `CallInvocationBoundary`; runtime route-hit proof for identifier and named-member calls with property-read arguments. |
 | 2026-06-02 | `PropertyReadBoundaryOutOfScope` inside `SuperConstructInvocationBoundary` | Derived constructors now keep production unified bytecode when an admitted constructor parameter is read through a simple named or computed property inside `super(...)`, for example `constructor(values) { super(values.length); }`, `constructor(prefix, ...items) { super(items.length); }`, and `super(items["length"])`. The property-read op is now recognized as owned by the super-construct argument boundary instead of forcing the constructor back to the existing route. | Focused eligibility proof for `GetNamedProperty` / `GetComputedProperty` plus `SuperConstructInvocationBoundary`; runtime route-hit proof for `Derived` with `super(values.length)`, `super(items.length)`, and `super(items["length"])`. |
 | 2026-06-02 | `pre-gate:IsClassConstructor` plus derived-constructor parameter gates | Explicit derived class constructors now enter production unified bytecode with simple literal-default parameters and final-rest identifier parameters when the body is otherwise on the admitted `super(...)` route. Runtime-dependent derived-constructor defaults and destructured constructor parameters remain separately owned. | Focused derived-constructor route-hit and no-route tests; constructor proof pack; `UnifiedBytecodeProduction` pack. |
@@ -134,8 +135,8 @@ Current snapshot from local route-hit probes:
 | `forloop` | 20 | Green: ordinary sync loop/arithmetic VM route is active. |
 | `forofiteration` | 2000 | Green: admitted sync driver route is active. |
 | `propertyaccess` | 0 | Red: this profile did not enter the production VM. |
-| `functioncalls-lite` | 0 | Red: this profile did not enter the production VM. |
-| `activation-noargs-lite` | 0 | Red: this profile did not enter the production VM. |
+| `functioncalls-lite` | 1,600,000 | Green: simple ordinary function calls now route through production bytecode instead of the simple binary IR shortcuts. |
+| `activation-noargs-lite` | 600,000 | Green: simple literal-return activation now routes through production bytecode instead of the public simple-return shortcut. |
 
 Zero route hits do not necessarily mean the syntax family has no bytecode
 support. They mean the measured workload shape did not enter the production

--- a/docs/performance/unified-bytecode-branch-production-routing.md
+++ b/docs/performance/unified-bytecode-branch-production-routing.md
@@ -1,6 +1,7 @@
 # Unified Bytecode Production Routing Evidence
 
 Date: 2026-05-27
+Updated: 2026-06-02
 Issues: #2227 (initial direct-branch slice), #2243 (expanded control-flow boundary), Batch 5 plan proof run (`planitem-planmanual1779822558747978000-batch-1-production-eligibility-boundary-ba-a10f14eb22`)
 
 ## Current boundary summary
@@ -28,7 +29,7 @@ unsupported payloads/opcodes/operators.
 Command:
 
 ```bash
-rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_DirectBranchReturnPlan_Accepts|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_NestedDirectBranchReturnPlan_DeclinesAsPrototypeOnlyJumpIfFalse|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.DirectBranchReturnFunction_UsesUnifiedBytecodeProductionFastPathForTrueAndFalseOutcomes|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.BinaryReturnFunction_KeepsExistingSpecializedFastPath"
+rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_DirectBranchReturnPlan_Accepts|FullyQualifiedName~UnifiedBytecodeProductionEligibilityTests.Evaluate_NestedDirectBranchReturnPlan_DeclinesAsPrototypeOnlyJumpIfFalse|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.DirectBranchReturnFunction_UsesUnifiedBytecodeProductionFastPathForTrueAndFalseOutcomes|FullyQualifiedName~UnifiedBytecodeProductionInvocationTests.BinaryReturnFunction_UsesProductionUnifiedBytecodeBeforeSpecializedFastPath"
 ```
 
 Result:
@@ -39,8 +40,8 @@ This historical slice proved:
 
 - Direct `JumpIfFalse` branch-return eligibility is accepted.
 - Nested adjacent `JumpIfFalse` shape remains declined.
-- Invocation routes accepted branch-return through `unified-bytecode-production-fast-path` for both `pick(true)` and `pick(false)` while keeping `SyncIrCallTrampoline` priority intact.
-- Existing binary specialized fast path remains prioritized.
+- Invocation routes accepted branch-return through `unified-bytecode-production-fast-path` for both `pick(true)` and `pick(false)`.
+- The original 2026-05-27 slice kept the binary specialized fast path prioritized. That route priority is superseded as of 2026-06-02: production unified bytecode now runs before simple binary fallbacks for admitted ordinary sync plans.
 
 ## Batch 5 production proof pack (current evidence)
 

--- a/docs/performance/unified-bytecode-primary-sync-route-coverage.md
+++ b/docs/performance/unified-bytecode-primary-sync-route-coverage.md
@@ -1,7 +1,7 @@
 # Unified Bytecode Primary Sync Route Coverage
 
 Date: 2026-05-29
-Updated: 2026-06-01
+Updated: 2026-06-02
 Issues: #2634 (primary route boundary recording),
 `planitem-planmanual1780240661926543000-burn-down-unified-bytecode-production-decl-3df21bc582`
 (break/continue decline taxonomy cleanup)
@@ -9,7 +9,7 @@ Based on: ADR 0278 (Keep unified-bytecode ordinary sync primary route source-gat
 
 ## Coverage Summary
 
-For ordinary sync functions that pass both `CanUseProductionUnifiedBytecodeFastPath` and `UnifiedBytecodeProductionEligibility.Evaluate`, the unified-bytecode production VM is the primary default attempt before fallback routes.
+For ordinary sync functions that pass both `CanUseProductionUnifiedBytecodeFastPath` and `UnifiedBytecodeProductionEligibility.Evaluate`, the unified-bytecode production VM is the primary default attempt before simple IR shortcuts and fallback routes.
 
 ### Workload: propertyaccess
 
@@ -76,6 +76,10 @@ Evidence: See `docs/performance/unified-bytecode-branch-production-routing.md`.
 This document records route coverage for the accepted production boundary only.
 Coverage is 100% for expressions that pass production-eligibility gates.
 Unsupported expressions decline before VM execution and are not included in hit-rate calculation.
+Simple literal returns, simple parameter returns, and simple parameter binary or
+binary-chain returns are included in the accepted production boundary when their
+plans are otherwise production-bytecode eligible; their legacy simple-IR
+shortcuts now run only as fallbacks for non-eligible shapes.
 Break/continue-specific loop control is no longer an active decline bucket; admitted
 unlabeled and resolved labeled control flow routes through the compiler-owned jump
 target model, while unsupported driver-crossing labeled control flow remains covered

--- a/docs/rules/unified-bytecode-prototypes.md
+++ b/docs/rules/unified-bytecode-prototypes.md
@@ -686,15 +686,17 @@ all-or-nothing until a separate routing issue proves production readiness.
     owned opcodes, and assert absence of non-executable call-target preparation
     or invocation-boundary opcodes. The matching public invocation proof should
     assert `unified-bytecode-production-fast-path` on the same function and
-    expected JavaScript result. Keep direct specialized simple-return binary and
-    binary-chain shortcuts ahead of unified bytecode and assert that those
-    functions do not log the unified route. Do not add VM fallback or broaden
-    adjacent unowned families to make an integrated test pass. WHY: issue
+    expected JavaScript result. For admitted ordinary sync plans, keep
+    production unified bytecode ahead of direct specialized simple-return binary
+    and binary-chain shortcuts; those shortcuts are fallback paths only for
+    shapes that do not pass production bytecode eligibility. Do not add VM
+    fallback or broaden adjacent unowned families to make an integrated test
+    pass. WHY: issue
     `planitem-planmanual1779943568009120000-batch-1-shared-bytecode-surface-and-parall-fc03ae9db9`
     / PR #2503 closed the production-routing integration slice with a guard-only
     proof pack. The durable lesson was that per-lane acceptance is not enough:
     completed lanes must compose inside one VM-owned program while route
-    priority still protects older specialized fast paths.
+    priority explicitly protects the bytecode-first production boundary.
 31. Keep production unified-bytecode no-mixed-execution source gates both
     method-boundary-scoped and VM-scoped. The sync-invoker source gate should
     scan only `TryInvokeProductionUnifiedBytecode<TArgs>(...)`, because the
@@ -1588,11 +1590,14 @@ tests rather than runtime widening. The lesson is that the accepted surface must
 be proven both lane-by-lane and as an ordinary mixed program: literals, property
 reads/writes/updates, block lexical scopes, loop control, and primitive
 operations should compose as one `UnifiedBytecodeProgram` without non-executable
-call-boundary opcodes or fallback. The same slice also proved binary-chain
-simple returns still use their specialized fast path. WHY: without an
-integrated guard, future agents can have complete-looking per-lane coverage
-while an ordinary sync function either drifts into mixed execution or shadows a
-faster established route.
+call-boundary opcodes or fallback. That older slice proved binary-chain simple
+returns still used their specialized fast path; the later bytecode-only route
+work superseded that priority by making production unified bytecode run before
+the simple-return/simple-binary shortcuts whenever the plan is production
+eligible. WHY: without an integrated guard, future agents can have
+complete-looking per-lane coverage while an ordinary sync function either
+drifts into mixed execution or shadows the bytecode-first route with an older
+shortcut.
 
 Faktorial issue
 `planitem-planmanual1779943568009120000-batch-1-shared-bytecode-surface-and-parall-a88c0a9ba1`

--- a/docs/unified-bytecode-expansion-contract.md
+++ b/docs/unified-bytecode-expansion-contract.md
@@ -23,18 +23,18 @@ for assignment destructuring parity instead of falling back to expression or
 statement interpretation.
 
 ## Ordinary Sync Routing Boundary
-- Ordinary sync invocation keeps the dedicated simple-return binary and
-  binary-chain fast paths ahead of the broader production unified-bytecode
-  route, matching ADR 0258's route-priority contract.
 - For ordinary sync functions that pass both
   `CanUseProductionUnifiedBytecodeFastPath` and
   `UnifiedBytecodeProductionEligibility.Evaluate`, the production VM is the
-  primary default attempt before `SyncIrCallTrampoline` and generic
-  `ExecutionPlanRunner` interpretation.
+  primary default attempt before dedicated simple-return/simple-binary IR
+  shortcuts, `SyncIrCallTrampoline`, and generic `ExecutionPlanRunner`
+  interpretation. This supersedes ADR 0258's earlier route-priority contract
+  for admitted ordinary sync production shapes.
 - Current route coverage estimate: 100% of accepted ordinary sync production
-  programs attempt `UnifiedBytecodeVirtualMachine` before generic IR fallback.
-  This is a selector coverage estimate, not a full ECMAScript function-surface
-  claim; unsupported buckets below remain pre-VM declines.
+  programs attempt `UnifiedBytecodeVirtualMachine` before simple IR shortcuts
+  and generic IR fallback. This is a selector coverage estimate, not a full
+  ECMAScript function-surface claim; unsupported buckets below remain pre-VM
+  declines.
 
 - Coverage evidence: `docs/performance/unified-bytecode-primary-sync-route-coverage.md`
 

--- a/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
+++ b/src/Asynkron.JsEngine/Ast/TypedAstEvaluator.SyncFunctionInvoker.cs
@@ -927,6 +927,11 @@ public static partial class TypedAstEvaluator
             out JsValue result)
         {
             result = JsValue.Undefined;
+            if (ShouldDeferSimpleIrFastPathToProductionUnifiedBytecode(newTarget))
+            {
+                return false;
+            }
+
             if ((!_hasSimpleReturnLiteralFastPath && !_hasSimpleReturnParameterNoArgsFastPath) ||
                 !newTarget.IsUndefined ||
                 IsClassConstructor ||
@@ -1543,6 +1548,11 @@ TryCreateSimpleNumericSelfRecursionFastPath(
                 return false;
             }
 
+            if (ShouldDeferSimpleIrFastPathToProductionUnifiedBytecode(JsValue.Undefined))
+            {
+                return false;
+            }
+
             RealmState.Logger?.LogInformation(
                 "simple-ir-parameter-number-binary-fast-path func={Function}",
                 _function.Name?.Name ?? "<anonymous>");
@@ -1600,6 +1610,11 @@ TryCreateSimpleNumericSelfRecursionFastPath(
                     arg2,
                     _simpleReturnParameterBinaryChainFastPath.ThirdParameterIndex,
                     out var third))
+            {
+                return false;
+            }
+
+            if (ShouldDeferSimpleIrFastPathToProductionUnifiedBytecode(JsValue.Undefined))
             {
                 return false;
             }
@@ -2740,6 +2755,12 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
         {
             result = JsValue.Undefined;
 
+            if (CanUseProductionUnifiedBytecodeFastPath(plan, newTarget) &&
+                TryInvokeProductionUnifiedBytecode(arguments, thisValue, newTarget, plan, context, callingContext, out result))
+            {
+                return true;
+            }
+
             var canUseSimpleIrActivationFastPath = CanUseSimpleIrActivationFastPath(plan, newTarget);
             if (canUseSimpleIrActivationFastPath &&
                 plan.SimpleReturnParameterBinary is { } parameterBinary)
@@ -2771,12 +2792,6 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
 
                 result = EvaluateSimpleReturnParameterBinaryChain(arguments, parameterBinaryChain, context);
                 return TryCompleteIrFastExpressionResult(context, callingContext, ref result);
-            }
-
-            if (CanUseProductionUnifiedBytecodeFastPath(plan, newTarget) &&
-                TryInvokeProductionUnifiedBytecode(arguments, thisValue, newTarget, plan, context, callingContext, out result))
-            {
-                return true;
             }
 
             if (SyncIrCallTrampoline.TryInvoke(
@@ -2859,6 +2874,24 @@ isLexicalBinding: true, blocksFunctionScopeOverride: true);
                 // activation environments created above are owned by this fast path.
                 ReturnSimpleIrActivationEnvironment(executionEnvironment);
             }
+        }
+
+        [MethodImpl(JsEngineConstants.Inlining)]
+        private bool ShouldDeferSimpleIrFastPathToProductionUnifiedBytecode(JsValue newTarget)
+        {
+            if (_planSeed.Plan is not { } plan ||
+                plan.IsProductionEligibilityPermanentDecline)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(_unifiedBytecodeProductionEligibilityPlan, plan) &&
+                _unifiedBytecodeProductionEligibility != UnifiedBytecodeEligibilityUnknown)
+            {
+                return _unifiedBytecodeProductionEligibility == UnifiedBytecodeEligibilityAccepted;
+            }
+
+            return CanUseProductionUnifiedBytecodeFastPath(plan, newTarget);
         }
 
         private bool TryInvokeSimpleDerivedClassConstructorFastPath<TArgs>(

--- a/tests/Asynkron.JsEngine.Tests/ActivationSemanticsProofPackTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/ActivationSemanticsProofPackTests.cs
@@ -42,7 +42,7 @@ public sealed class ActivationSemanticsProofPackTests(ITestOutputHelper output) 
     }
 
     [Fact(Timeout = 5000)]
-    public async Task SimpleReturnFunction_NumberArgumentsUseCallerBinaryFastPath()
+    public async Task SimpleReturnFunction_NumberArgumentsUseProductionUnifiedBytecode()
     {
         await using var engine = CreateEngine();
         var result = await engine.Evaluate("""
@@ -56,16 +56,18 @@ public sealed class ActivationSemanticsProofPackTests(ITestOutputHelper output) 
         Assert.Equal(42d, result);
         Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(SimpleIrActivationFastPathLog, StringComparison.Ordinal));
-        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(SimpleIrParameterNumberBinaryFastPathLog, StringComparison.Ordinal));
         Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(SimpleIrParameterBinaryFastPathLog, StringComparison.Ordinal));
         Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(SimpleIrReturnFastPathLog, StringComparison.Ordinal));
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(UnifiedBytecodeProductionFastPathLog, StringComparison.Ordinal));
     }
 
     [Fact(Timeout = 5000)]
-    public async Task SimpleReturnFunction_NumberParameterBinaryChainUsesCallerFastPath()
+    public async Task SimpleReturnFunction_NumberParameterBinaryChainUsesProductionUnifiedBytecode()
     {
         await using var engine = CreateEngine();
         var result = await engine.Evaluate("""
@@ -79,16 +81,18 @@ public sealed class ActivationSemanticsProofPackTests(ITestOutputHelper output) 
         Assert.Equal(42d, result);
         Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(SimpleIrActivationFastPathLog, StringComparison.Ordinal));
-        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(
                 SimpleIrParameterNumberBinaryChainFastPathLog,
                 StringComparison.Ordinal));
         Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(SimpleIrParameterBinaryChainFastPathLog, StringComparison.Ordinal));
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(UnifiedBytecodeProductionFastPathLog, StringComparison.Ordinal));
     }
 
     [Fact(Timeout = 5000)]
-    public async Task SimpleReturnFunction_CoercingParameterBinaryChainUsesIrFastPath()
+    public async Task SimpleReturnFunction_CoercingParameterBinaryChainUsesProductionUnifiedBytecode()
     {
         await using var engine = CreateEngine();
         var result = await engine.Evaluate("""
@@ -106,8 +110,10 @@ public sealed class ActivationSemanticsProofPackTests(ITestOutputHelper output) 
             static record => record.Message.Contains(
                 SimpleIrParameterNumberBinaryChainFastPathLog,
                 StringComparison.Ordinal));
-        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(SimpleIrParameterBinaryChainFastPathLog, StringComparison.Ordinal));
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(UnifiedBytecodeProductionFastPathLog, StringComparison.Ordinal));
     }
 
     [Fact(Timeout = 5000)]
@@ -131,13 +137,14 @@ public sealed class ActivationSemanticsProofPackTests(ITestOutputHelper output) 
             """);
 
         Assert.Equal("42:1", result);
-        // Non-number args bypass the precomputed numeric path but use the general binary parameter path.
         Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(SimpleIrActivationFastPathLog, StringComparison.Ordinal));
         Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(SimpleIrParameterNumberBinaryFastPathLog, StringComparison.Ordinal));
-        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(SimpleIrParameterBinaryFastPathLog, StringComparison.Ordinal));
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(UnifiedBytecodeProductionFastPathLog, StringComparison.Ordinal));
     }
 
     [Fact(Timeout = 5000)]
@@ -167,7 +174,7 @@ public sealed class ActivationSemanticsProofPackTests(ITestOutputHelper output) 
     }
 
     [Fact(Timeout = 5000)]
-    public async Task SimpleReturnLiteralFunction_UsesLiteralFastPath()
+    public async Task SimpleReturnLiteralFunction_UsesProductionUnifiedBytecode()
     {
         await using var engine = CreateEngine();
         var result = await engine.Evaluate("""
@@ -181,10 +188,14 @@ public sealed class ActivationSemanticsProofPackTests(ITestOutputHelper output) 
         Assert.Equal(1d, result);
         Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(SimpleIrActivationFastPathLog, StringComparison.Ordinal));
+        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(SimpleIrReturnFastPathLog, StringComparison.Ordinal));
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(UnifiedBytecodeProductionFastPathLog, StringComparison.Ordinal));
     }
 
     [Fact(Timeout = 5000)]
-    public async Task SimpleReturnParameterFunction_NoArguments_UsesNoArgsReturnFastPath()
+    public async Task SimpleReturnParameterFunction_NoArguments_UsesProductionUnifiedBytecode()
     {
         await using var engine = CreateEngine();
         var result = await engine.Evaluate("""
@@ -196,10 +207,12 @@ public sealed class ActivationSemanticsProofPackTests(ITestOutputHelper output) 
             """);
 
         Assert.Equal(Asynkron.JsEngine.Ast.Symbol.Undefined, result);
-        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+        Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(SimpleIrReturnFastPathLog, StringComparison.Ordinal));
         Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains(SimpleIrActivationFastPathLog, StringComparison.Ordinal));
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(UnifiedBytecodeProductionFastPathLog, StringComparison.Ordinal));
     }
 
     [Fact(Timeout = 5000)]
@@ -217,6 +230,8 @@ public sealed class ActivationSemanticsProofPackTests(ITestOutputHelper output) 
         Assert.Equal(42d, result);
         Assert.DoesNotContain(CurrentLogger!.Collector.Snapshot(),
             static record => record.Message.Contains("simple-ir-return-fast-path func=probe argc=0", StringComparison.Ordinal));
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(UnifiedBytecodeProductionFastPathLog, StringComparison.Ordinal));
     }
 
     [Theory(Timeout = 5000)]

--- a/tests/Asynkron.JsEngine.Tests/ExpressionProgramCoverageMapTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/ExpressionProgramCoverageMapTests.cs
@@ -77,7 +77,7 @@ public sealed class ExpressionProgramCoverageMapTests
             "Evaluate_LinearSlotLiteralReturnPlan_Accepts",
             "Execute_LinearSlotLiteralReturnPlan_ReturnsSlotValueInProductionVm",
             "LinearSlotReturnFunction_UsesUnifiedBytecodeProductionFastPath",
-            "BinaryReturnFunction_KeepsExistingSpecializedFastPath",
+            "NonLiteralDefaultParameter_DoesNotUseUnifiedBytecodeProductionFastPath",
             "SourceGate_ProductionUnifiedBytecodeAcceptedPath_DoesNotDelegateToAstOrExecutionPlanRunner")
     ];
 

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionInvocationTests.cs
@@ -2211,7 +2211,7 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact(Timeout = 5000)]
-    public async Task BinaryReturnFunction_KeepsExistingSpecializedFastPath()
+    public async Task BinaryReturnFunction_UsesProductionUnifiedBytecodeBeforeSpecializedFastPath()
     {
         await using var engine = CreateEngine();
         var result = await engine.Evaluate("""
@@ -2224,14 +2224,14 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
 
         var logRecords = CurrentLogger!.Collector.Snapshot();
         Assert.Equal(42d, result);
-        Assert.DoesNotContain(logRecords,
-            static record => record.Message.Contains(UnifiedBytecodeProductionFastPathLog, StringComparison.Ordinal));
         Assert.Contains(logRecords,
+            static record => record.Message.Contains(UnifiedBytecodeProductionFastPathLog, StringComparison.Ordinal));
+        Assert.DoesNotContain(logRecords,
             static record => record.Message.Contains(SimpleIrParameterNumberBinaryFastPathLog, StringComparison.Ordinal));
     }
 
     [Fact(Timeout = 5000)]
-    public async Task BinaryChainReturnFunction_KeepsExistingSpecializedFastPath()
+    public async Task BinaryChainReturnFunction_UsesProductionUnifiedBytecodeBeforeSpecializedFastPath()
     {
         await using var engine = CreateEngine();
         var result = await engine.Evaluate("""
@@ -2244,9 +2244,9 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
 
         var logRecords = CurrentLogger!.Collector.Snapshot();
         Assert.Equal(42d, result);
-        Assert.DoesNotContain(logRecords,
-            static record => record.Message.Contains(UnifiedBytecodeProductionFastPathLog, StringComparison.Ordinal));
         Assert.Contains(logRecords,
+            static record => record.Message.Contains(UnifiedBytecodeProductionFastPathLog, StringComparison.Ordinal));
+        Assert.DoesNotContain(logRecords,
             static record => record.Message.Contains(SimpleIrParameterNumberBinaryChainFastPathLog, StringComparison.Ordinal));
     }
 
@@ -7254,7 +7254,7 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
     }
 
     [Fact]
-    public void SourceGate_OrdinarySyncRouteAttemptsProductionUnifiedBytecodeBeforeGenericIr()
+    public void SourceGate_OrdinarySyncRouteAttemptsProductionUnifiedBytecodeBeforeSimpleIr()
     {
         var repositoryRoot = FindRepositoryRootForSourceGate();
         var invokerPath = Path.Combine(
@@ -7291,17 +7291,17 @@ public sealed class UnifiedBytecodeProductionInvocationTests(ITestOutputHelper o
         var genericRunnerIndex = routeSource.IndexOf("new ExecutionPlanRunner(", StringComparison.Ordinal);
 
         Assert.True(
-            binaryFastPathIndex >= 0,
-            "Simple binary fast path is missing from the ordinary sync route.");
+            unifiedBytecodeIndex >= 0,
+            "Production unified bytecode is missing from the ordinary sync route.");
+        Assert.True(
+            binaryFastPathIndex > unifiedBytecodeIndex,
+            "Production unified bytecode should be attempted before the simple binary fast path.");
         Assert.True(
             binaryChainFastPathIndex > binaryFastPathIndex,
             "Binary-chain fast path should stay after the simple binary fast path.");
         Assert.True(
-            unifiedBytecodeIndex > binaryChainFastPathIndex,
-            "Production unified bytecode should stay behind the specialized simple-return fast paths.");
-        Assert.True(
-            syncIrTrampolineIndex > unifiedBytecodeIndex,
-            "Production unified bytecode should be attempted before SyncIrCallTrampoline.");
+            syncIrTrampolineIndex > binaryChainFastPathIndex,
+            "SyncIrCallTrampoline should stay behind production unified bytecode and simple binary fallbacks.");
         Assert.True(
             genericRunnerIndex > syncIrTrampolineIndex,
             "Generic ExecutionPlanRunner fallback should stay after production unified bytecode and SyncIrCallTrampoline.");


### PR DESCRIPTION
## Summary
- route production unified bytecode before simple-return/simple-binary IR shortcuts for eligible ordinary sync functions
- update activation and production proof tests to assert bytecode-first routing for simple literal, parameter, binary, and binary-chain returns
- update bytecode progress and route-priority docs with verified route-hit numbers

## Verification
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ActivationSemanticsProofPackTests" -- xUnit.MaxParallelThreads=1 -timeout 20000
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~UnifiedBytecodeProduction" -- xUnit.MaxParallelThreads=1 -timeout 20000
- rtk dotnet test tests/Asynkron.JsEngine.Tests --filter "FullyQualifiedName~ExpressionProgramCoverageMapTests&FullyQualifiedName~UnifiedBytecodeExpansionContract_ListsRequiredHeadingsAndCurrentEnums" -- xUnit.MaxParallelThreads=1 -timeout 20000
- rtk ./tools/profile activation-noargs-lite --route-hits (600000 hits)
- rtk ./tools/profile functioncalls-lite --route-hits (1600000 hits)
- rtk rg "EvaluateExpression\(|ProfileEvaluateExpression\(" src/Asynkron.JsEngine/Ast/TypedAstEvaluator.ExecutionPlanRunner* (no matches)
- rtk git diff --check
- rtk ./tools/profile forloop --memory (6.85 MB)