### PR TITLE
Fix: enforce const on resumable lexical-slot plain assignment

### DIFF
--- a/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
+++ b/src/Asynkron.JsEngine/Execution/UnifiedBytecode/UnifiedBytecodeProductionEligibility.cs
@@ -763,6 +763,28 @@ internal static class UnifiedBytecodeProductionEligibility
                 }
             }
 
+            // Plain slot assignment (`x = v`) to a lexical (`let`/`const`) slot keeps its interpreter route
+            // for the SAME reason as the slot-update guard above: the resumable VM
+            // (UnifiedBytecodeResumeState) carries no const-slot metadata, so it cannot raise the
+            // `TypeError: Assignment to constant variable` the sync VM enforces for a `const` reassignment.
+            // The already-admitted resumable StoreSlot opcode does not distinguish `const`, so without this
+            // guard `const x = 1; x = 2` inside a generator/async body silently succeeds (yields `1|2`).
+            // Declining every resolved lexical-slot assignment keeps the const-unsafe shapes on the
+            // interpreter while still admitting provably-non-const parameter/`var` assignments. (Unresolved
+            // free/dynamic stores already decline at the opcode level and are not affected here.)
+            if (instruction is AssignmentSlotInstruction
+                {
+                    TargetSymbol: { } assignTargetSymbol, FlatSlotId: var assignFlatSlotId, SlotIndex: var assignSlotIndex
+                }
+                && TryResolveActivationSymbolSlot(assignTargetSymbol, assignFlatSlotId, activationSlots)
+                && IsLexicalSlotUpdateTarget(assignSlotIndex, assignFlatSlotId, activationSlots))
+            {
+                declineCode = UnifiedBytecodeProductionDeclineCode.UnsupportedPlanShape;
+                declineReason =
+                    $"Assignment target '{assignTargetSymbol.Name}' is a lexical (let/const) slot; the resumable VM cannot enforce const-assignment semantics and the assignment is not eligible for resumable unified bytecode routing.";
+                return true;
+            }
+
             // `yield* <iterable>` keeps its prior verified routing when the iterable resolves through a
             // free/dynamic identifier (`yield* spyIterable`). The resumable YieldStar delegation protocol
             // was only validated against slot-resolved iterables; admitting a dynamic-identifier iterable

--- a/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeResumableSlotUpdateTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/UnifiedBytecodeResumableSlotUpdateTests.cs
@@ -276,6 +276,56 @@ public sealed class UnifiedBytecodeResumableSlotUpdateTests(ITestOutputHelper ou
             record => record.Message.Contains(ResumableGeneratorFastPathLog, StringComparison.Ordinal));
     }
 
+    // GATE (isolates the fix): a generator that PLAIN-ASSIGNS a `const` slot (`x = 2`, no try/catch) must
+    // be DECLINED by EvaluateResumable. The already-admitted StoreSlot opcode carries no const metadata, so
+    // without the AssignmentSlotInstruction lexical-slot guard this program was wrongly eligible and `x = 2`
+    // silently succeeded on the resumable fast path (yielding `1|2`). This is the direct, non-vacuous proof:
+    // it is eligible without the guard and declined with it.
+    [Fact]
+    public void EvaluateResumable_ConstSlotAssignment_StaysDeclined()
+    {
+        var plan = GetFunctionPlan("""
+            function* g() {
+                const x = 1;
+                yield x;
+                x = 2;
+                yield x;
+            }
+            """,
+            "g");
+
+        var result = UnifiedBytecodeProductionEligibility.EvaluateResumable(
+            plan,
+            new UnifiedBytecodeProductionActivationDescriptor(IsGenerator: true));
+
+        Assert.False(result.IsEligible);
+    }
+
+    // NEGATIVE end-to-end (mirrors ConstIncrementInGenerator, for plain assignment): a `const`
+    // reassignment in a generator keeps its interpreter route and throws TypeError; the resumable
+    // fast-path log must be ABSENT.
+    [Fact(Timeout = 5000)]
+    public async Task ConstAssignmentInGenerator_StaysOnInterpreterAndThrows()
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate("""
+            function* g() {
+                const x = 1;
+                yield x;
+                try { x = 2; } catch (e) { yield "THROW:" + e.constructor.name; return; }
+                yield "no-throw";
+            }
+
+            var it = g();
+            (it.next().value) + "|" + (it.next().value);
+            """);
+
+        Assert.Equal("1|THROW:TypeError", result);
+        Assert.DoesNotContain(
+            CurrentLogger!.Collector.Snapshot(),
+            record => record.Message.Contains(ResumableGeneratorFastPathLog, StringComparison.Ordinal));
+    }
+
     private void AssertGeneratorFastPath(string functionName, int argc) =>
         Assert.Contains(CurrentLogger!.Collector.Snapshot(),
             record => record.Message.Contains(


### PR DESCRIPTION
## Bug
The resumable VM's `StoreSlot` path (admitted since the first resumable slice) does not enforce `const` reassignment. A generator/async body that plain-assigns a `const` slot — `function* g(){ const x = 1; yield x; x = 2; yield x; }` — ran on the resumable fast path and **silently succeeded** (`1|2`) instead of throwing `TypeError: Assignment to constant variable`. The sync VM enforces this via `IsConstSlot`, but `UnifiedBytecodeResumeState` carries no const-slot bitmap, so the check is impossible there.

Pre-existing latent bug, independent of B8 (#3115, which already declined lexical-slot *updates*).

## Fix (option b — provably safe, mirrors B8)
Decline at `EvaluateResumable` any `AssignmentSlotInstruction` whose resolved target is a lexical (`let`/`const`) slot, exactly mirroring B8's `IsLexicalSlotUpdateTarget` guard. Const-unsafe assignments keep their interpreter route (which enforces const correctly); provably-non-const parameter/`var` assignments stay admitted. Unresolved free/dynamic stores already decline at the opcode level and are untouched.

**Trade-off:** this also routes `let x; x = 2` in a generator to the interpreter (correctness over coverage). Option (a) — threading a static const-slot bitmap into the `ExecutionPlan`/`ActivationSlotShape`/`UnifiedBytecodeResumeState` so the resumable handler can raise the `TypeError` itself — is the follow-up to restore `let`-write fast-path coverage.

## Tests
- `EvaluateResumable_ConstSlotAssignment_StaysDeclined` — gate, isolates the fix. **Proven non-vacuous**: without the guard `Assert.False` fails (the program was wrongly eligible).
- `ConstAssignmentInGenerator_StaysOnInterpreterAndThrows` — end-to-end (mirrors the B8 `ConstIncrement` test for plain assignment): `1|THROW:TypeError`, fast-path log absent.
- Full internal suite: **5439 passed / 0 failed / 2 skipped**. Build 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)