### PR TITLE
Fix TCO-in-finally stack-overflow crash (route finally-return calls to IR runner)

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -484,6 +484,19 @@ internal static class UnifiedBytecodeProductionEligibility
             return true;
         }
 
+        // The production VM does not implement same-function tail-call optimization. A call expression
+        // returned from inside a finally block is a tail position per spec (the finally completion
+        // overrides the protected block), so deep self-recursion through such a return must run on the
+        // TCO-capable IR runner (ExecutionPlanRunner) instead of the VM; otherwise the native call stack
+        // grows unbounded and overflows. Decline so these functions route to the IR runner.
+        if (ContainsCallReturnReachableFromFinally(plan))
+        {
+            declineCode = UnifiedBytecodeProductionDeclineCode.CallDependency;
+            declineReason =
+                "A call returned from within a finally block is a tail position and requires the tail-call-optimizing IR runner; not eligible for production unified bytecode routing.";
+            return true;
+        }
+
         for (var instructionIndex = 0; instructionIndex < plan.Instructions.Length; instructionIndex++)
         {
             if (activeWithDepths[instructionIndex] < 0)
@@ -612,6 +625,129 @@ internal static class UnifiedBytecodeProductionEligibility
 
         declineCode = UnifiedBytecodeProductionDeclineCode.None;
         declineReason = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    ///     Returns true when the plan contains a <c>return &lt;call&gt;;</c> reachable inside a finally
+    ///     block. Such a return is in tail position (the finally completion overrides the protected
+    ///     block), but the production VM has no tail-call optimization, so deep self-recursion through it
+    ///     would overflow the native stack. These functions must run on the TCO-capable IR runner.
+    /// </summary>
+    private static bool ContainsCallReturnReachableFromFinally(ExecutionPlan plan)
+    {
+        var instructions = plan.Instructions;
+        for (var i = 0; i < instructions.Length; i++)
+        {
+            if (instructions[i] is EnterTryInstruction { FinallyIndex: >= 0 } enterTry &&
+                FinallyRegionContainsCallReturn(instructions, enterTry.FinallyIndex))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool FinallyRegionContainsCallReturn(
+        ImmutableArray<ExecutionInstruction> instructions,
+        int finallyIndex)
+    {
+        var visited = new HashSet<int>();
+        var pending = new Stack<int>();
+        pending.Push(finallyIndex);
+        while (pending.Count > 0)
+        {
+            var index = pending.Pop();
+            if ((uint)index >= (uint)instructions.Length || !visited.Add(index))
+            {
+                continue;
+            }
+
+            var instruction = instructions[index];
+
+            // The finally body terminates at its EndFinally marker; do not traverse past it so that we
+            // only inspect instructions that execute as part of the finally block itself.
+            if (instruction is EndFinallyInstruction)
+            {
+                continue;
+            }
+
+            if (instruction is ReturnInstruction { AwaitedProgram: null, ReturnProgram: { } returnProgram } &&
+                ExpressionProgramContainsCall(returnProgram))
+            {
+                return true;
+            }
+
+            switch (instruction)
+            {
+                case ReturnInstruction:
+                case ThrowInstruction:
+                    break;
+
+                case BranchInstruction branch:
+                    pending.Push(branch.ConsequentIndex);
+                    pending.Push(branch.AlternateIndex);
+                    break;
+
+                case JumpInstruction jump:
+                    pending.Push(jump.TargetIndex);
+                    break;
+
+                case BreakInstruction breakInstruction:
+                    pending.Push(breakInstruction.TargetIndex);
+                    break;
+
+                case ContinueInstruction continueInstruction:
+                    pending.Push(continueInstruction.TargetIndex);
+                    break;
+
+                case EnterTryInstruction nestedTry:
+                    if (nestedTry.HandlerIndex >= 0)
+                    {
+                        pending.Push(nestedTry.HandlerIndex);
+                    }
+
+                    if (nestedTry.FinallyIndex >= 0)
+                    {
+                        pending.Push(nestedTry.FinallyIndex);
+                    }
+
+                    if (nestedTry.EndFinallyIndex >= 0)
+                    {
+                        pending.Push(nestedTry.EndFinallyIndex);
+                    }
+
+                    if (instruction.Next >= 0)
+                    {
+                        pending.Push(instruction.Next);
+                    }
+
+                    break;
+
+                default:
+                    if (instruction.Next >= 0)
+                    {
+                        pending.Push(instruction.Next);
+                    }
+
+                    break;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ExpressionProgramContainsCall(ExpressionProgram program)
+    {
+        for (var i = 0; i < program.OperationCount; i++)
+        {
+            if (program.GetOperation(i).Kind == ExpressionOpKind.Call)
+            {
+                return true;
+            }
+        }
+
         return false;
     }
 


### PR DESCRIPTION
## Problem

`TailCallTests.StrictSameFunctionTailCall_InFinallyReturnDoesNotGrowCallDepth` **crashed the test host** with an uncatchable `StackOverflowException`. The test runs `countdown(1500)` where the recursive `return countdown(n-1)` lives inside a `finally` block in strict mode:

```js
function countdown(n) {
  "use strict";
  if (n === 0) { callCount++; return; }
  try {
  } finally {
    return countdown(n - 1);   // tail position per spec
  }
}
countdown(1500);
```

This is a genuine native stack overflow (overflows at ~900 frames), not a managed depth-limit exception — which is why it aborts the worker process and produces crash-collateral.

## Root cause

A `return f(...)` inside `finally` is a **tail position** per spec (the finally completion overrides the protected block). The TCO-capable IR runner (`ExecutionPlanRunner`) handles it correctly, but the function was being routed to the **production UnifiedBytecode VM**, which has **no same-function tail-call optimization** — so each recursion added native frames.

Why it was admitted to the VM:
- The production-eligibility decline scan (`TryFindPlanDecline`) skips instructions that the with-depth reachability analysis (`UnifiedBytecodeWithDepthAnalysis`) never visits.
- That analysis only follows ordinary control-flow edges (`Next`/branch/jump/break/continue). It does **not** traverse an `EnterTryInstruction`'s `HandlerIndex`/`FinallyIndex`/`EndFinallyIndex` edges, so catch/finally bodies stay unvisited (depth `-1`) and are skipped by the decline scan.
- A function that also touches an outer binding (e.g. `callCount`) takes the "ordinary dynamic name" admit path, so the finally tail call slips through and the whole function runs on the no-TCO VM.

By contrast, the equivalent top-level tail call (`return countdown(n-1)` not in a finally) and the try/**catch** tail call are already declined (`DynamicLookupDependency`) and correctly run on the IR runner — which is why those tests pass.

## Fix

In `TryFindPlanDecline`, decline any plan whose **finally region contains a `return <call>;`** (`ContainsCallReturnReachableFromFinally`). Those functions route to the TCO-capable `ExecutionPlanRunner`.

The check is deliberately **narrow** — verified that the VM is still used for:
- `finally { return 42; }` (returns a literal)
- `finally { pushit(); }` (calls without returning)

Only a *call returned from* finally is declined.

## Test evidence

- `FullyQualifiedName~TailCall`: **40/40 pass** (including the previously-crashing test).
- `Finally|TryCatch|UnifiedBytecode|Production` groups: **1298/1298 pass**.
- `Recursion|Generator|Async|Closure|Scope` groups: **721/721 pass**.
- Full internal suite: **5324 passed, 5 failed**. All 5 failures (`BigIntIncrement`, `BigIntDecrement`, `PostfixIncrement_OnObjectWithValueOf`, `PrefixIncrement_OnObjectWithValueOf_BasicCase`, `ValueOfCoercionCanResizeBackingBuffer`) **fail identically on clean `origin/main`** — pre-existing, unrelated to this change.

## Risk / what a human should check before merge

- **Performance:** functions whose finally returns a call now run on the IR runner instead of the VM. This is the correct/safe path; the only cost is the slower runner for that narrow shape. Confirm no perf-sensitive hot path relies on a finally-returned call running on the VM.
- **Scope of the over-approximation:** the decline fires for *any* call returned from finally (not just self-recursive). This is intentional (mutual recursion through a finally-return would overflow too), but it is slightly broader than strictly required.
- **Latent gap not addressed here:** `UnifiedBytecodeWithDepthAnalysis` still does not traverse catch/finally edges, so the decline scan remains blind to other ineligible shapes inside catch/finally. I intentionally kept this PR minimal (single-file, no traversal change) to limit blast radius; broadening the reachability analysis is a reasonable follow-up but has wider eligibility impact and deserves its own review.

**Do not auto-merge — human review requested (stack-overflow crash; wrong fix can destabilize the suite).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)