### PR TITLE
Maintain resumable short-circuit flags across stack-permute opcodes

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeVirtualMachine.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeVirtualMachine.cs
@@ -3402,6 +3402,42 @@ internal static class UnifiedBytecodeVirtualMachine
             SetResumableShortCircuitFlag(stackPointer - 1, wasShortCircuited);
         }
 
+        // Mirrors the sync Execute path's CopyShortCircuitFlag/SwapShortCircuitFlags/
+        // RotateShortCircuitFlagsRight so the stack-permuting opcodes keep the short-circuit flag
+        // column aligned with the operand stack. The null-guarded resumable accessors make these
+        // no-ops when no flag column is allocated. Keeping the invariant here (rather than relying on
+        // eligibility never admitting a JumpIfShortCircuited-bearing resumable program) means a future
+        // relaxation of the resumable gate cannot silently corrupt flag alignment across these opcodes.
+        void CopyResumableShortCircuitFlag(int source, int target)
+        {
+            SetResumableShortCircuitFlag(target, GetResumableShortCircuitFlag(source));
+        }
+
+        void SwapResumableShortCircuitFlags(int left, int right)
+        {
+            if (stackShortCircuitFlags is null)
+            {
+                return;
+            }
+
+            var leftValue = GetStackFlag(stackShortCircuitFlags, left);
+            SetStackFlag(stackShortCircuitFlags, left, GetStackFlag(stackShortCircuitFlags, right));
+            SetStackFlag(stackShortCircuitFlags, right, leftValue);
+        }
+
+        void RotateResumableShortCircuitFlagsRight(int first, int second, int third)
+        {
+            if (stackShortCircuitFlags is null)
+            {
+                return;
+            }
+
+            var thirdValue = GetStackFlag(stackShortCircuitFlags, third);
+            SetStackFlag(stackShortCircuitFlags, third, GetStackFlag(stackShortCircuitFlags, second));
+            SetStackFlag(stackShortCircuitFlags, second, GetStackFlag(stackShortCircuitFlags, first));
+            SetStackFlag(stackShortCircuitFlags, first, thirdValue);
+        }
+
         while ((uint)programCounter < (uint)instructions.Length)
         {
             var instruction = instructions[programCounter];
@@ -3656,6 +3692,7 @@ internal static class UnifiedBytecodeVirtualMachine
 
                 case UnifiedBytecodeOpCode.DuplicateTop:
                     stack[stackPointer] = stack[stackPointer - 1];
+                    CopyResumableShortCircuitFlag(stackPointer - 1, stackPointer);
                     stackPointer++;
                     programCounter++;
                     break;
@@ -3663,6 +3700,8 @@ internal static class UnifiedBytecodeVirtualMachine
                 case UnifiedBytecodeOpCode.DuplicateTopTwo:
                     stack[stackPointer] = stack[stackPointer - 2];
                     stack[stackPointer + 1] = stack[stackPointer - 1];
+                    CopyResumableShortCircuitFlag(stackPointer - 2, stackPointer);
+                    CopyResumableShortCircuitFlag(stackPointer - 1, stackPointer + 1);
                     stackPointer += 2;
                     programCounter++;
                     break;
@@ -3671,6 +3710,7 @@ internal static class UnifiedBytecodeVirtualMachine
                     var resumableTop = stack[stackPointer - 1];
                     stack[stackPointer - 1] = stack[stackPointer - 2];
                     stack[stackPointer - 2] = resumableTop;
+                    SwapResumableShortCircuitFlags(stackPointer - 1, stackPointer - 2);
                     programCounter++;
                     break;
 
@@ -3679,6 +3719,7 @@ internal static class UnifiedBytecodeVirtualMachine
                     stack[stackPointer - 1] = stack[stackPointer - 2];
                     stack[stackPointer - 2] = stack[stackPointer - 3];
                     stack[stackPointer - 3] = resumableRotateTop;
+                    RotateResumableShortCircuitFlagsRight(stackPointer - 3, stackPointer - 2, stackPointer - 1);
                     programCounter++;
                     break;
 

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeResumablePermuteFlagTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeResumablePermuteFlagTests.cs
@@ -1,0 +1,204 @@
+using System.Collections.Immutable;
+using Asynkron.JsEngine.Execution;
+using Asynkron.JsEngine.Execution.UnifiedBytecode;
+using Asynkron.JsEngine.JsTypes;
+using Asynkron.JsEngine.Runtime;
+using Xunit.Abstractions;
+
+namespace Asynkron.JsEngine.Tests;
+
+/// <summary>
+///     Regression guard for the short-circuit flag column maintained by the resumable VM
+///     (<see cref="UnifiedBytecodeVirtualMachine.ExecuteResumable" />) across the stack-permuting
+///     opcodes <c>SwapTopTwo</c> / <c>RotateTopThreeRight</c> / <c>DuplicateTop</c> /
+///     <c>DuplicateTopTwo</c>.
+///
+///     Background: the synchronous <c>Execute</c> path keeps the short-circuit flag array
+///     (<c>stackShortCircuitFlags</c>) aligned with the operand stack as those opcodes shuffle values
+///     (via <c>SwapShortCircuitFlags</c> / <c>RotateShortCircuitFlagsRight</c> / <c>CopyShortCircuitFlag</c>).
+///     The resumable VM originally permuted the operand stack WITHOUT permuting the flag column. That
+///     asymmetry was unreachable in practice — the resumable eligibility gate
+///     (<c>TryFindResumablePlanDecline</c>) declines every shape that would emit
+///     <c>JumpIfShortCircuited</c>, the only opcode that sets
+///     <see cref="UnifiedBytecodeProgram.RequiresShortCircuitStackFlags" /> and thus allocates the flag
+///     column — so no admitted resumable program ever exercised the gap. But a future relaxation of that
+///     gate could admit a flag-bearing program and silently corrupt flag alignment across a permute.
+///
+///     These tests close that trap by exercising the ported flag maintenance directly: each builds a
+///     minimal resumable program with the flag column allocated (it contains a
+///     <c>JumpIfShortCircuited</c>), sets the short-circuit flag on an operand via a nullish optional
+///     read, runs ONE permute opcode, then branches on <c>JumpIfShortCircuited</c> reading the operand
+///     slot the flagged value was moved to. If the flag column tracked the permute, the branch is taken
+///     and the program returns <see cref="ShortCircuitedResult" />; otherwise it falls through to
+///     <see cref="NotShortCircuitedResult" />. Every case must return
+///     <see cref="ShortCircuitedResult" />, which only holds if the permute maintained the flag column.
+/// </summary>
+[Category(TestCategories.RuntimeSemantics)]
+public sealed class UnifiedBytecodeResumablePermuteFlagTests(ITestOutputHelper output) : InternalTestBase(output)
+{
+    private const double ShortCircuitedResult = 100;
+    private const double NotShortCircuitedResult = 200;
+
+    // SwapTopTwo: flag the bottom-of-two operand, push a fresh top, swap. The flag must follow its value
+    // to the new top so JumpIfShortCircuited (reading the top) is taken.
+    [Fact]
+    public void SwapTopTwo_MovesShortCircuitFlagWithValue()
+    {
+        // 0: push undefined                -> stack [undef]            flags [_]
+        // 1: GetNamedPropertyOptional 'a'  -> nullish base short-circuits: stack [undef*]   flags [1]
+        // 2: push 7                        -> stack [undef*, 7]        flags [1, 0]
+        // 3: SwapTopTwo                    -> stack [7, undef*]        flags [0, 1]  (only with the port)
+        // 4: JumpIfShortCircuited -> 7     -> top flag set => jump
+        // 5: push 200 / 6: return          (not short-circuited path)
+        // 7: push 100 / 8: return          (short-circuited path)
+        var result = RunPermuteProgram(
+            ImmutableArray.Create(
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 0),
+                Op(UnifiedBytecodeOpCode.GetNamedPropertyOptional, 0),
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 1),
+                Op(UnifiedBytecodeOpCode.SwapTopTwo),
+                Op(UnifiedBytecodeOpCode.JumpIfShortCircuited, 7),
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 2),
+                Op(UnifiedBytecodeOpCode.Return),
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 3),
+                Op(UnifiedBytecodeOpCode.Return)),
+            maxStackDepth: 6);
+
+        Assert.Equal(ShortCircuitedResult, result);
+    }
+
+    // RotateTopThreeRight: (a, b, c=top) -> (c, a, b=top). Flag the MIDDLE operand (b); after the rotate
+    // b is the new top, so its flag must be at the top for JumpIfShortCircuited to fire.
+    [Fact]
+    public void RotateTopThreeRight_MovesShortCircuitFlagWithValue()
+    {
+        // 0: push 1                        -> [1]
+        // 1: push undefined                -> [1, undef]
+        // 2: GetNamedPropertyOptional 'a'  -> [1, undef*]            flags [0, 1]   (b is flagged)
+        // 3: push 9                        -> [1, undef*, 9]         flags [0, 1, 0]
+        // 4: RotateTopThreeRight           -> [9, 1, undef*]         flags [0, 0, 1] (only with the port)
+        // 5: JumpIfShortCircuited -> 8
+        // 6: push 200 / 7: return
+        // 8: push 100 / 9: return
+        var result = RunPermuteProgram(
+            ImmutableArray.Create(
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 4),
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 0),
+                Op(UnifiedBytecodeOpCode.GetNamedPropertyOptional, 0),
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 5),
+                Op(UnifiedBytecodeOpCode.RotateTopThreeRight),
+                Op(UnifiedBytecodeOpCode.JumpIfShortCircuited, 8),
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 2),
+                Op(UnifiedBytecodeOpCode.Return),
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 3),
+                Op(UnifiedBytecodeOpCode.Return)),
+            maxStackDepth: 6);
+
+        Assert.Equal(ShortCircuitedResult, result);
+    }
+
+    // DuplicateTop: flag the top, duplicate it; the copy must inherit the flag.
+    [Fact]
+    public void DuplicateTop_CopiesShortCircuitFlagToDuplicate()
+    {
+        // 0: push undefined                -> [undef]
+        // 1: GetNamedPropertyOptional 'a'  -> [undef*]               flags [1]
+        // 2: DuplicateTop                  -> [undef*, undef*]       flags [1, 1]  (copy flag only with port)
+        // 3: JumpIfShortCircuited -> 6     (reads the duplicated top)
+        // 4: push 200 / 5: return
+        // 6: push 100 / 7: return
+        var result = RunPermuteProgram(
+            ImmutableArray.Create(
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 0),
+                Op(UnifiedBytecodeOpCode.GetNamedPropertyOptional, 0),
+                Op(UnifiedBytecodeOpCode.DuplicateTop),
+                Op(UnifiedBytecodeOpCode.JumpIfShortCircuited, 6),
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 2),
+                Op(UnifiedBytecodeOpCode.Return),
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 3),
+                Op(UnifiedBytecodeOpCode.Return)),
+            maxStackDepth: 6);
+
+        Assert.Equal(ShortCircuitedResult, result);
+    }
+
+    // DuplicateTopTwo: flag the LOWER of the top two; after the dup-two its copy lands two slots up.
+    // Pop the topmost copy so JumpIfShortCircuited reads the copied flag of the lower operand.
+    [Fact]
+    public void DuplicateTopTwo_CopiesShortCircuitFlagsOfBothOperands()
+    {
+        // 0: push undefined                -> [undef]
+        // 1: GetNamedPropertyOptional 'a'  -> [undef*]               flags [1]            (lower = flagged)
+        // 2: push 5                        -> [undef*, 5]            flags [1, 0]
+        // 3: DuplicateTopTwo               -> [undef*, 5, undef*, 5] flags [1, 0, 1, 0]   (copies only with port)
+        // 4: Pop                           -> [undef*, 5, undef*]    flags [1, 0, 1]
+        // 5: JumpIfShortCircuited -> 8     (reads the copied lower operand at slot 2)
+        // 6: push 200 / 7: return
+        // 8: push 100 / 9: return
+        var result = RunPermuteProgram(
+            ImmutableArray.Create(
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 0),
+                Op(UnifiedBytecodeOpCode.GetNamedPropertyOptional, 0),
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 6),
+                Op(UnifiedBytecodeOpCode.DuplicateTopTwo),
+                Op(UnifiedBytecodeOpCode.Pop),
+                Op(UnifiedBytecodeOpCode.JumpIfShortCircuited, 8),
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 2),
+                Op(UnifiedBytecodeOpCode.Return),
+                Op(UnifiedBytecodeOpCode.LoadLiteral, 3),
+                Op(UnifiedBytecodeOpCode.Return)),
+            maxStackDepth: 6);
+
+        Assert.Equal(ShortCircuitedResult, result);
+    }
+
+    private static UnifiedBytecodeInstruction Op(UnifiedBytecodeOpCode opCode, int operand = 0) =>
+        new(opCode, operand);
+
+    private static double RunPermuteProgram(
+        ImmutableArray<UnifiedBytecodeInstruction> instructions,
+        int maxStackDepth)
+    {
+        // LiteralConstants: 0=undefined (nullish optional base), 1=7, 2=NotShortCircuitedResult,
+        // 3=ShortCircuitedResult, 4=1, 5=9, 6=5.
+        var literals = ImmutableArray.Create(
+            JsValue.Undefined,
+            JsValue.FromDouble(7),
+            JsValue.FromDouble(NotShortCircuitedResult),
+            JsValue.FromDouble(ShortCircuitedResult),
+            JsValue.FromDouble(1),
+            JsValue.FromDouble(9),
+            JsValue.FromDouble(5));
+
+        var program = new UnifiedBytecodeProgram(
+            Instructions: instructions,
+            MaxStackDepth: maxStackDepth,
+            SlotCount: 0,
+            LiteralConstants: literals,
+            StringConstants: ImmutableArray.Create("a"),
+            SlotNames: ImmutableArray<string?>.Empty,
+            ParameterSlotIndices: ImmutableArray<int>.Empty,
+            LexicalSlotIndices: ImmutableArray<int>.Empty,
+            CallTargetConstants: ImmutableArray<UnifiedBytecodeCallTarget>.Empty,
+            ScopeDescriptors: ImmutableArray<UnifiedBytecodeScopeDescriptor>.Empty,
+            TryDescriptors: ImmutableArray<UnifiedBytecodeTryDescriptor>.Empty,
+            CatchDescriptors: ImmutableArray<UnifiedBytecodeCatchDescriptor>.Empty,
+            DriverDescriptors: ImmutableArray<UnifiedBytecodeDriverDescriptor>.Empty,
+            RequiresShortCircuitStackFlags: true);
+
+        // The flag column is allocated iff RequiresShortCircuitStackFlags — assert the premise so a
+        // future change to that wiring can't make this test silently vacuous.
+        var state = new UnifiedBytecodeResumeState(program, Array.Empty<JsValue>());
+        Assert.NotNull(state.OperandStackShortCircuitFlags);
+
+        var context = new EvaluationContext(new RealmState());
+        var result = UnifiedBytecodeVirtualMachine.ExecuteResumable(
+            state,
+            UnifiedBytecodeResumeMode.Next,
+            JsValue.Undefined,
+            context);
+
+        Assert.Equal(UnifiedBytecodeStepKind.Completed, result.Kind);
+        return result.Value.AsDouble();
+    }
+}


