### PR TITLE
Fix typeof-member binary stray operand crash (TypedArray resize coercion test)

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -12873,6 +12873,25 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        // Validate the multi-op RHS shape before emitting anything. The emission pass below
+        // only knows how to lower an array/object/template-literal span; any other multi-op
+        // RHS (e.g. `typeof base.prop === literal`, where the op after the property chain is
+        // `TypeOf`) is not this shape. Rejecting here keeps the contract "validate the entire
+        // shape before emitting anything" — otherwise the base load + property reads would be
+        // emitted and then left stranded on a non-rolled-back `false` return, doubling them
+        // when the general loop re-emits the expression and overflowing MaxStackDepth.
+        if (rhsStart != rhsEnd)
+        {
+            var rhsKind = expressionProgram.GetOperation(rhsStart).Kind;
+            if (rhsKind is not (ExpressionOpKind.CreateArray
+                or ExpressionOpKind.CreateObject
+                or ExpressionOpKind.LoadLiteral))
+            {
+                reason = string.Empty;
+                return false;
+            }
+        }
+
         // Validate base (read-only, mirrors TryAppendActivationValueLoad without emitting).
         var baseOp = expressionProgram.GetOperation(0);
         if (baseOp.Kind != ExpressionOpKind.LoadThis && baseOp.Kind != ExpressionOpKind.LoadNewTarget)


### PR DESCRIPTION
## Root cause

`TypedArrayResizeCoercionTests.ValueOfCoercionCanResizeBackingBuffer` crashed with `System.IndexOutOfRangeException` in `UnifiedBytecodeVirtualMachine.PushValue` — an operand-stack overflow, not a TypedArray/resize semantics bug.

The IIFE body contains `const hasResize = typeof rab.resize === 'function';`. In the unified bytecode compiler, `TryAppendFirstBoundaryPropertyReadBinaryExpression` matched this `<property-read> <binary> RHS` shape, but only validated the **multi-op RHS kind during its emission pass** — after already emitting the base load and `GetNamedProperty`. For `typeof base.prop === literal` the op after the property chain is `TypeOf`, so the RHS-kind switch fell through to a `return false` with **no rollback**, stranding a `LoadSlot`/`GetNamedProperty` pair on the operand stack.

The general expression loop then re-emitted the full expression, so the property read was emitted twice. The duplicate pushed one extra value past the program's computed `MaxStackDepth`, overflowing the VM operand stack.

Minimal repro (no resize needed):
```js
(function(){
  const ta = new Int8Array(4);
  typeof ta.foo === 'function';
  return { g: 1 };
})();
```

## Fix

Validate the multi-op RHS op-kind (`CreateArray`/`CreateObject`/`LoadLiteral`) **before** any emission, honoring the function's documented "validate the entire shape before emitting anything" contract. Non-literal-span multi-op RHS shapes (like `typeof <member>`) are now rejected cleanly before the base/property loads are emitted, so the general loop owns them without duplication.

## Verification
- Target test `ValueOfCoercionCanResizeBackingBuffer`: passes
- TypedArray group: 192 passed (was 191 passed / 1 failed)
- Production pack (`UnifiedBytecodeProduction`, single-threaded): 1040 passed
- UnifiedBytecode + ExpressionProgram + TypeOf suites: 1348 passed
- Full internal suite: 3284 passed, 2 failed — both `BigIntIncrement`/`BigIntDecrement`, confirmed pre-existing on clean `origin/main` (git stash + rerun), not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)