### PR TITLE
Harden first-boundary emit helpers against unrolled-back bailouts

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeCompiler.cs
@@ -10486,6 +10486,13 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        // Capture builder lengths before any emission so a later validation failure
+        // rolls back and never leaks half-written operand loads the general loop would
+        // re-emit (doubling them past MaxStackDepth -> VM stack overflow).
+        var unifiedCount = unified.Count;
+        var literalCount = literalConstants.Count;
+        var stringCount = stringConstants.Count;
+
         if (!TryAppendActivationOrPlainDynamicIdentifierReadValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
@@ -10495,6 +10502,9 @@ internal static class UnifiedBytecodeCompiler
                 stringConstants,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -10527,6 +10537,9 @@ internal static class UnifiedBytecodeCompiler
                     stringConstants,
                     out reason))
             {
+                RollBackUnifiedBuilder(unified, unifiedCount);
+                RollBackUnifiedBuilder(literalConstants, literalCount);
+                RollBackUnifiedBuilder(stringConstants, stringCount);
                 return false;
             }
         }
@@ -10536,6 +10549,9 @@ internal static class UnifiedBytecodeCompiler
             if (rhsOp.Kind != ExpressionOpKind.LoadLiteral)
             {
                 reason = string.Empty;
+                RollBackUnifiedBuilder(unified, unifiedCount);
+                RollBackUnifiedBuilder(literalConstants, literalCount);
+                RollBackUnifiedBuilder(stringConstants, stringCount);
                 return false;
             }
 
@@ -10543,12 +10559,18 @@ internal static class UnifiedBytecodeCompiler
                     expressionProgram, rhsStart, activationSlots,
                     unified, literalConstants, out var spanLen, out reason))
             {
+                RollBackUnifiedBuilder(unified, unifiedCount);
+                RollBackUnifiedBuilder(literalConstants, literalCount);
+                RollBackUnifiedBuilder(stringConstants, stringCount);
                 return false;
             }
 
             if (rhsStart + spanLen - 1 != rhsEnd)
             {
                 reason = "Template literal RHS span does not match expected boundary.";
+                RollBackUnifiedBuilder(unified, unifiedCount);
+                RollBackUnifiedBuilder(literalConstants, literalCount);
+                RollBackUnifiedBuilder(stringConstants, stringCount);
                 return false;
             }
         }
@@ -11237,6 +11259,13 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        // Capture builder lengths before emission so a later failure rolls back
+        // instead of leaking half-written operand loads the general loop would
+        // re-emit (doubling them past MaxStackDepth -> VM stack overflow).
+        var unifiedCount = unified.Count;
+        var literalCount = literalConstants.Count;
+        var stringCount = stringConstants.Count;
+
         if (!TryAppendSimpleOperandLoadWithDynamic(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
@@ -11247,6 +11276,9 @@ internal static class UnifiedBytecodeCompiler
                 stringConstants,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -11262,6 +11294,9 @@ internal static class UnifiedBytecodeCompiler
                     stringConstants,
                     out reason))
             {
+                RollBackUnifiedBuilder(unified, unifiedCount);
+                RollBackUnifiedBuilder(literalConstants, literalCount);
+                RollBackUnifiedBuilder(stringConstants, stringCount);
                 return false;
             }
         }
@@ -11271,12 +11306,18 @@ internal static class UnifiedBytecodeCompiler
                     expressionProgram, rhsStart, activationSlots,
                     unified, literalConstants, out var spanLen, out reason))
             {
+                RollBackUnifiedBuilder(unified, unifiedCount);
+                RollBackUnifiedBuilder(literalConstants, literalCount);
+                RollBackUnifiedBuilder(stringConstants, stringCount);
                 return false;
             }
 
             if (rhsStart + spanLen - 1 != rhsEnd)
             {
                 reason = "Template literal RHS span does not match expected boundary.";
+                RollBackUnifiedBuilder(unified, unifiedCount);
+                RollBackUnifiedBuilder(literalConstants, literalCount);
+                RollBackUnifiedBuilder(stringConstants, stringCount);
                 return false;
             }
         }
