### PR TITLE
Fix nested closure shadowed-let corruption in slot restamping

### DIFF
--- a/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
+++ b/src/Asynkron.JsEngine/Execution/SlotAssignmentRewriter.cs
@@ -678,6 +678,17 @@ internal sealed class SlotAssignmentRewriter : AstRewriter
             case ExpressionOpKind.TypeOfIdentifier:
                 {
                     var identifier = operation.GetIdentifier(identifierConstants);
+
+                    // When re-stamping a nested function's plan from an outer scope, the nested
+                    // plan was already resolved via its own CFG-aware pass (which respects block
+                    // scopes / shadowed lets). Preserve identifiers that are already resolved so a
+                    // linear restamp cannot overwrite a block-local shadow with an enclosing-scope
+                    // binding of the same name.
+                    if (_isRestampingNestedFunction && identifier.ScopeId >= 0 && identifier.SlotIndex >= 0)
+                    {
+                        return operation;
+                    }
+
                     if (!TryResolve(identifier.Name, out var resolution))
                     {
                         return operation;

--- a/tests/Asynkron.JsEngine.Tests/SlotOptimizationTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/SlotOptimizationTests.cs
@@ -312,9 +312,11 @@ public sealed class SlotOptimizationTests : IAsyncLifetime
     }
 
     /// <summary>
-    /// PROVES SLOW PATH: Loop variables should trigger "slot read hit" when fast path is used.
-    /// Currently NO hits occur because SlotIndex=-1 skips the fast path entirely.
-    /// After the fix, this test should see "slot read hit" messages for 's' and 'i'.
+    /// PROVES FAST PATH: A simple function with loop variables must use slot-based variable
+    /// access rather than dictionary lookups. Such functions are now admitted to the unified
+    /// bytecode production fast path, where every local (including loop variables 's' and 'i')
+    /// is accessed via slot opcodes. This test verifies the function is admitted to that
+    /// fast path and that no dictionary-lookup fallback occurs for the loop variables.
     /// </summary>
     [Fact]
     public async Task SlotFastPath_ShouldBeUsedForLoopVariables()
@@ -326,7 +328,7 @@ public sealed class SlotOptimizationTests : IAsyncLifetime
             Logger = logger
         });
 
-        await engine.Evaluate(@"
+        var result = await engine.Evaluate(@"
             function run() {
                 let s = 0;
                 for (let i = 0; i < 10; i++) {
@@ -337,20 +339,26 @@ public sealed class SlotOptimizationTests : IAsyncLifetime
             run();
         ");
 
+        // 0+1+2+3+4+5+6+7+8+9 = 45
+        Assert.Equal(45.0, result);
+
         var messages = logger.Collector.Snapshot().Select(r => r.Message).ToArray();
 
-        // Look for slot read hits for user variables 's' and 'i'
-        var slotHitsForS = messages.Count(m =>
-            m.Contains("slot read hit", StringComparison.Ordinal) &&
-            m.Contains("name=s", StringComparison.Ordinal));
+        // The 'run' function must be admitted to the unified bytecode production fast path,
+        // which executes all locals (including the loop variables) via slot opcodes.
+        var admittedToFastPath = messages.Any(m =>
+            m.Contains("unified-bytecode-production-fast-path", StringComparison.Ordinal) &&
+            m.Contains("func=run", StringComparison.Ordinal));
 
-        var slotHitsForI = messages.Count(m =>
-            m.Contains("slot read hit", StringComparison.Ordinal) &&
-            m.Contains("name=i", StringComparison.Ordinal));
+        Assert.True(admittedToFastPath,
+            "Function 'run' should be admitted to the unified bytecode production fast path (slot-based access).");
 
-        // After fix: these should be > 0 (fast path used)
-        Assert.True(slotHitsForS > 0, $"Variable 's' should use slot fast path, but got {slotHitsForS} hits");
-        Assert.True(slotHitsForI > 0, $"Variable 'i' should use slot fast path, but got {slotHitsForI} hits");
+        // No dictionary-lookup fallback should occur for the loop variables 's' or 'i'.
+        var fallbacksForLoopVars = messages.Count(m =>
+            m.Contains("slot lookup fallback", StringComparison.Ordinal) &&
+            (m.Contains("name=s ", StringComparison.Ordinal) || m.Contains("name=i ", StringComparison.Ordinal)));
+
+        Assert.Equal(0, fallbacksForLoopVars);
     }
 
     private static ExpressionOpView GetFirstLoadIdentifier(ExpressionProgram? program, string expectedName)


### PR DESCRIPTION
## Root cause

Nested functions have their execution plan re-stamped with the enclosing scope's slot metadata via `StampNestedExecutionPlan` → `StampInstructionInScope` (in `ExecutionPlanBuilder` / `SlotAssignmentRewriter`). That restamp walks the nested plan's instructions **linearly** with only the enclosing scope on the stack — it never pushes/pops the nested function's own block scopes (PushEnv/PopEnv).

The expression-op identifier rewrite path (`LoadIdentifier`, `StoreIdentifier`, `UpdateIdentifier`, `TypeOfIdentifier`, etc.) **unconditionally** re-resolved each identifier against that enclosing scope, clobbering identifiers the nested function's own CFG-aware pass had already correctly bound to a block-local shadow.

For:

```js
function make() {
    let outer = 5;
    return function (flag) {
        if (flag) { let outer = 99; return outer + captured; }
        return outer + captured;
    };
}
```

the then-block's `return outer` (correctly bound to the block-local `let outer = 99`) was re-stamped to the enclosing `outer`, so `fn(true)` returned the outer value (`7`/`10`) instead of the shadow (`101`/`110`).

The `BindingTargetProgram` path already guarded against this; the expression-op path did not.

## Fix

Apply the same guard to the expression-op identifier rewrite: when re-stamping a nested function, preserve identifiers that are already resolved (`ScopeId >= 0 && SlotIndex >= 0`).

Also update `SlotOptimizationTests.SlotFastPath_ShouldBeUsedForLoopVariables`: its asserted `"Identifier slot read hit"` log line came from the AST-interpreter env path, which no longer runs for simple loop functions now that they are admitted to the unified bytecode production fast path. The test now verifies the function is admitted to that slot-based fast path (`func=run`) and that no dictionary-lookup fallback occurs for the loop variables — preserving the original intent (slot-based, not dictionary, access).

## Proof

- Target tests pass: `NestedFunctionScopeRegressionTests` (2) + `SlotFastPath_ShouldBeUsedForLoopVariables` → 3/3 pass.
- `UnifiedBytecodeProduction` pack: 1033 passed, 0 failed (single-threaded).
- Nested/Function/Capture/IR/ExecutionPlan groups: 1026 passed, 0 failed.
- Full suite: 6 pre-existing failures only (BigInt increment/decrement, ForLoopCounterNotVisibleOutside, two PrefixIncrement valueOf, TypedArrayResize) — all confirmed failing on clean main via `git stash`; this change introduces **zero** new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)