### PR DESCRIPTION
## What

The resumable VM (`ExecuteResumable`) permuted the operand stack via `SwapTopTwo` / `RotateTopThreeRight` / `DuplicateTop` / `DuplicateTopTwo` **without** permuting the parallel short-circuit flag column (`UnifiedBytecodeResumeState.OperandStackShortCircuitFlags`). The synchronous `Execute` path keeps the two aligned (`SwapShortCircuitFlags` / `RotateShortCircuitFlagsRight` / `CopyShortCircuitFlag`).

This PR ports that flag maintenance into the four resumable permute cases.

## Why

The asymmetry is **currently unreachable**: the resumable eligibility gate (`TryFindResumablePlanDecline`) declines every shape that would emit `JumpIfShortCircuited` — the only opcode that sets `RequiresShortCircuitStackFlags` and thus allocates the flag column — so no admitted resumable program exercises the gap today (verified empirically across many optional-chain shapes during #3109 review).

The risk it closes: a **future** PR relaxing the resumable gate to admit a flag-bearing shape (e.g. `o?.m?.()`, `o?.a?.b?.()`, computed optional call) **without** porting the permute flag maintenance would silently corrupt flag alignment — a subtle wrong-value bug, not a crash. Keeping the invariant in the executor (rather than relying on the gate) makes that class of future change safe by construction.

## Safety

The ported helpers are null-guarded, so they are **no-ops for every program that does not allocate the flag column** — i.e. all currently-admitted resumable programs. Existing runtime behaviour is unchanged.

## Tests

`UnifiedBytecodeResumablePermuteFlagTests` — four synthetic resumable programs that allocate the flag column, set a short-circuit flag via a nullish optional read, run one permute opcode, then branch on `JumpIfShortCircuited` reading the slot the flagged value moved to. Each returns `100` iff the flag tracked the permute. **Verified non-vacuous**: with the flag maintenance stashed out, all four fail (return `200`); with it, all four pass.

- Full internal suite: **5401 passed / 0 failed / 2 skipped**.
- `UnifiedBytecodeResumable*` + `UnifiedBytecodeProduction` (single-threaded): **1104 passed / 0 failed**.
- Engine Release build: 0 errors, 0 warnings.

Follow-up to the resumable-VM build-out (#3107 / #3108 / #3109); addresses the latent-hazard note from #3109's adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)