### PR TITLE
Treat computed '#'-string keys as ordinary properties (not private members)

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeVirtualMachine.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeVirtualMachine.cs
@@ -1263,7 +1263,18 @@ internal static class UnifiedBytecodeVirtualMachine
                         return StopWithDriverCleanup(slots, slotEnvironments, context, context.IsThrow);
                     }
 
-                    SetPropertyValue(computedSetTarget, computedSetName, computedPropertyValue, context, isStrict);
+                    // Computed property assignment (`obj[key] = value`) is always an ordinary
+                    // property set. A string key that happens to start with '#' (e.g.
+                    // `obj["#x"]`) is an ordinary property, not a private member, so private
+                    // resolution must stay disabled — matching the IR runner's
+                    // ApplyProgramComputedPropertyAssignment (allowPrivate: false).
+                    SetPropertyValue(
+                        computedSetTarget,
+                        computedSetName,
+                        computedPropertyValue,
+                        context,
+                        isStrict,
+                        allowPrivate: false);
                     if (context.ShouldStopEvaluation)
                     {
                         if (TryHandleCurrentContextThrow(slots))
@@ -1417,13 +1428,16 @@ internal static class UnifiedBytecodeVirtualMachine
                         return StopWithDriverCleanup(slots, slotEnvironments, context, context.IsThrow);
                     }
 
+                    // Computed property update (`obj[key]++`) is an ordinary property update;
+                    // a '#'-prefixed string key is an ordinary property, not a private member.
                     ReplaceTopValue(UpdatePropertyValue(
                         computedUpdateTarget,
                         computedUpdateName,
                         DecodeIsIncrement(instruction.Operand),
                         DecodeIsPrefix(instruction.Operand),
                         context,
-                        isStrict));
+                        isStrict,
+                        allowPrivate: false));
                     if (context.ShouldStopEvaluation)
                     {
                         if (TryHandleCurrentContextThrow(slots))
@@ -6884,14 +6898,15 @@ internal static class UnifiedBytecodeVirtualMachine
         string propertyName,
         JsValue propertyValue,
         EvaluationContext context,
-        bool isStrict)
+        bool isStrict,
+        bool allowPrivate = true)
     {
         var handle = PropertyHandle.Resolve(
             target,
             propertyName,
             context,
             context.CurrentScope.IsStrict || isStrict,
-            allowPrivate: true);
+            allowPrivate: allowPrivate);
         handle.SetValue(propertyValue);
     }
 
@@ -7107,14 +7122,15 @@ internal static class UnifiedBytecodeVirtualMachine
         bool isIncrement,
         bool isPrefix,
         EvaluationContext context,
-        bool isStrict)
+        bool isStrict,
+        bool allowPrivate = true)
     {
         var handle = PropertyHandle.Resolve(
             target,
             propertyName,
             context,
             context.CurrentScope.IsStrict || isStrict,
-            allowPrivate: true);
+            allowPrivate: allowPrivate);
         var currentValue = handle.GetJsValue();
         if (context.ShouldStopEvaluation)
         {

--- a/tests/Asynkron.JsEngine.Tests/StaticClassFieldsTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/StaticClassFieldsTests.cs
@@ -303,6 +303,31 @@ public sealed class StaticClassFieldsTests(ITestOutputHelper output) : InternalT
     }
 
     [Fact(Timeout = 2000)]
+    public async Task ComputedHashStringKey_TreatedAsOrdinaryProperty_AcrossSetUpdateDelete()
+    {
+        // A computed member access with a '#'-prefixed STRING key (`obj["#x"]`) is an
+        // ordinary property, NOT a private member. The production VM must not route the
+        // computed set/update/compound/delete paths through private resolution.
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function run(o) {
+                o["#x"] = 1;        // SetComputedProperty
+                o["#x"] += 4;       // GetComputedPropertyForCompoundSet + SetComputedProperty
+                o["#x"]++;          // update
+                var read = o["#x"]; // GetComputedProperty
+                var deleted = delete o["#x"];
+                return [read, deleted, ("#x" in o)];
+            }
+            run({});
+            """);
+
+        var array = Assert.IsType<JsTypes.JsArray>(result);
+        Assert.Equal(6d, array.Items[0].NumberValue); // 1 + 4, then ++ => 6
+        Assert.True(array.Items[1].AsBoolean());       // delete succeeded
+        Assert.False(array.Items[2].AsBoolean());      // property gone
+    }
+
+    [Fact(Timeout = 2000)]
     public async Task Instance_Method_Cannot_Access_Static_Field_Via_This()
     {
         await using var engine = CreateEngine();


### PR DESCRIPTION
## Summary

Fixes `StaticClassFieldsTests.PublicFieldNamedHashConstructorUsesOrdinaryWritableDescriptor` (failing on `main`).

A computed member access whose key is a **string** starting with `#` — e.g. `obj["#x"]`, or `class C { ["#constructor"]; }` then `c["#constructor"] = ...` — is an **ordinary property**, not a private member. Private names are a distinct lexical concept (`obj.#x`), internally resolved to `@`-marked private slot names (`IsPrivateSlotName`).

### Root cause
The unified-bytecode VM's `SetComputedProperty` and `UpdateComputedProperty` routed through `SetPropertyValue` / `UpdatePropertyValue` with `allowPrivate: true`. `PropertyHandle.Resolve` then treated a `#`-prefixed string key as a private access and threw `TypeError: Invalid access of private member` when the target had no matching private slot. The Tier-2 `ExecutionPlanRunner` already uses `allowPrivate: false` for computed assignment (`ApplyProgramComputedPropertyAssignment`).

Diagnosis confirmed the read path uses `GetComputedProperty` → ordinary `JsOps` (fine); only the computed **write/update** paths mis-resolved. Genuine private access (`this.#x`) uses `GetNamedProperty`/`SetNamedProperty` with the resolved slot name and is unaffected.

### Fix
Thread an `allowPrivate` parameter (default `true`, preserving the genuine private named-op path) through `SetPropertyValue` / `UpdatePropertyValue`, and pass `allowPrivate: false` from the `SetComputedProperty` / `UpdateComputedProperty` opcodes.

## Verification
- Target test now passes; added `ComputedHashStringKey_TreatedAsOrdinaryProperty_AcrossSetUpdateDelete` (set/compound/update/delete/read + `in`).
- Genuine private intact: **PrivateField 28**, **PrivateName 30**, **StaticClassFields 13**.
- `UnifiedBytecodeProduction` pack: **1020 passed**. Computed (267) / Delete (108) / MemberExpression / ClassField green. `git diff --check` clean.

## Note (out of scope, flagged)
A separate pre-existing failure — `AssignmentReferenceTests.StrictIdentifierAssignment_ResolvesReferenceBeforeRhsCreatesGlobalProperty` (strict-mode assignment evaluation order) — was confirmed failing on the branch base without this change and is flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)