@@ -11592,6 +11633,13 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        // Capture builder lengths before emission so a later failure rolls back
+        // instead of leaking half-written operand loads the general loop would
+        // re-emit (doubling them past MaxStackDepth -> VM stack overflow).
+        var unifiedCount = unified.Count;
+        var literalCount = literalConstants.Count;
+        var stringCount = stringConstants.Count;
+
         if (!TryAppendActivationValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
@@ -11599,6 +11647,9 @@ internal static class UnifiedBytecodeCompiler
                 unified,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -11621,6 +11672,9 @@ internal static class UnifiedBytecodeCompiler
                     literalConstants,
                     out reason))
             {
+                RollBackUnifiedBuilder(unified, unifiedCount);
+                RollBackUnifiedBuilder(literalConstants, literalCount);
+                RollBackUnifiedBuilder(stringConstants, stringCount);
                 return false;
             }
         }
@@ -11630,18 +11684,27 @@ internal static class UnifiedBytecodeCompiler
             if (rhsOp.Kind != ExpressionOpKind.LoadLiteral)
             {
                 reason = string.Empty;
+                RollBackUnifiedBuilder(unified, unifiedCount);
+                RollBackUnifiedBuilder(literalConstants, literalCount);
+                RollBackUnifiedBuilder(stringConstants, stringCount);
                 return false;
             }
 
             if (!TryAppendSimpleTemplateLiteralSpan(
                     expressionProgram, rhsStart, activationSlots, unified, literalConstants, out var spanLen, out reason))
             {
+                RollBackUnifiedBuilder(unified, unifiedCount);
+                RollBackUnifiedBuilder(literalConstants, literalCount);
+                RollBackUnifiedBuilder(stringConstants, stringCount);
                 return false;
             }
 
             if (rhsStart + spanLen - 1 != rhsEnd)
             {
                 reason = "Template literal RHS span does not match expected nested property-write boundary.";
+                RollBackUnifiedBuilder(unified, unifiedCount);
+                RollBackUnifiedBuilder(literalConstants, literalCount);
+                RollBackUnifiedBuilder(stringConstants, stringCount);
                 return false;
             }
         }
