### PR TITLE
Propagate unhandled top-level throws on the production bytecode script path

### DIFF
--- a/src/Asynkron.JsEngine/Ast/Legacy/StatementNodeExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/Legacy/StatementNodeExtensions.cs
@@ -2596,6 +2596,20 @@ public static partial class TypedAstEvaluator
                 thisValue,
                 JsValue.Undefined,
                 executionEnvironment.IsStrict);
+
+            // The VM records an unhandled top-level throw in the context rather than
+            // raising it, returning JsValue.Undefined as the completion value. The IR
+            // script path (ExecutionPlanRunner.RunScript) surfaces such throws as a
+            // ThrowSignal exception, which JsEngine.Evaluate translates into a faulted
+            // task. Mirror that contract so const-reassignment TypeErrors and any other
+            // top-level throws are not silently swallowed on the bytecode fast path.
+            if (context.IsThrow)
+            {
+                var thrownValue = context.FlowValue;
+                context.Clear();
+                throw new ThrowSignal(thrownValue);
+            }
+
             return true;
         }
         finally

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionScriptThrowTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionScriptThrowTests.cs
@@ -1,0 +1,60 @@
+using Xunit.Abstractions;
+
+namespace Asynkron.JsEngine.Tests;
+
+/// <summary>
+/// Regression tests guarding that unhandled top-level throws still propagate when an admitted
+/// script runs through the production unified-bytecode VM. The VM records an unhandled throw in
+/// the evaluation context and returns <c>undefined</c> as the completion value; the script
+/// admission wrapper must re-raise it so behaviour matches the IR script path. See the script
+/// fast-path in <c>TryRunScriptViaProductionUnifiedBytecode</c>.
+/// </summary>
+[Category(TestCategories.RuntimeSemantics)]
+public sealed class UnifiedBytecodeProductionScriptThrowTests(ITestOutputHelper output)
+    : InternalTestBase(output)
+{
+    private const string ProductionScriptFastPathLog = "unified-bytecode-production-fast-path script";
+
+    [Fact(Timeout = 5000)]
+    public async Task ConstReassignment_TopLevelScript_ThrowsTypeErrorOnProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+
+        var program = engine.ParseProgram("""
+            const value = 1;
+            value = 2;
+            """);
+
+        var error = await Assert.ThrowsAsync<ThrowSignal>(async () => await engine.Evaluate(program));
+        Assert.Contains("constant variable", error.Message, StringComparison.Ordinal);
+        AssertRanOnProductionScriptFastPath();
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task ThrowStatement_TopLevelScript_PropagatesOnProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+
+        var error = await Assert.ThrowsAsync<ThrowSignal>(async () => await engine.Evaluate("throw 42;"));
+        Assert.Contains("42", error.Message, StringComparison.Ordinal);
+        AssertRanOnProductionScriptFastPath();
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task NullPropertyAccess_TopLevelScript_ThrowsTypeErrorOnProductionFastPath()
+    {
+        await using var engine = CreateEngine();
+
+        var error = await Assert.ThrowsAsync<ThrowSignal>(async () => await engine.Evaluate("null.x;"));
+        Assert.Contains("null or undefined", error.Message, StringComparison.Ordinal);
+        AssertRanOnProductionScriptFastPath();
+    }
+
+    private void AssertRanOnProductionScriptFastPath()
+    {
+        Assert.Contains(CurrentLogger!.Collector.Snapshot(),
+            static record => record.Message.Contains(
+                ProductionScriptFastPathLog,
+                StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Problem

Admitted top-level scripts routed through the unified bytecode VM (PRs #3081/#3083/#3084) silently swallowed unhandled throws. The VM records an unhandled top-level throw in the `EvaluationContext` and returns `JsValue.Undefined` as the completion value, but `TryRunScriptViaProductionUnifiedBytecode` returned that value without re-checking `context.IsThrow`.

This dropped:
- `const value = 1; value = 2;` → should throw `TypeError: Assignment to constant variable`
- `throw 42;`
- runtime errors like `null.x;` and calls to undefined globals

The IR script path (`ExecutionPlanRunner.RunScript`) correctly surfaces all of these as a `ThrowSignal`, which `JsEngine.Evaluate` translates into a faulted task. The VM script path did not.

## Fix

After `UnifiedBytecodeVirtualMachine.Execute` returns, re-raise a pending context throw as a `ThrowSignal`, mirroring the IR contract and the function-VM pattern in `TryCompleteIrFastExpressionResult`.

## Tests

- Fixes `ExpressionProgramLoweringTests.ScriptExpressionStatement_ImmutableIdentifierAssignment_StillBuildsIrPlan` (failing on main).
- Adds `UnifiedBytecodeProductionScriptThrowTests` — 3 regression tests (const reassignment, `throw`, null property access) that assert propagation **and** verify the script ran on the production bytecode fast path via the log marker.
- Full internal suite green except 2 pre-existing, unrelated failures (`PrefixIncrementDebugTests.*OnObjectWithValueOf*`, confirmed failing on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)