### PR TITLE
Resolve dynamic assignment LHS reference before RHS (strict ReferenceError ordering)

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -982,6 +982,18 @@ internal static class UnifiedBytecodeCompiler
                                 return false;
                             }
 
+                            // §13.15.2: with no static slot resolution, resolve the LHS
+                            // assignment reference BEFORE evaluating the RHS so that an RHS
+                            // side effect (e.g. creating a matching global property) cannot
+                            // change whether the LHS was originally resolvable. This mirrors
+                            // ExecutionPlanRunner.HandleAssignmentSlot's pre-resolved-reference
+                            // path and keeps strict-mode unresolved-reference ReferenceErrors.
+                            var dynamicAssignmentNameIndex = stringConstants.Count;
+                            stringConstants.Add(assignmentTargetSymbol.Name);
+                            unified.Add(new UnifiedBytecodeInstruction(
+                                UnifiedBytecodeOpCode.ResolveDynamicIdentifierReference,
+                                dynamicAssignmentNameIndex));
+
                             if (!TryAppendExpressionProgramOps(
                                     valueProgram,
                                     slotLayout,
@@ -999,11 +1011,9 @@ internal static class UnifiedBytecodeCompiler
                                 return false;
                             }
 
-                            AppendDynamicStoreInstruction(
-                                assignmentTargetSymbol,
-                                assignment.AllowNameInference,
-                                unified,
-                                stringConstants);
+                            unified.Add(new UnifiedBytecodeInstruction(
+                                UnifiedBytecodeOpCode.StoreDynamicIdentifierReference,
+                                EncodeDynamicStoreOperand(dynamicAssignmentNameIndex, assignment.AllowNameInference)));
                             unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.Pop));
                             maxStackDepth = Math.Max(maxStackDepth, GetCompiledExpressionMaxStackDepth(valueProgram));
                             if (TryAppendJumpToCompiledTarget(

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeProductionEligibilityTests.cs
@@ -525,7 +525,7 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         nameof(UnifiedBytecodeOpCode.PrepareDynamicIdentifierCallTarget))]
     [InlineData(
         "arguments; arguments = 7; return arguments;",
-        nameof(UnifiedBytecodeOpCode.StoreDynamicIdentifier))]
+        nameof(UnifiedBytecodeOpCode.StoreDynamicIdentifierReference))]
     public void Evaluate_FinalRestArgumentsDynamicOperation_AcceptsOwnedOpcode(
         string body,
         string expectedOpCodeName)
@@ -2886,7 +2886,7 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
 
         Assert.True(result.IsEligible, result.Reason);
         Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
-        Assert.Contains(result.Program.Instructions, instruction => instruction.OpCode == UnifiedBytecodeOpCode.StoreDynamicIdentifier);
+        Assert.Contains(result.Program.Instructions, instruction => instruction.OpCode == UnifiedBytecodeOpCode.StoreDynamicIdentifierReference);
         Assert.Contains(result.Program.Instructions, instruction => instruction.OpCode == UnifiedBytecodeOpCode.UpdateDynamicIdentifier);
         Assert.Contains(result.Program.Instructions, instruction => instruction.OpCode == UnifiedBytecodeOpCode.TypeOfDynamicIdentifier);
         Assert.Contains(result.Program.Instructions, instruction => instruction.OpCode == UnifiedBytecodeOpCode.DeleteDynamicIdentifier);
@@ -4940,8 +4940,12 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
 
         Assert.True(result.IsEligible, result.Reason);
         Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
+        // Dynamic identifier assignment resolves the LHS reference before the RHS
+        // (§13.15.2), so it lowers to ResolveDynamicIdentifierReference + StoreDynamicIdentifierReference.
         Assert.Contains(result.Program.Instructions, instruction =>
-            instruction.OpCode == UnifiedBytecodeOpCode.StoreDynamicIdentifier);
+            instruction.OpCode == UnifiedBytecodeOpCode.ResolveDynamicIdentifierReference);
+        Assert.Contains(result.Program.Instructions, instruction =>
+            instruction.OpCode == UnifiedBytecodeOpCode.StoreDynamicIdentifierReference);
     }
 
     [Fact]
@@ -5052,7 +5056,7 @@ public sealed class UnifiedBytecodeProductionEligibilityTests(ITestOutputHelper 
         Assert.True(result.IsEligible, result.Reason);
         Assert.Equal(UnifiedBytecodeProductionDeclineCode.None, result.Code);
         Assert.Contains(result.Program.Instructions, instruction => instruction.OpCode == UnifiedBytecodeOpCode.LoadDynamicIdentifier);
-        Assert.Contains(result.Program.Instructions, instruction => instruction.OpCode == UnifiedBytecodeOpCode.StoreDynamicIdentifier);
+        Assert.Contains(result.Program.Instructions, instruction => instruction.OpCode == UnifiedBytecodeOpCode.StoreDynamicIdentifierReference);
         Assert.Contains(result.Program.Instructions, instruction => instruction.OpCode == UnifiedBytecodeOpCode.UpdateDynamicIdentifier);
         Assert.Contains(result.Program.Instructions, instruction => instruction.OpCode == UnifiedBytecodeOpCode.TypeOfDynamicIdentifier);
         Assert.Contains(result.Program.Instructions, instruction => instruction.OpCode == UnifiedBytecodeOpCode.DeleteDynamicIdentifier);


### PR DESCRIPTION
## Summary

Fixes `AssignmentReferenceTests.StrictIdentifierAssignment_ResolvesReferenceBeforeRhsCreatesGlobalProperty` (failing on `main`).

Per **§13.15.2**, a simple assignment resolves its LHS reference **before** evaluating the RHS, so an RHS side effect (e.g. creating a matching global property) cannot retroactively make an originally-unresolvable LHS resolvable. In strict mode an unresolvable LHS must throw `ReferenceError`.

### Root cause
The production unified-bytecode compiler lowered a dynamic (no-slot) identifier assignment as `[RHS, StoreDynamicIdentifier]` — resolving the target **after** the RHS. So:
```js
"use strict";
undeclared = (this.undeclared = 5);
```
created `global.undeclared` via the RHS, then `StoreDynamicIdentifier` found it and stored — no error. (Plain `undeclared = 5` already threw, since its RHS doesn't create the binding — which is why this was a narrow edge case.)

The Tier-2 `ExecutionPlanRunner.HandleAssignmentSlot` already does the correct thing: for any no-slot / with-chain / cache-disabled target it resolves an `AssignmentReference` before the RHS (`usePreResolvedRef`). The production compiler did not.

### Fix
In the compiler's dynamic-assignment branch, emit `ResolveDynamicIdentifierReference` **before** the value program, then `StoreDynamicIdentifierReference` — mirroring the IR runner and the existing `DeclareDynamicVar` lowering. The reference captures the unresolvable state at resolve-time, so a strict store throws even after the RHS creates the binding.

Updated four eligibility opcode-assertion tests (arguments / ordinary-global / with dynamic assignments) that documented the old `StoreDynamicIdentifier` lowering to the reference opcodes. Runtime behavior is unchanged for those (same binding, just resolved earlier).

## Verification
- Target test passes. `UnifiedBytecodeProduction` pack: **1025 passed**. AssignmentReference (13), Reference (65), Strict (72), Global (71), Eval (815), WithStatement (26/27) green.
- The one WithStatement failure (`With_EmptyBodyProducesUndefinedCompletion`) and a few closure/scope/slot failures were confirmed **pre-existing** on the branch base (fail without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)