@@ -12159,6 +12222,13 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        // Capture builder lengths before emission so a later failure rolls back
+        // instead of leaking half-written operand loads the general loop would
+        // re-emit (doubling them past MaxStackDepth -> VM stack overflow).
+        var unifiedCount = unified.Count;
+        var literalCount = literalConstants.Count;
+        var stringCount = stringConstants.Count;
+
         if (!TryAppendActivationValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
@@ -12166,6 +12236,9 @@ internal static class UnifiedBytecodeCompiler
                 unified,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -12186,6 +12259,9 @@ internal static class UnifiedBytecodeCompiler
                 endExclusive: expressionProgram.OperationCount - 1,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -12250,6 +12326,13 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        // Capture builder lengths before emission so a later failure rolls back
+        // instead of leaking half-written operand loads the general loop would
+        // re-emit (doubling them past MaxStackDepth -> VM stack overflow).
+        var unifiedCount = unified.Count;
+        var literalCount = literalConstants.Count;
+        var stringCount = stringConstants.Count;
+
         if (!TryAppendActivationValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
@@ -12257,6 +12340,9 @@ internal static class UnifiedBytecodeCompiler
                 unified,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -12277,6 +12363,9 @@ internal static class UnifiedBytecodeCompiler
                 endExclusive: deleteIndex,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -12345,6 +12434,13 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        // Capture builder lengths before emission so a later failure rolls back
+        // instead of leaking half-written operand loads the general loop would
+        // re-emit (doubling them past MaxStackDepth -> VM stack overflow).
+        var unifiedCount = unified.Count;
+        var literalCount = literalConstants.Count;
+        var stringCount = stringConstants.Count;
+
         if (!TryAppendActivationValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
@@ -12352,6 +12448,9 @@ internal static class UnifiedBytecodeCompiler
                 unified,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -12376,6 +12475,9 @@ internal static class UnifiedBytecodeCompiler
                 endExclusive: deleteIndex,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -12718,8 +12820,18 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        // Capture builder lengths before emission so a later failure rolls back
+        // instead of leaking half-written operand loads the general loop would
+        // re-emit (doubling them past MaxStackDepth -> VM stack overflow).
+        var unifiedCount = unified.Count;
+        var literalCount = literalConstants.Count;
+        var stringCount = stringConstants.Count;
+
         if (!TryAppendActivationValueLoad(baseLoad, expressionProgram, activationSlots, unified, out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -12748,6 +12860,9 @@ internal static class UnifiedBytecodeCompiler
                 endExclusive: computedIndex,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -12863,6 +12978,13 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        // Capture builder lengths before emission so a later failure rolls back
+        // instead of leaking half-written operand loads the general loop would
+        // re-emit (doubling them past MaxStackDepth -> VM stack overflow).
+        var unifiedCount = unified.Count;
+        var literalCount = literalConstants.Count;
+        var stringCount = stringConstants.Count;
+
         if (!TryAppendActivationValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
@@ -12870,6 +12992,9 @@ internal static class UnifiedBytecodeCompiler
                 unified,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -12894,6 +13019,9 @@ internal static class UnifiedBytecodeCompiler
                 endExclusive: computedIndex,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -13286,7 +13414,14 @@ internal static class UnifiedBytecodeCompiler
             }
         }
 
-        // Emission pass — only reached when all validation passes.
+        // Emission pass — only reached when all validation passes. Capture builder
+        // lengths so any lowering helper that still returns false mid-emission rolls
+        // back instead of leaving half-written operand loads the general loop would
+        // re-emit (doubling them past MaxStackDepth).
+        var unifiedCount = unified.Count;
+        var literalCount = literalConstants.Count;
+        var stringCount = stringConstants.Count;
+
         if (!TryAppendActivationValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
@@ -13294,6 +13429,9 @@ internal static class UnifiedBytecodeCompiler
                 unified,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -13316,6 +13454,9 @@ internal static class UnifiedBytecodeCompiler
                     literalConstants,
                     out reason))
             {
+                RollBackUnifiedBuilder(unified, unifiedCount);
+                RollBackUnifiedBuilder(literalConstants, literalCount);
+                RollBackUnifiedBuilder(stringConstants, stringCount);
                 return false;
             }
         }
@@ -13332,6 +13473,9 @@ internal static class UnifiedBytecodeCompiler
                     rhsStart + arraySpanLen - 1 != rhsEnd)
                 {
                     reason = reason.Length == 0 ? "Array literal RHS span does not match expected boundary." : reason;
+                    RollBackUnifiedBuilder(unified, unifiedCount);
+                    RollBackUnifiedBuilder(literalConstants, literalCount);
+                    RollBackUnifiedBuilder(stringConstants, stringCount);
                     return false;
                 }
             }
@@ -13344,6 +13488,9 @@ internal static class UnifiedBytecodeCompiler
                     rhsStart + objSpanLen - 1 != rhsEnd)
                 {
                     reason = reason.Length == 0 ? "Object literal RHS span does not match expected boundary." : reason;
+                    RollBackUnifiedBuilder(unified, unifiedCount);
+                    RollBackUnifiedBuilder(literalConstants, literalCount);
+                    RollBackUnifiedBuilder(stringConstants, stringCount);
                     return false;
                 }
             }
@@ -13355,12 +13502,18 @@ internal static class UnifiedBytecodeCompiler
                     rhsStart + templateSpanLen - 1 != rhsEnd)
                 {
                     reason = reason.Length == 0 ? "Template literal RHS span does not match expected boundary." : reason;
+                    RollBackUnifiedBuilder(unified, unifiedCount);
+                    RollBackUnifiedBuilder(literalConstants, literalCount);
+                    RollBackUnifiedBuilder(stringConstants, stringCount);
                     return false;
                 }
             }
             else
             {
                 reason = string.Empty;
+                RollBackUnifiedBuilder(unified, unifiedCount);
+                RollBackUnifiedBuilder(literalConstants, literalCount);
+                RollBackUnifiedBuilder(stringConstants, stringCount);
                 return false;
             }
         }
