### PR TITLE
Fix optional-chain delete short-circuit (delete box?.[k1][k2])

### DIFF
--- a/src/Asynkron.JsEngine/Ast/Legacy/ExpressionNodeExtensions.cs
+++ b/src/Asynkron.JsEngine/Ast/Legacy/ExpressionNodeExtensions.cs
@@ -3227,6 +3227,19 @@ public static partial class TypedAstEvaluator
                         return false;
                     }
 
+                    // Optional-chain short-circuit: if the target chain short-circuited to nullish — this
+                    // hop is optional with a nullish base (`delete box?.x`), or an earlier optional hop in
+                    // the target short-circuited (`delete box?.[k1][k2]`) — the enclosing `delete` evaluates
+                    // to `true` per spec rather than attempting a delete on the nullish reference (which
+                    // would throw `Cannot delete property on null or undefined`). This mirrors the read path
+                    // short-circuit condition in EvaluateMember, so `delete chain` returns true exactly when
+                    // reading `chain` would short-circuit to undefined.
+                    if (targetJs.IsNullOrUndefined
+                        && (member.IsOptional || HasOptionalChaining(member.Target)))
+                    {
+                        return true;
+                    }
+
                     var propertyValueJs = EvaluateDynamicExpressionProgram(
                         member.Property,
                         environment,

--- a/src/Asynkron.JsEngine/Execution/Instructions/ExpressionProgramCompiler.cs
+++ b/src/Asynkron.JsEngine/Execution/Instructions/ExpressionProgramCompiler.cs
@@ -350,13 +350,19 @@ internal static class ExpressionProgramCompiler
                         failureReason = null;
                         return true;
 
+                    // Guarded (optional-chain) named delete. Matches both this hop being optional
+                    // (`delete box?.x`) AND a member whose TARGET chain short-circuits
+                    // (`delete box?.a.b` — the outer `.b` is not optional but `box?.a` is). Without the
+                    // target-chain check the latter fell through to the unguarded named-delete case below
+                    // and threw `Cannot delete property on null or undefined` instead of short-circuiting
+                    // the whole `delete` to `true` per spec.
                     case MemberExpression
                         {
                             Target: not SuperExpression,
-                            IsOptional: true,
                             IsComputed: false,
                             Property: LiteralExpression { Value.IsString: true } propertyLiteral
-                        } optionalNamedDelete:
+                        } optionalNamedDelete
+                        when optionalNamedDelete.IsOptional || HasOptionalChaining(optionalNamedDelete.Target):
                         if (!TryCompileExpression(optionalNamedDelete.Target, builder, out failureReason))
                         {
                             return false;
@@ -378,12 +384,15 @@ internal static class ExpressionProgramCompiler
                         failureReason = null;
                         return true;
 
+                    // Guarded (optional-chain) computed delete. Matches both this hop being optional
+                    // (`delete box?.[k]`) AND a member whose TARGET chain short-circuits
+                    // (`delete box?.[k1][k2]` — the outer `[k2]` is not optional but `box?.[k1]` is).
                     case MemberExpression
                         {
                             Target: not SuperExpression,
-                            IsOptional: true,
                             IsComputed: true
-                        } optionalComputedDelete:
+                        } optionalComputedDelete
+                        when optionalComputedDelete.IsOptional || HasOptionalChaining(optionalComputedDelete.Target):
                         if (!TryCompileExpression(optionalComputedDelete.Target, builder, out failureReason))
                         {
                             return false;

--- a/tests/Asynkron.JsEngine.Tests/OptionalChainDeleteTests.cs
+++ b/tests/Asynkron.JsEngine.Tests/OptionalChainDeleteTests.cs
@@ -1,0 +1,59 @@
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Asynkron.JsEngine.Tests;
+
+/// <summary>
+///     `delete` over an optional chain must short-circuit the WHOLE delete to `true` when an optional hop's
+///     base is nullish, rather than attempting the delete on the nullish reference (which throws
+///     `TypeError: Cannot delete property on null or undefined`). Regression for the compiler emitting the
+///     optional short-circuit guard only when the delete member itself was optional, missing the case where
+///     an EARLIER hop in the target chain is optional (`delete box?.[k1][k2]`).
+/// </summary>
+[Category(TestCategories.RuntimeSemantics)]
+public sealed class OptionalChainDeleteTests(ITestOutputHelper output) : InternalTestBase(output)
+{
+    [Theory]
+    // single-hop optional named delete
+    [InlineData("function f(box){ return delete box?.x; } f(null);", true)]
+    [InlineData("function f(box){ return delete box?.x; } f(undefined);", true)]
+    // single-hop optional computed delete
+    [InlineData("function f(box,k){ return delete box?.[k]; } f(null,'a');", true)]
+    [InlineData("function f(box,k){ return delete box?.[k]; } f(undefined,'a');", true)]
+    // optional hop EARLIER in the chain (the reported bug): outer hop not optional
+    [InlineData("function f(box,k1,k2){ return delete box?.[k1][k2]; } f(null,'a','b');", true)]
+    [InlineData("function f(box,k1,k2){ return delete box?.[k1][k2]; } f(undefined,'a','b');", true)]
+    [InlineData("function f(box){ return delete box?.a.b; } f(null);", true)]
+    public async Task DeleteOptionalChain_NullishBase_ShortCircuitsToTrue(string source, bool expected)
+    {
+        await using var engine = CreateEngine();
+        var result = await engine.Evaluate(source);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task DeleteOptionalChain_NonNullBase_DeletesAndReturnsTrue()
+    {
+        await using var engine = CreateEngine();
+        // delete box?.x with a present property removes it and returns true.
+        Assert.Equal(true, await engine.Evaluate(
+            "function f(box){ var ok = delete box?.x; return ok && !('x' in box); } f({x:1});"));
+        // delete box?.[k] removes the computed key.
+        Assert.Equal(true, await engine.Evaluate(
+            "function f(box,k){ var ok = delete box?.[k]; return ok && !(k in box); } f({a:1},'a');"));
+        // delete box?.[k1][k2] removes the nested key on a present chain.
+        Assert.Equal(true, await engine.Evaluate(
+            "function f(box,k1,k2){ var ok = delete box?.[k1][k2]; return ok && !(k2 in box[k1]); } f({a:{b:1}},'a','b');"));
+    }
+
+    [Fact]
+    public async Task Delete_NonOptional_NullishBase_StillThrows()
+    {
+        await using var engine = CreateEngine();
+        // A NON-optional member delete on a genuinely nullish base must still throw (the fix must not
+        // make every nullish-target delete return true).
+        var result = await engine.Evaluate(
+            "function f(box,k1,k2){ try { delete box[k1][k2]; return 'no-throw'; } catch (e) { return e.constructor.name; } } f({}, 'a', 'b');");
+        Assert.Equal("TypeError", result);
+    }
+}


### PR DESCRIPTION
`delete box?.[k1][k2]` (and `delete box?.a.b`, `delete box?.x`, `delete box?.[k]`) with a nullish optional base threw `TypeError: Cannot delete property on null or undefined` instead of evaluating the `delete` to `true` per spec.

**Root cause:** the `ExpressionProgram` compiler emitted the optional short-circuit guard only when the delete member *itself* was optional. For `delete box?.[k1][k2]` the outer `[k2]` hop isn't optional (the inner `?.[k1]` is), so it fell through to the unguarded delete and deleted on the short-circuited `undefined` → threw.

**Fix:** the guarded optional-delete cases now also match when the target chain is optional-bearing (`HasOptionalChaining(Target)`), so the guard fires exactly when reading the same chain would short-circuit. Non-optional members are unaffected — `delete box[k1][k2]` on a genuinely nullish base still throws. Legacy `EvaluateDelete` path fixed to match.

9 regression tests (null/undefined/non-null bases + the non-optional-still-throws guard). Full suite **5562/0/2**. Confirmed present on `cb4a971ae`, not a regression from recent delete-chain work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)