### PR TITLE
Fix script completion value for trailing increment/decrement statements

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -1271,8 +1271,26 @@ internal static class UnifiedBytecodeCompiler
                                     increment.IsPrefix)));
                         }
 
+                        // The update opcodes leave the result (new value for prefix, old
+                        // numeric value for postfix) on the stack. When this update is the
+                        // value of an expression statement, that result is the statement's
+                        // completion value, so capture it into the script completion slot
+                        // before discarding. Loop update expressions set SuppressCompletionValue
+                        // and must not contribute to the completion value (per ES spec).
+                        if (slotLayout.ScriptCompletionSlot >= 0 && !increment.SuppressCompletionValue)
+                        {
+                            unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.DuplicateTop));
+                            unified.Add(new UnifiedBytecodeInstruction(
+                                UnifiedBytecodeOpCode.StoreSlot,
+                                slotLayout.ScriptCompletionSlot));
+                            maxStackDepth = Math.Max(maxStackDepth, 2);
+                        }
+                        else
+                        {
+                            maxStackDepth = Math.Max(maxStackDepth, 1);
+                        }
+
                         unified.Add(new UnifiedBytecodeInstruction(UnifiedBytecodeOpCode.Pop));
-                        maxStackDepth = Math.Max(maxStackDepth, 1);
                         if (TryAppendJumpToCompiledTarget(
                                 instructionIndex,
                                 increment.Next,


### PR DESCRIPTION
## Root cause

When an update expression (`++x` / `--x` / `x++` / `x--`) is the value of a **trailing expression statement**, the unified bytecode compiler's statement-level `IncrementSlotInstruction` handling emitted `UpdateSlot` / `UpdateDynamicIdentifier` followed immediately by `Pop`, discarding the update result **without first storing it into the script completion slot**.

The `UpdateSlot`/`UpdateDynamicIdentifier` opcodes correctly mutate the variable and push the result (new value for prefix, old numeric value for postfix), but because that result was popped without being captured, the script's completion value was left as the stale completion-slot sentinel.

This produced wrong completion values:
- `var o = {valueOf: () => 1}; ++o;` returned the object itself instead of `2`
- `var p = {valueOf: () => 1}; p++;` returned the object instead of `1`
- even `var n = 1; ++n;` returned the wrong value (the underlying mutation was correct; only the *expression statement result* was wrong)

The `EvaluateAndDiscardInstruction` path already does the right thing (`DuplicateTop` + `StoreSlot(ScriptCompletionSlot)` before `Pop`); the statement-level increment path bypassed that wrapper and never captured the value.

## Fix

In `UnifiedBytecodeCompiler.cs`, before the `Pop` in the statement-level `IncrementSlotInstruction` case, capture the result into the script completion slot (`DuplicateTop` + `StoreSlot`), gated on `SuppressCompletionValue` so for-loop update expressions still contribute no completion value (per ES spec). Stack depth accounting updated accordingly.

## Verification (Release)

- `PrefixIncrementDebugTests`: 10/10 pass (was 2 failing)
- `Update` group: 78 pass
- `Increment`/`Decrement`/`Completion`/`ForLoop` groups: 194 pass
- Production pack (`FullyQualifiedName~UnifiedBytecodeProduction`, MaxParallelThreads=1): 1040 pass
- Full internal suite: 4348 pass; only pre-existing `TypedArrayResizeCoercionTests.ValueOfCoercionCanResizeBackingBuffer` fails (confirmed failing on clean `origin/main` via `git stash`, not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)