@@ -13435,9 +13588,19 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        // Capture builder lengths before emission so a later operand-load failure
+        // rolls back instead of leaking half-written loads the general loop would
+        // re-emit (doubling them past MaxStackDepth -> VM stack overflow).
+        var unifiedCount = unified.Count;
+        var literalCount = literalConstants.Count;
+        var stringCount = stringConstants.Count;
+
         var baseOp = expressionProgram.GetOperation(0);
         if (!TryAppendActivationValueLoad(baseOp, expressionProgram, activationSlots, unified, out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -13468,6 +13631,9 @@ internal static class UnifiedBytecodeCompiler
                 literalConstants,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -13520,6 +13686,13 @@ internal static class UnifiedBytecodeCompiler
             return false;
         }
 
+        // Capture builder lengths before emission so a later key-load failure rolls
+        // back instead of leaking a half-written base load the general loop would
+        // re-emit (doubling them past MaxStackDepth -> VM stack overflow).
+        var unifiedCount = unified.Count;
+        var literalCount = literalConstants.Count;
+        var stringCount = stringConstants.Count;
+
         if (!TryAppendActivationOrImplicitArgumentsObjectReadValueLoad(
                 expressionProgram.GetOperation(0),
                 expressionProgram,
@@ -13529,6 +13702,9 @@ internal static class UnifiedBytecodeCompiler
                 stringConstants,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 
@@ -13542,6 +13718,9 @@ internal static class UnifiedBytecodeCompiler
                 stringConstants,
                 out reason))
         {
+            RollBackUnifiedBuilder(unified, unifiedCount);
+            RollBackUnifiedBuilder(literalConstants, literalCount);
+            RollBackUnifiedBuilder(stringConstants, stringCount);
             return false;
         }
 

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeFirstBoundaryStackDepthGuardTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeFirstBoundaryStackDepthGuardTests.cs
@@ -1,0 +1,255 @@
+using System.Collections.Generic;
+using System.Linq;
+using Asynkron.JsEngine.Ast;
+using Asynkron.JsEngine.Execution;
+using Asynkron.JsEngine.Execution.Instructions;
+using Asynkron.JsEngine.Execution.UnifiedBytecode;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Asynkron.JsEngine.Tests;
+
+/// <summary>
+/// Guard tests that lock the invariant violated by the recurring "first boundary"
+/// double-emission crash class (PRs #3097, #3101, #3104 and the rollback-hardening pass):
+/// a <c>TryAppendFirstBoundary*</c> helper that appends operand loads and then returns
+/// false on a later validation failure WITHOUT rolling back leaves stray ops behind.
+/// The general expression loop then re-emits the full expression, doubling the leading
+/// ops and pushing the operand stack past <see cref="UnifiedBytecodeProgram.MaxStackDepth"/>,
+/// crashing the VM with IndexOutOfRangeException.
+///
+/// For a representative corpus of admitted first-boundary shapes this test compiles the
+/// production program and asserts the statically-required peak operand-stack depth never
+/// exceeds the program's declared <see cref="UnifiedBytecodeProgram.MaxStackDepth"/>. If a
+/// rollback regresses (or a future helper reintroduces the bug) a shape double-emits and the
+/// computed peak exceeds the declared budget, failing here instead of crashing at runtime.
+/// </summary>
+[Category(TestCategories.RuntimeSemantics)]
+public sealed class UnifiedBytecodeFirstBoundaryStackDepthGuardTests(ITestOutputHelper output)
+    : InternalTestBase(output)
+{
+    public static IEnumerable<object[]> AdmittedFirstBoundaryShapes()
+    {
+        // Each entry: a function whose body is exactly one admitted first-boundary shape.
+        // Covers every vulnerable/at-risk helper family audited in the hardening pass.
+
+        // NamedPropertySet: base.name = rhs
+        yield return Shape("f", "function f(o, v) { return o.name = v; }");
+        // NamedPropertySet with template-literal RHS span.
+        yield return Shape("f", "function f(o, v) { return o.name = `a${v}b`; }");
+        // NestedNamedPropertySet: base.a.b = rhs
+        yield return Shape("f", "function f(o, v) { return o.a.b = v; }");
+        // NamedCompoundPropertySet: base.name += rhs
+        yield return Shape("f", "function f(o, v) { return o.name += v; }");
+        // NamedPropertyUpdate: ++base.name
+        yield return Shape("f", "function f(o) { return ++o.name; }");
+        // NestedNamedPropertyUpdate: ++base.a.b
+        yield return Shape("f", "function f(o) { return ++o.a.b; }");
+        // NamedPropertyReadChain: base.a.b.c
+        yield return Shape("f", "function f(o) { return o.a.b.c; }");
+        // ComputedPropertyRead: base[key]
+        yield return Shape("f", "function f(o, k) { return o[k]; }");
+        // PropertyReadBinaryExpression: base.a.b + rhs
+        yield return Shape("f", "function f(o, v) { return o.a.b + v; }");
+        // PropertyReadBinaryExpression with array-literal RHS span.
+        yield return Shape("f", "function f(o, v) { return o.a === [v]; }");
+        // PropertyReadShortCircuitExpression: base.a.b && rhs
+        yield return Shape("f", "function f(o, v) { return o.a.b && v; }");
+        // OptionalNamedPropertyRead: base?.a
+        yield return Shape("f", "function f(o) { return o?.a; }");
+        // OptionalNamedPropertyReadChain: base?.a.b
+        yield return Shape("f", "function f(o) { return o?.a.b; }");
+        // OptionalNamedThenComputed: base?.a[k]
+        yield return Shape("f", "function f(o, k) { return o?.a[k]; }");
+        // OptionalComputedPropertyReadChain: base?.[k].a
+        yield return Shape("f", "function f(o, k) { return o?.[k].a; }");
+        // OptionalNamedPropertyDelete: delete base?.a
+        yield return Shape("f", "function f(o) { return delete o?.a; }");
+        // OptionalNamedThenComputedPropertyDelete: delete base?.a[k]
+        yield return Shape("f", "function f(o, k) { return delete o?.a[k]; }");
+        // OptionalComputedPropertyDeleteWithJump: delete base?.[k]
+        yield return Shape("f", "function f(o, k) { return delete o?.[k]; }");
+    }
+
+    [Theory]
+    [MemberData(nameof(AdmittedFirstBoundaryShapes))]
+    public void AdmittedFirstBoundaryShape_RequiredStackDepthWithinDeclaredBudget(
+        string functionName,
+        string source)
+    {
+        var plan = GetFunctionPlan(source, functionName);
+
+        var eligibility = UnifiedBytecodeProductionEligibility.Evaluate(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor());
+
+        Assert.True(eligibility.IsEligible, eligibility.Reason);
+
+        var program = eligibility.Program;
+        var requiredDepth = ComputeRequiredStackDepth(program);
+
+        Assert.True(
+            requiredDepth <= program.MaxStackDepth,
+            $"Required operand-stack depth {requiredDepth} exceeds declared MaxStackDepth " +
+            $"{program.MaxStackDepth} for shape '{source}'. This indicates a first-boundary " +
+            "helper emitted operand loads and then bailed without rolling back, doubling the " +
+            "leading ops via the general expression loop.");
+    }
+
+    /// <summary>
+    /// Abstract-interpretation of operand-stack depth over the emitted instructions, following
+    /// jump targets via a worklist over (pc, depth). Each modeled opcode has an explicit net
+    /// stack delta; an unmodeled opcode fails the test loudly so the simulation can never
+    /// silently under-count.
+    /// </summary>
+    private int ComputeRequiredStackDepth(UnifiedBytecodeProgram program)
+    {
+        var instructions = program.Instructions;
+        var peak = 0;
+        var visited = new Dictionary<int, int>();
+        var worklist = new Stack<(int Pc, int Depth)>();
+        worklist.Push((0, 0));
+
+        while (worklist.Count > 0)
+        {
+            var (pc, depth) = worklist.Pop();
+            while (pc >= 0 && pc < instructions.Length)
+            {
+                // If we already analyzed this pc at >= this depth, the path is subsumed.
+                if (visited.TryGetValue(pc, out var seenDepth) && seenDepth >= depth)
+                {
+                    break;
+                }
+
+                visited[pc] = depth;
+
+                var instruction = instructions[pc];
+                var (delta, isJump, isUnconditionalJump, target) =
+                    DescribeStackEffect(instruction);
+
+                // Account for transient pushes before the net delta lands (e.g. an op that
+                // consumes 1 and produces 1 still only needs `depth` slots). The shapes here
+                // only push at most one transient value beyond the net, so the peak is the
+                // max of pre- and post-delta depths.
+                var afterDepth = depth + delta;
+                peak = System.Math.Max(peak, System.Math.Max(depth, afterDepth));
+
+                Assert.True(afterDepth >= 0,
+                    $"Operand-stack underflow at pc {pc} ({instruction.OpCode}).");
+
+                if (isJump)
+                {
+                    worklist.Push((target, afterDepth));
+                    if (isUnconditionalJump)
+                    {
+                        break;
+                    }
+                }
+
+                pc++;
+                depth = afterDepth;
+            }
+        }
+
+        return peak;
+    }
+
+    private (int Delta, bool IsJump, bool IsUnconditionalJump, int Target) DescribeStackEffect(
+        UnifiedBytecodeInstruction instruction)
+    {
+        switch (instruction.OpCode)
+        {
+            // Pushes one value.
+            case UnifiedBytecodeOpCode.LoadSlot:
+            case UnifiedBytecodeOpCode.LoadDynamicIdentifier:
+            case UnifiedBytecodeOpCode.LoadThis:
+            case UnifiedBytecodeOpCode.LoadNewTarget:
+            case UnifiedBytecodeOpCode.LoadLiteral:
+                return (+1, false, false, 0);
+
+            // Net-neutral unary transforms of the top of stack.
+            case UnifiedBytecodeOpCode.GetNamedProperty:
+            case UnifiedBytecodeOpCode.GetNamedPropertyOptional:
+            case UnifiedBytecodeOpCode.GetNamedPropertyForCompoundSet:
+            case UnifiedBytecodeOpCode.GetComputedPropertyForCompoundSet:
+            case UnifiedBytecodeOpCode.RequireObjectCoercible:
+            case UnifiedBytecodeOpCode.ResolvePropertyKey:
+            case UnifiedBytecodeOpCode.UpdateNamedProperty:
+            case UnifiedBytecodeOpCode.DeleteNamedProperty:
+            case UnifiedBytecodeOpCode.ToString:
+                return (0, false, false, 0);
+
+            // Consume one extra than they produce (binary fold of two operands -> one).
+            case UnifiedBytecodeOpCode.Binary:
+            case UnifiedBytecodeOpCode.GetComputedProperty:
+            case UnifiedBytecodeOpCode.SetNamedProperty:
+            case UnifiedBytecodeOpCode.DeleteComputedProperty:
+                return (-1, false, false, 0);
+
+            // [object, key, value] -> [value]
+            case UnifiedBytecodeOpCode.SetComputedProperty:
+                return (-2, false, false, 0);
+
+            // Pushes a duplicate of the current top, or a fresh empty container.
+            case UnifiedBytecodeOpCode.DuplicateTop:
+            case UnifiedBytecodeOpCode.CreateArray:
+                return (+1, false, false, 0);
+
+            // Append-to-container ops keep the container and consume the appended value.
+            case UnifiedBytecodeOpCode.ArrayPush:
+            case UnifiedBytecodeOpCode.ArraySpread:
+                return (-1, false, false, 0);
+
+            case UnifiedBytecodeOpCode.ArrayPushHole:
+                return (0, false, false, 0);
+
+            // Pure stack shuffles.
+            case UnifiedBytecodeOpCode.SwapTopTwo:
+                return (0, false, false, 0);
+
+            case UnifiedBytecodeOpCode.Pop:
+                return (-1, false, false, 0);
+
+            // Unconditional jump preserves depth, transfers control.
+            case UnifiedBytecodeOpCode.Jump:
+                return (0, true, true, instruction.Operand);
+
+            // Conditional / short-circuit jumps inspect (and, for ReplaceUndefined, keep) the
+            // top; both branches continue with the current depth.
+            case UnifiedBytecodeOpCode.JumpIfNullishReplaceUndefined:
+            case UnifiedBytecodeOpCode.JumpIfShortCircuitFalse:
+            case UnifiedBytecodeOpCode.JumpIfShortCircuitTrue:
+            case UnifiedBytecodeOpCode.JumpIfShortCircuitNotNullish:
+                return (0, true, false, instruction.Operand);
+
+            // Function epilogue: consumes the return value (or operates on an empty stack
+            // when the slot path is used). Treat as neutral terminator.
+            case UnifiedBytecodeOpCode.Return:
+            case UnifiedBytecodeOpCode.StoreSlot:
+            case UnifiedBytecodeOpCode.UpdateSlot:
+            case UnifiedBytecodeOpCode.InitializeSlot:
+                // StoreSlot/Update/Initialize pop the value they persist.
+                return instruction.OpCode == UnifiedBytecodeOpCode.Return
+                    ? (0, false, true, 0)
+                    : (-1, false, false, 0);
+
+            default:
+                Assert.Fail(
+                    $"Unmodeled opcode '{instruction.OpCode}' in first-boundary stack-depth " +
+                    "guard. Add an explicit stack delta so the simulation stays sound.");
+                return (0, false, false, 0);
+        }
+    }
+
+    private static object[] Shape(string functionName, string source) => [functionName, source];
+
+    private static ExecutionPlan GetFunctionPlan(string source, string functionName)
+    {
+        var pipeline = AstTestHelpers.ParseAndAnalyze(source);
+        var declaration = Assert.IsType<FunctionDeclaration>(pipeline.Analyzed.Body
+            .Single(node => node is FunctionDeclaration f && f.Name?.Name == functionName));
+        var cache = ((IAstCacheable<ExecutionPlanCache>)declaration.Function).GetOrCreateCache();
+        Assert.True(cache.Succeeded, cache.FailureReason);
+        return Assert.IsType<ExecutionPlan>(cache.Plan);
+    }
+}


### PR DESCRIPTION
## Problem

A recurring latent crash class in `UnifiedBytecodeCompiler.cs`: a `TryAppendFirstBoundary*` helper appends operand loads / property reads to the `unified` (and literal/string) builders, then `return false` on a **later** validation failure **without rolling back**. Dispatch then falls through to the general expression loop, which re-emits the full expression — doubling the leading ops, pushing the operand stack past `MaxStackDepth`, and crashing the VM with `IndexOutOfRangeException` at runtime.

This previously caused three point-fixed crashes: #3097, #3101, #3104. Other helpers still had the pattern (masked by earlier validation but fragile).

## Audit

Audited **every** `TryAppendFirstBoundary*` helper (26 total):
- **Staged-builder helpers** (newer, commit-on-success into `stagedUnified`): already safe, left unchanged.
- **Atomic value-load-only false paths**: helpers whose sole post-emit `false` is the atomic `TryAppendActivationValueLoad`/`...OperandLoad` own failure (which appends nothing on failure) — verified safe, left unchanged.
- **Vulnerable**: helpers that emit a base load / receiver-read loop and then a *later* helper or check can `return false` without rollback.

## Fix (purely mechanical — no admission/behavior change)

Applied the existing count-capture + `RollBackUnifiedBuilder` pattern to every false-returning path that can run after emission, in:

- `TryAppendFirstBoundaryNamedCompoundPropertySet`
- `TryAppendFirstBoundaryNamedPropertySet`
- `TryAppendFirstBoundaryNestedNamedPropertySet`
- `TryAppendFirstBoundaryComputedPropertyRead`
- `TryAppendFirstBoundaryOptionalNamedThenComputed`
- `TryAppendFirstBoundaryOptionalComputedPropertyReadChain`
- `TryAppendFirstBoundaryOptionalNamedThenComputedPropertyDelete`
- `TryAppendFirstBoundaryOptionalNamedThenOptionalComputedPropertyDelete`
- `TryAppendFirstBoundaryOptionalComputedPropertyDeleteWithJump`
- `TryAppendFirstBoundaryPropertyReadBinaryExpression` (lowering pass)
- `TryAppendFirstBoundaryPropertyReadShortCircuitExpression`

No logic restructuring; no shape's admission changed.

## Guard test

`UnifiedBytecodeFirstBoundaryStackDepthGuardTests` compiles a representative corpus of admitted first-boundary shapes, abstract-interprets the emitted program's peak operand-stack depth (worklist over jump targets, explicit per-opcode stack deltas, **loud failure on unmodeled opcodes**), and asserts it never exceeds `program.MaxStackDepth` — locking the invariant the bug violated. Confirmed the test **fails** when a rollback is removed and a near-miss shape (`typeof o.a.b === v`) double-emits.

## Verification

- Release build: 0 errors, 0 warnings.
- Guard test: 18/18 pass.
- `UnifiedBytecodeProduction` pack: **1066 pass** (parity with baseline).
- Broad sweep (UnifiedBytecode/ExpressionProgram/PropertyRead/Write/Optional/Computed/ActivationSemantics): 1475 pass.
- Delete/Assignment/Compound/Call/Update/Template sweep: 1044 pass.
- Zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)