### PR TITLE
Reset completion value when entering with statement in production bytecode

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -1368,6 +1368,21 @@ internal static class UnifiedBytecodeCompiler
 
                         unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.EnterWith));
                         maxStackDepth = Math.Max(maxStackDepth, GetCompiledExpressionMaxStackDepth(enterWithObjectProgram));
+
+                        // Mirror HandleEnterWith in the AST runner: entering a `with` statement
+                        // resets the script completion value to undefined so an empty/value-less
+                        // body produces undefined rather than leaking the previous statement's value.
+                        if (slotLayout.ScriptCompletionSlot >= 0)
+                        {
+                            var enterWithUndefinedIndex = literalConstants.Count;
+                            literalConstants.Add(JsValue.Undefined);
+                            unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.LoadLiteral, enterWithUndefinedIndex));
+                            unified.Add(new UnifiedBytecodeInstruction(
+                                UnifiedBytecodeOpCode.StoreSlot,
+                                slotLayout.ScriptCompletionSlot));
+                            maxStackDepth = Math.Max(maxStackDepth, 1);
+                        }
+
                         if (TryAppendJumpToCompiledTarget(
                                 instructionIndex,
                                 enterWith.Next,


### PR DESCRIPTION
## Root cause
The unified bytecode VM's `EnterWith` opcode did not reset the script completion value. The AST `ExecutionPlanRunner.HandleEnterWith` sets `_scriptCompletionValue = JsValue.Undefined` in script mode, but the production bytecode path had no equivalent. So an empty `with (obj) {}` body leaked the prior statement's completion value: `1; with ({}) { }` produced `1` instead of `undefined`.

## Fix
The compiler now emits a completion-slot reset (`LoadLiteral undefined` + `StoreSlot ScriptCompletionSlot`) immediately after the `EnterWith` opcode, mirroring the existing `SetCompletionValueInstruction` lowering and the AST runner behavior. Per spec, `with (obj) Body` evaluates to `UpdateEmpty(stmtResult, undefined)`, so an empty body yields `undefined` while a value-producing body (`with ({}) { 3; }`) still yields `3`.

The awaited `with` variant is rejected by production eligibility, so the only compiled path is covered.

## Proof
- `WithStatementTests.With_EmptyBodyProducesUndefinedCompletion` — passes
- `FullyQualifiedName~WithStatement` — 27/27 passed
- `FullyQualifiedName~UnifiedBytecodeProduction` (MaxParallelThreads=1) — 1025/1025 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)